### PR TITLE
Atspi rustfmt.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "atspi"
-version = "0.3.2"
+version = "0.3.5"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,11 @@
+# Rustfmt documentation:
+# https://rust-lang.github.io/rustfmt/?version=v1.5.1&search=
+
+# This crate is 'unix' only.
+newline_style = "Unix"
+reorder_imports = true
+
+# chain_width; a percentage of maximum width
+# precedes what is implied by `use_small_heuristics"
+chain_width = 70
+use_small_heuristics = "Max"

--- a/src/accessible.rs
+++ b/src/accessible.rs
@@ -13,11 +13,10 @@
 use crate::{InterfaceSet, StateSet};
 use serde::{Deserialize, Serialize};
 use zbus::{
-    CacheProperties,
     dbus_proxy,
     names::UniqueName,
     zvariant::{ObjectPath, Type},
-    Connection,
+    CacheProperties, Connection,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Type, Hash)]

--- a/src/accessible_ext.rs
+++ b/src/accessible_ext.rs
@@ -9,14 +9,8 @@ use async_trait::async_trait;
 use std::{collections::HashMap, error::Error};
 use zbus::CacheProperties;
 
-pub type MatcherArgs = (
-    Vec<Role>,
-    MatchType,
-    HashMap<String, String>,
-    MatchType,
-    InterfaceSet,
-    MatchType,
-);
+pub type MatcherArgs =
+    (Vec<Role>, MatchType, HashMap<String, String>, MatchType, InterfaceSet, MatchType);
 
 #[async_trait]
 pub trait AccessibleExt {
@@ -84,8 +78,7 @@ impl AccessibleProxy<'_> {
                 return Ok(Some(child));
             }
             /* 0 here is ignored because we are recursive; see the line starting with if !recur */
-            if let Some(found_decendant) =
-                child.find_inner(0, matcher_args, backward, true).await?
+            if let Some(found_decendant) = child.find_inner(0, matcher_args, backward, true).await?
             {
                 return Ok(Some(found_decendant));
             }
@@ -136,7 +129,7 @@ impl AccessibleExt for AccessibleProxy<'_> {
         }
         Ok(children)
     }
-    async fn get_siblings<'a>(&self) -> Result<Vec<AccessibleProxy<'a>>, Box<dyn Error>>  {
+    async fn get_siblings<'a>(&self) -> Result<Vec<AccessibleProxy<'a>>, Box<dyn Error>> {
         let parent = self.get_parent_ext().await?;
         let index = self.get_index_in_parent().await?.try_into()?;
         let children: Vec<AccessibleProxy<'a>> = parent

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -10,8 +10,8 @@
 //! section of the zbus documentation.
 //!
 
-use crate::StateSet;
 use crate::InterfaceSet;
+use crate::StateSet;
 use zbus::dbus_proxy;
 
 /// A structure which represents a cache item from AT-SPI.

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -34,10 +34,7 @@ impl Connection {
     pub async fn connect(bus_addr: Address) -> zbus::Result<Self> {
         tracing::debug!("Connecting to a11y bus");
         let bus = zbus::ConnectionBuilder::address(bus_addr)?.build().await?;
-        tracing::debug!(
-            name = bus.unique_name().map(|n| n.as_str()),
-            "Connected to a11y bus"
-        );
+        tracing::debug!(name = bus.unique_name().map(|n| n.as_str()), "Connected to a11y bus");
         // The Proxy holds a strong reference to a Connection, so we only need to store the proxy
         let registry = RegistryProxy::new(&bus).await?;
 

--- a/src/convertable.rs
+++ b/src/convertable.rs
@@ -1,6 +1,6 @@
 use crate::{
-    accessible::AccessibleProxy, action::ActionProxy, application::ApplicationProxy, cache::CacheProxy,
-    collection::CollectionProxy, component::ComponentProxy,
+    accessible::AccessibleProxy, action::ActionProxy, application::ApplicationProxy,
+    cache::CacheProxy, collection::CollectionProxy, component::ComponentProxy,
     device_event_controller::DeviceEventControllerProxy,
     device_event_listener::DeviceEventListenerProxy, document::DocumentProxy,
     editable_text::EditableTextProxy, hyperlink::HyperlinkProxy, hypertext::HypertextProxy,
@@ -119,23 +119,19 @@ impl Convertable for AccessibleProxy<'_> {
     async fn to_accessible<'a>(&'a self) -> zbus::Result<AccessibleProxy<'a>> {
         AccessibleProxy::builder(self.connection())
             .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+            .cache_properties(CacheProperties::No)
             .path(self.path())?
             .build()
             .await
     }
     async fn to_action<'a>(&'a self) -> zbus::Result<ActionProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::Action)
-        {
+        if acc.get_interfaces().await?.contains(Interface::Action) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return ActionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -149,7 +145,7 @@ impl Convertable for AccessibleProxy<'_> {
             // variables
             return ApplicationProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -163,7 +159,7 @@ impl Convertable for AccessibleProxy<'_> {
             // variables
             return CollectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -177,7 +173,7 @@ impl Convertable for AccessibleProxy<'_> {
             // variables
             return ComponentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -191,7 +187,7 @@ impl Convertable for AccessibleProxy<'_> {
             // variables
             return DocumentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -205,7 +201,7 @@ impl Convertable for AccessibleProxy<'_> {
             // variables
             return HypertextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -219,7 +215,7 @@ impl Convertable for AccessibleProxy<'_> {
             // variables
             return HyperlinkProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -233,7 +229,7 @@ impl Convertable for AccessibleProxy<'_> {
             // variables
             return ImageProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -247,7 +243,7 @@ impl Convertable for AccessibleProxy<'_> {
             // variables
             return SelectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -261,7 +257,7 @@ impl Convertable for AccessibleProxy<'_> {
             // variables
             return TableProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -275,7 +271,7 @@ impl Convertable for AccessibleProxy<'_> {
             // variables
             return TableCellProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -289,7 +285,7 @@ impl Convertable for AccessibleProxy<'_> {
             // variables
             return TextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -298,16 +294,12 @@ impl Convertable for AccessibleProxy<'_> {
     }
     async fn to_editable_text<'a>(&'a self) -> zbus::Result<EditableTextProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::EditableText)
-        {
+        if acc.get_interfaces().await?.contains(Interface::EditableText) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return EditableTextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -321,7 +313,7 @@ impl Convertable for AccessibleProxy<'_> {
             // variables
             return CacheProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -335,7 +327,7 @@ impl Convertable for AccessibleProxy<'_> {
             // variables
             return ValueProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -349,7 +341,7 @@ impl Convertable for AccessibleProxy<'_> {
             // variables
             return RegistryProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -360,16 +352,12 @@ impl Convertable for AccessibleProxy<'_> {
         &'a self,
     ) -> zbus::Result<DeviceEventControllerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventController)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventController) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventControllerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -378,16 +366,12 @@ impl Convertable for AccessibleProxy<'_> {
     }
     async fn to_device_event_listener<'a>(&'a self) -> zbus::Result<DeviceEventListenerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventListener)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventListener) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventListenerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -401,23 +385,19 @@ impl Convertable for ApplicationProxy<'_> {
     async fn to_accessible<'a>(&'a self) -> zbus::Result<AccessibleProxy<'a>> {
         AccessibleProxy::builder(self.connection())
             .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+            .cache_properties(CacheProperties::No)
             .path(self.path())?
             .build()
             .await
     }
     async fn to_action<'a>(&'a self) -> zbus::Result<ActionProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::Action)
-        {
+        if acc.get_interfaces().await?.contains(Interface::Action) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return ActionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -431,7 +411,7 @@ impl Convertable for ApplicationProxy<'_> {
             // variables
             return ApplicationProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -445,7 +425,7 @@ impl Convertable for ApplicationProxy<'_> {
             // variables
             return CollectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -459,7 +439,7 @@ impl Convertable for ApplicationProxy<'_> {
             // variables
             return ComponentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -473,7 +453,7 @@ impl Convertable for ApplicationProxy<'_> {
             // variables
             return DocumentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -487,7 +467,7 @@ impl Convertable for ApplicationProxy<'_> {
             // variables
             return HypertextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -501,7 +481,7 @@ impl Convertable for ApplicationProxy<'_> {
             // variables
             return HyperlinkProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -515,7 +495,7 @@ impl Convertable for ApplicationProxy<'_> {
             // variables
             return ImageProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -529,7 +509,7 @@ impl Convertable for ApplicationProxy<'_> {
             // variables
             return SelectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -543,7 +523,7 @@ impl Convertable for ApplicationProxy<'_> {
             // variables
             return TableProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -557,7 +537,7 @@ impl Convertable for ApplicationProxy<'_> {
             // variables
             return TableCellProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -571,7 +551,7 @@ impl Convertable for ApplicationProxy<'_> {
             // variables
             return TextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -580,16 +560,12 @@ impl Convertable for ApplicationProxy<'_> {
     }
     async fn to_editable_text<'a>(&'a self) -> zbus::Result<EditableTextProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::EditableText)
-        {
+        if acc.get_interfaces().await?.contains(Interface::EditableText) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return EditableTextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -603,7 +579,7 @@ impl Convertable for ApplicationProxy<'_> {
             // variables
             return CacheProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -617,7 +593,7 @@ impl Convertable for ApplicationProxy<'_> {
             // variables
             return ValueProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -631,7 +607,7 @@ impl Convertable for ApplicationProxy<'_> {
             // variables
             return RegistryProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -642,16 +618,12 @@ impl Convertable for ApplicationProxy<'_> {
         &'a self,
     ) -> zbus::Result<DeviceEventControllerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventController)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventController) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventControllerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -660,16 +632,12 @@ impl Convertable for ApplicationProxy<'_> {
     }
     async fn to_device_event_listener<'a>(&'a self) -> zbus::Result<DeviceEventListenerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventListener)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventListener) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventListenerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -683,23 +651,19 @@ impl Convertable for CacheProxy<'_> {
     async fn to_accessible<'a>(&'a self) -> zbus::Result<AccessibleProxy<'a>> {
         AccessibleProxy::builder(self.connection())
             .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+            .cache_properties(CacheProperties::No)
             .path(self.path())?
             .build()
             .await
     }
     async fn to_action<'a>(&'a self) -> zbus::Result<ActionProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::Action)
-        {
+        if acc.get_interfaces().await?.contains(Interface::Action) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return ActionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -713,7 +677,7 @@ impl Convertable for CacheProxy<'_> {
             // variables
             return ApplicationProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -727,7 +691,7 @@ impl Convertable for CacheProxy<'_> {
             // variables
             return CollectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -741,7 +705,7 @@ impl Convertable for CacheProxy<'_> {
             // variables
             return ComponentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -755,7 +719,7 @@ impl Convertable for CacheProxy<'_> {
             // variables
             return DocumentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -769,7 +733,7 @@ impl Convertable for CacheProxy<'_> {
             // variables
             return HypertextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -783,7 +747,7 @@ impl Convertable for CacheProxy<'_> {
             // variables
             return HyperlinkProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -797,7 +761,7 @@ impl Convertable for CacheProxy<'_> {
             // variables
             return ImageProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -811,7 +775,7 @@ impl Convertable for CacheProxy<'_> {
             // variables
             return SelectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -825,7 +789,7 @@ impl Convertable for CacheProxy<'_> {
             // variables
             return TableProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -839,7 +803,7 @@ impl Convertable for CacheProxy<'_> {
             // variables
             return TableCellProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -853,7 +817,7 @@ impl Convertable for CacheProxy<'_> {
             // variables
             return TextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -862,16 +826,12 @@ impl Convertable for CacheProxy<'_> {
     }
     async fn to_editable_text<'a>(&'a self) -> zbus::Result<EditableTextProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::EditableText)
-        {
+        if acc.get_interfaces().await?.contains(Interface::EditableText) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return EditableTextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -885,7 +845,7 @@ impl Convertable for CacheProxy<'_> {
             // variables
             return CacheProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -899,7 +859,7 @@ impl Convertable for CacheProxy<'_> {
             // variables
             return ValueProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -913,7 +873,7 @@ impl Convertable for CacheProxy<'_> {
             // variables
             return RegistryProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -924,16 +884,12 @@ impl Convertable for CacheProxy<'_> {
         &'a self,
     ) -> zbus::Result<DeviceEventControllerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventController)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventController) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventControllerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -942,16 +898,12 @@ impl Convertable for CacheProxy<'_> {
     }
     async fn to_device_event_listener<'a>(&'a self) -> zbus::Result<DeviceEventListenerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventListener)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventListener) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventListenerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -965,23 +917,19 @@ impl Convertable for CollectionProxy<'_> {
     async fn to_accessible<'a>(&'a self) -> zbus::Result<AccessibleProxy<'a>> {
         AccessibleProxy::builder(self.connection())
             .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+            .cache_properties(CacheProperties::No)
             .path(self.path())?
             .build()
             .await
     }
     async fn to_action<'a>(&'a self) -> zbus::Result<ActionProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::Action)
-        {
+        if acc.get_interfaces().await?.contains(Interface::Action) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return ActionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -995,7 +943,7 @@ impl Convertable for CollectionProxy<'_> {
             // variables
             return ApplicationProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1009,7 +957,7 @@ impl Convertable for CollectionProxy<'_> {
             // variables
             return CollectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1023,7 +971,7 @@ impl Convertable for CollectionProxy<'_> {
             // variables
             return ComponentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1037,7 +985,7 @@ impl Convertable for CollectionProxy<'_> {
             // variables
             return DocumentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1051,7 +999,7 @@ impl Convertable for CollectionProxy<'_> {
             // variables
             return HypertextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1065,7 +1013,7 @@ impl Convertable for CollectionProxy<'_> {
             // variables
             return HyperlinkProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1079,7 +1027,7 @@ impl Convertable for CollectionProxy<'_> {
             // variables
             return ImageProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1093,7 +1041,7 @@ impl Convertable for CollectionProxy<'_> {
             // variables
             return SelectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1107,7 +1055,7 @@ impl Convertable for CollectionProxy<'_> {
             // variables
             return TableProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1121,7 +1069,7 @@ impl Convertable for CollectionProxy<'_> {
             // variables
             return TableCellProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1135,7 +1083,7 @@ impl Convertable for CollectionProxy<'_> {
             // variables
             return TextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1144,16 +1092,12 @@ impl Convertable for CollectionProxy<'_> {
     }
     async fn to_editable_text<'a>(&'a self) -> zbus::Result<EditableTextProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::EditableText)
-        {
+        if acc.get_interfaces().await?.contains(Interface::EditableText) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return EditableTextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1167,7 +1111,7 @@ impl Convertable for CollectionProxy<'_> {
             // variables
             return CacheProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1181,7 +1125,7 @@ impl Convertable for CollectionProxy<'_> {
             // variables
             return ValueProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1195,7 +1139,7 @@ impl Convertable for CollectionProxy<'_> {
             // variables
             return RegistryProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1206,16 +1150,12 @@ impl Convertable for CollectionProxy<'_> {
         &'a self,
     ) -> zbus::Result<DeviceEventControllerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventController)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventController) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventControllerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1224,16 +1164,12 @@ impl Convertable for CollectionProxy<'_> {
     }
     async fn to_device_event_listener<'a>(&'a self) -> zbus::Result<DeviceEventListenerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventListener)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventListener) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventListenerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1247,23 +1183,19 @@ impl Convertable for ComponentProxy<'_> {
     async fn to_accessible<'a>(&'a self) -> zbus::Result<AccessibleProxy<'a>> {
         AccessibleProxy::builder(self.connection())
             .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+            .cache_properties(CacheProperties::No)
             .path(self.path())?
             .build()
             .await
     }
     async fn to_action<'a>(&'a self) -> zbus::Result<ActionProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::Action)
-        {
+        if acc.get_interfaces().await?.contains(Interface::Action) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return ActionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1277,7 +1209,7 @@ impl Convertable for ComponentProxy<'_> {
             // variables
             return ApplicationProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1291,7 +1223,7 @@ impl Convertable for ComponentProxy<'_> {
             // variables
             return CollectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1305,7 +1237,7 @@ impl Convertable for ComponentProxy<'_> {
             // variables
             return ComponentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1319,7 +1251,7 @@ impl Convertable for ComponentProxy<'_> {
             // variables
             return DocumentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1333,7 +1265,7 @@ impl Convertable for ComponentProxy<'_> {
             // variables
             return HypertextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1347,7 +1279,7 @@ impl Convertable for ComponentProxy<'_> {
             // variables
             return HyperlinkProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1361,7 +1293,7 @@ impl Convertable for ComponentProxy<'_> {
             // variables
             return ImageProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1375,7 +1307,7 @@ impl Convertable for ComponentProxy<'_> {
             // variables
             return SelectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1389,7 +1321,7 @@ impl Convertable for ComponentProxy<'_> {
             // variables
             return TableProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1403,7 +1335,7 @@ impl Convertable for ComponentProxy<'_> {
             // variables
             return TableCellProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1417,7 +1349,7 @@ impl Convertable for ComponentProxy<'_> {
             // variables
             return TextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1426,16 +1358,12 @@ impl Convertable for ComponentProxy<'_> {
     }
     async fn to_editable_text<'a>(&'a self) -> zbus::Result<EditableTextProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::EditableText)
-        {
+        if acc.get_interfaces().await?.contains(Interface::EditableText) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return EditableTextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1449,7 +1377,7 @@ impl Convertable for ComponentProxy<'_> {
             // variables
             return CacheProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1463,7 +1391,7 @@ impl Convertable for ComponentProxy<'_> {
             // variables
             return ValueProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1477,7 +1405,7 @@ impl Convertable for ComponentProxy<'_> {
             // variables
             return RegistryProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1488,16 +1416,12 @@ impl Convertable for ComponentProxy<'_> {
         &'a self,
     ) -> zbus::Result<DeviceEventControllerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventController)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventController) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventControllerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1506,16 +1430,12 @@ impl Convertable for ComponentProxy<'_> {
     }
     async fn to_device_event_listener<'a>(&'a self) -> zbus::Result<DeviceEventListenerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventListener)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventListener) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventListenerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1529,23 +1449,19 @@ impl Convertable for DeviceEventControllerProxy<'_> {
     async fn to_accessible<'a>(&'a self) -> zbus::Result<AccessibleProxy<'a>> {
         AccessibleProxy::builder(self.connection())
             .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+            .cache_properties(CacheProperties::No)
             .path(self.path())?
             .build()
             .await
     }
     async fn to_action<'a>(&'a self) -> zbus::Result<ActionProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::Action)
-        {
+        if acc.get_interfaces().await?.contains(Interface::Action) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return ActionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1559,7 +1475,7 @@ impl Convertable for DeviceEventControllerProxy<'_> {
             // variables
             return ApplicationProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1573,7 +1489,7 @@ impl Convertable for DeviceEventControllerProxy<'_> {
             // variables
             return CollectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1587,7 +1503,7 @@ impl Convertable for DeviceEventControllerProxy<'_> {
             // variables
             return ComponentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1601,7 +1517,7 @@ impl Convertable for DeviceEventControllerProxy<'_> {
             // variables
             return DocumentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1615,7 +1531,7 @@ impl Convertable for DeviceEventControllerProxy<'_> {
             // variables
             return HypertextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1629,7 +1545,7 @@ impl Convertable for DeviceEventControllerProxy<'_> {
             // variables
             return HyperlinkProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1643,7 +1559,7 @@ impl Convertable for DeviceEventControllerProxy<'_> {
             // variables
             return ImageProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1657,7 +1573,7 @@ impl Convertable for DeviceEventControllerProxy<'_> {
             // variables
             return SelectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1671,7 +1587,7 @@ impl Convertable for DeviceEventControllerProxy<'_> {
             // variables
             return TableProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1685,7 +1601,7 @@ impl Convertable for DeviceEventControllerProxy<'_> {
             // variables
             return TableCellProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1699,7 +1615,7 @@ impl Convertable for DeviceEventControllerProxy<'_> {
             // variables
             return TextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1708,16 +1624,12 @@ impl Convertable for DeviceEventControllerProxy<'_> {
     }
     async fn to_editable_text<'a>(&'a self) -> zbus::Result<EditableTextProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::EditableText)
-        {
+        if acc.get_interfaces().await?.contains(Interface::EditableText) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return EditableTextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1731,7 +1643,7 @@ impl Convertable for DeviceEventControllerProxy<'_> {
             // variables
             return CacheProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1745,7 +1657,7 @@ impl Convertable for DeviceEventControllerProxy<'_> {
             // variables
             return ValueProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1759,7 +1671,7 @@ impl Convertable for DeviceEventControllerProxy<'_> {
             // variables
             return RegistryProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1770,16 +1682,12 @@ impl Convertable for DeviceEventControllerProxy<'_> {
         &'a self,
     ) -> zbus::Result<DeviceEventControllerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventController)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventController) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventControllerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1788,16 +1696,12 @@ impl Convertable for DeviceEventControllerProxy<'_> {
     }
     async fn to_device_event_listener<'a>(&'a self) -> zbus::Result<DeviceEventListenerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventListener)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventListener) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventListenerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1811,23 +1715,19 @@ impl Convertable for DeviceEventListenerProxy<'_> {
     async fn to_accessible<'a>(&'a self) -> zbus::Result<AccessibleProxy<'a>> {
         AccessibleProxy::builder(self.connection())
             .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+            .cache_properties(CacheProperties::No)
             .path(self.path())?
             .build()
             .await
     }
     async fn to_action<'a>(&'a self) -> zbus::Result<ActionProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::Action)
-        {
+        if acc.get_interfaces().await?.contains(Interface::Action) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return ActionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1841,7 +1741,7 @@ impl Convertable for DeviceEventListenerProxy<'_> {
             // variables
             return ApplicationProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1855,7 +1755,7 @@ impl Convertable for DeviceEventListenerProxy<'_> {
             // variables
             return CollectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1869,7 +1769,7 @@ impl Convertable for DeviceEventListenerProxy<'_> {
             // variables
             return ComponentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1883,7 +1783,7 @@ impl Convertable for DeviceEventListenerProxy<'_> {
             // variables
             return DocumentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1897,7 +1797,7 @@ impl Convertable for DeviceEventListenerProxy<'_> {
             // variables
             return HypertextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1911,7 +1811,7 @@ impl Convertable for DeviceEventListenerProxy<'_> {
             // variables
             return HyperlinkProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1925,7 +1825,7 @@ impl Convertable for DeviceEventListenerProxy<'_> {
             // variables
             return ImageProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1939,7 +1839,7 @@ impl Convertable for DeviceEventListenerProxy<'_> {
             // variables
             return SelectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1953,7 +1853,7 @@ impl Convertable for DeviceEventListenerProxy<'_> {
             // variables
             return TableProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1967,7 +1867,7 @@ impl Convertable for DeviceEventListenerProxy<'_> {
             // variables
             return TableCellProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1981,7 +1881,7 @@ impl Convertable for DeviceEventListenerProxy<'_> {
             // variables
             return TextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -1990,16 +1890,12 @@ impl Convertable for DeviceEventListenerProxy<'_> {
     }
     async fn to_editable_text<'a>(&'a self) -> zbus::Result<EditableTextProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::EditableText)
-        {
+        if acc.get_interfaces().await?.contains(Interface::EditableText) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return EditableTextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2013,7 +1909,7 @@ impl Convertable for DeviceEventListenerProxy<'_> {
             // variables
             return CacheProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2027,7 +1923,7 @@ impl Convertable for DeviceEventListenerProxy<'_> {
             // variables
             return ValueProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2041,7 +1937,7 @@ impl Convertable for DeviceEventListenerProxy<'_> {
             // variables
             return RegistryProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2052,16 +1948,12 @@ impl Convertable for DeviceEventListenerProxy<'_> {
         &'a self,
     ) -> zbus::Result<DeviceEventControllerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventController)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventController) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventControllerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2070,16 +1962,12 @@ impl Convertable for DeviceEventListenerProxy<'_> {
     }
     async fn to_device_event_listener<'a>(&'a self) -> zbus::Result<DeviceEventListenerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventListener)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventListener) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventListenerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2093,23 +1981,19 @@ impl Convertable for DocumentProxy<'_> {
     async fn to_accessible<'a>(&'a self) -> zbus::Result<AccessibleProxy<'a>> {
         AccessibleProxy::builder(self.connection())
             .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+            .cache_properties(CacheProperties::No)
             .path(self.path())?
             .build()
             .await
     }
     async fn to_action<'a>(&'a self) -> zbus::Result<ActionProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::Action)
-        {
+        if acc.get_interfaces().await?.contains(Interface::Action) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return ActionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2123,7 +2007,7 @@ impl Convertable for DocumentProxy<'_> {
             // variables
             return ApplicationProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2137,7 +2021,7 @@ impl Convertable for DocumentProxy<'_> {
             // variables
             return CollectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2151,7 +2035,7 @@ impl Convertable for DocumentProxy<'_> {
             // variables
             return ComponentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2165,7 +2049,7 @@ impl Convertable for DocumentProxy<'_> {
             // variables
             return DocumentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2179,7 +2063,7 @@ impl Convertable for DocumentProxy<'_> {
             // variables
             return HypertextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2193,7 +2077,7 @@ impl Convertable for DocumentProxy<'_> {
             // variables
             return HyperlinkProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2207,7 +2091,7 @@ impl Convertable for DocumentProxy<'_> {
             // variables
             return ImageProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2221,7 +2105,7 @@ impl Convertable for DocumentProxy<'_> {
             // variables
             return SelectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2235,7 +2119,7 @@ impl Convertable for DocumentProxy<'_> {
             // variables
             return TableProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2249,7 +2133,7 @@ impl Convertable for DocumentProxy<'_> {
             // variables
             return TableCellProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2263,7 +2147,7 @@ impl Convertable for DocumentProxy<'_> {
             // variables
             return TextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2272,16 +2156,12 @@ impl Convertable for DocumentProxy<'_> {
     }
     async fn to_editable_text<'a>(&'a self) -> zbus::Result<EditableTextProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::EditableText)
-        {
+        if acc.get_interfaces().await?.contains(Interface::EditableText) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return EditableTextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2295,7 +2175,7 @@ impl Convertable for DocumentProxy<'_> {
             // variables
             return CacheProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2309,7 +2189,7 @@ impl Convertable for DocumentProxy<'_> {
             // variables
             return ValueProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2323,7 +2203,7 @@ impl Convertable for DocumentProxy<'_> {
             // variables
             return RegistryProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2334,16 +2214,12 @@ impl Convertable for DocumentProxy<'_> {
         &'a self,
     ) -> zbus::Result<DeviceEventControllerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventController)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventController) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventControllerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2352,16 +2228,12 @@ impl Convertable for DocumentProxy<'_> {
     }
     async fn to_device_event_listener<'a>(&'a self) -> zbus::Result<DeviceEventListenerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventListener)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventListener) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventListenerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2375,23 +2247,19 @@ impl Convertable for EditableTextProxy<'_> {
     async fn to_accessible<'a>(&'a self) -> zbus::Result<AccessibleProxy<'a>> {
         AccessibleProxy::builder(self.connection())
             .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+            .cache_properties(CacheProperties::No)
             .path(self.path())?
             .build()
             .await
     }
     async fn to_action<'a>(&'a self) -> zbus::Result<ActionProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::Action)
-        {
+        if acc.get_interfaces().await?.contains(Interface::Action) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return ActionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2405,7 +2273,7 @@ impl Convertable for EditableTextProxy<'_> {
             // variables
             return ApplicationProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2419,7 +2287,7 @@ impl Convertable for EditableTextProxy<'_> {
             // variables
             return CollectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2433,7 +2301,7 @@ impl Convertable for EditableTextProxy<'_> {
             // variables
             return ComponentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2447,7 +2315,7 @@ impl Convertable for EditableTextProxy<'_> {
             // variables
             return DocumentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2461,7 +2329,7 @@ impl Convertable for EditableTextProxy<'_> {
             // variables
             return HypertextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2475,7 +2343,7 @@ impl Convertable for EditableTextProxy<'_> {
             // variables
             return HyperlinkProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2489,7 +2357,7 @@ impl Convertable for EditableTextProxy<'_> {
             // variables
             return ImageProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2503,7 +2371,7 @@ impl Convertable for EditableTextProxy<'_> {
             // variables
             return SelectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2517,7 +2385,7 @@ impl Convertable for EditableTextProxy<'_> {
             // variables
             return TableProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2531,7 +2399,7 @@ impl Convertable for EditableTextProxy<'_> {
             // variables
             return TableCellProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2545,7 +2413,7 @@ impl Convertable for EditableTextProxy<'_> {
             // variables
             return TextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2554,16 +2422,12 @@ impl Convertable for EditableTextProxy<'_> {
     }
     async fn to_editable_text<'a>(&'a self) -> zbus::Result<EditableTextProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::EditableText)
-        {
+        if acc.get_interfaces().await?.contains(Interface::EditableText) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return EditableTextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2577,7 +2441,7 @@ impl Convertable for EditableTextProxy<'_> {
             // variables
             return CacheProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2591,7 +2455,7 @@ impl Convertable for EditableTextProxy<'_> {
             // variables
             return ValueProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2605,7 +2469,7 @@ impl Convertable for EditableTextProxy<'_> {
             // variables
             return RegistryProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2616,16 +2480,12 @@ impl Convertable for EditableTextProxy<'_> {
         &'a self,
     ) -> zbus::Result<DeviceEventControllerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventController)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventController) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventControllerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2634,16 +2494,12 @@ impl Convertable for EditableTextProxy<'_> {
     }
     async fn to_device_event_listener<'a>(&'a self) -> zbus::Result<DeviceEventListenerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventListener)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventListener) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventListenerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2657,23 +2513,19 @@ impl Convertable for HyperlinkProxy<'_> {
     async fn to_accessible<'a>(&'a self) -> zbus::Result<AccessibleProxy<'a>> {
         AccessibleProxy::builder(self.connection())
             .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+            .cache_properties(CacheProperties::No)
             .path(self.path())?
             .build()
             .await
     }
     async fn to_action<'a>(&'a self) -> zbus::Result<ActionProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::Action)
-        {
+        if acc.get_interfaces().await?.contains(Interface::Action) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return ActionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2687,7 +2539,7 @@ impl Convertable for HyperlinkProxy<'_> {
             // variables
             return ApplicationProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2701,7 +2553,7 @@ impl Convertable for HyperlinkProxy<'_> {
             // variables
             return CollectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2715,7 +2567,7 @@ impl Convertable for HyperlinkProxy<'_> {
             // variables
             return ComponentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2729,7 +2581,7 @@ impl Convertable for HyperlinkProxy<'_> {
             // variables
             return DocumentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2743,7 +2595,7 @@ impl Convertable for HyperlinkProxy<'_> {
             // variables
             return HypertextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2757,7 +2609,7 @@ impl Convertable for HyperlinkProxy<'_> {
             // variables
             return HyperlinkProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2771,7 +2623,7 @@ impl Convertable for HyperlinkProxy<'_> {
             // variables
             return ImageProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2785,7 +2637,7 @@ impl Convertable for HyperlinkProxy<'_> {
             // variables
             return SelectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2799,7 +2651,7 @@ impl Convertable for HyperlinkProxy<'_> {
             // variables
             return TableProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2813,7 +2665,7 @@ impl Convertable for HyperlinkProxy<'_> {
             // variables
             return TableCellProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2827,7 +2679,7 @@ impl Convertable for HyperlinkProxy<'_> {
             // variables
             return TextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2836,16 +2688,12 @@ impl Convertable for HyperlinkProxy<'_> {
     }
     async fn to_editable_text<'a>(&'a self) -> zbus::Result<EditableTextProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::EditableText)
-        {
+        if acc.get_interfaces().await?.contains(Interface::EditableText) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return EditableTextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2859,7 +2707,7 @@ impl Convertable for HyperlinkProxy<'_> {
             // variables
             return CacheProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2873,7 +2721,7 @@ impl Convertable for HyperlinkProxy<'_> {
             // variables
             return ValueProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2887,7 +2735,7 @@ impl Convertable for HyperlinkProxy<'_> {
             // variables
             return RegistryProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2898,16 +2746,12 @@ impl Convertable for HyperlinkProxy<'_> {
         &'a self,
     ) -> zbus::Result<DeviceEventControllerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventController)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventController) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventControllerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2916,16 +2760,12 @@ impl Convertable for HyperlinkProxy<'_> {
     }
     async fn to_device_event_listener<'a>(&'a self) -> zbus::Result<DeviceEventListenerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventListener)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventListener) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventListenerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2939,23 +2779,19 @@ impl Convertable for HypertextProxy<'_> {
     async fn to_accessible<'a>(&'a self) -> zbus::Result<AccessibleProxy<'a>> {
         AccessibleProxy::builder(self.connection())
             .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+            .cache_properties(CacheProperties::No)
             .path(self.path())?
             .build()
             .await
     }
     async fn to_action<'a>(&'a self) -> zbus::Result<ActionProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::Action)
-        {
+        if acc.get_interfaces().await?.contains(Interface::Action) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return ActionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2969,7 +2805,7 @@ impl Convertable for HypertextProxy<'_> {
             // variables
             return ApplicationProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2983,7 +2819,7 @@ impl Convertable for HypertextProxy<'_> {
             // variables
             return CollectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -2997,7 +2833,7 @@ impl Convertable for HypertextProxy<'_> {
             // variables
             return ComponentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3011,7 +2847,7 @@ impl Convertable for HypertextProxy<'_> {
             // variables
             return DocumentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3025,7 +2861,7 @@ impl Convertable for HypertextProxy<'_> {
             // variables
             return HypertextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3039,7 +2875,7 @@ impl Convertable for HypertextProxy<'_> {
             // variables
             return HyperlinkProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3053,7 +2889,7 @@ impl Convertable for HypertextProxy<'_> {
             // variables
             return ImageProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3067,7 +2903,7 @@ impl Convertable for HypertextProxy<'_> {
             // variables
             return SelectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3081,7 +2917,7 @@ impl Convertable for HypertextProxy<'_> {
             // variables
             return TableProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3095,7 +2931,7 @@ impl Convertable for HypertextProxy<'_> {
             // variables
             return TableCellProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3109,7 +2945,7 @@ impl Convertable for HypertextProxy<'_> {
             // variables
             return TextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3118,16 +2954,12 @@ impl Convertable for HypertextProxy<'_> {
     }
     async fn to_editable_text<'a>(&'a self) -> zbus::Result<EditableTextProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::EditableText)
-        {
+        if acc.get_interfaces().await?.contains(Interface::EditableText) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return EditableTextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3141,7 +2973,7 @@ impl Convertable for HypertextProxy<'_> {
             // variables
             return CacheProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3155,7 +2987,7 @@ impl Convertable for HypertextProxy<'_> {
             // variables
             return ValueProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3169,7 +3001,7 @@ impl Convertable for HypertextProxy<'_> {
             // variables
             return RegistryProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3180,16 +3012,12 @@ impl Convertable for HypertextProxy<'_> {
         &'a self,
     ) -> zbus::Result<DeviceEventControllerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventController)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventController) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventControllerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3198,16 +3026,12 @@ impl Convertable for HypertextProxy<'_> {
     }
     async fn to_device_event_listener<'a>(&'a self) -> zbus::Result<DeviceEventListenerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventListener)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventListener) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventListenerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3221,23 +3045,19 @@ impl Convertable for ImageProxy<'_> {
     async fn to_accessible<'a>(&'a self) -> zbus::Result<AccessibleProxy<'a>> {
         AccessibleProxy::builder(self.connection())
             .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+            .cache_properties(CacheProperties::No)
             .path(self.path())?
             .build()
             .await
     }
     async fn to_action<'a>(&'a self) -> zbus::Result<ActionProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::Action)
-        {
+        if acc.get_interfaces().await?.contains(Interface::Action) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return ActionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3251,7 +3071,7 @@ impl Convertable for ImageProxy<'_> {
             // variables
             return ApplicationProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3265,7 +3085,7 @@ impl Convertable for ImageProxy<'_> {
             // variables
             return CollectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3279,7 +3099,7 @@ impl Convertable for ImageProxy<'_> {
             // variables
             return ComponentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3293,7 +3113,7 @@ impl Convertable for ImageProxy<'_> {
             // variables
             return DocumentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3307,7 +3127,7 @@ impl Convertable for ImageProxy<'_> {
             // variables
             return HypertextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3321,7 +3141,7 @@ impl Convertable for ImageProxy<'_> {
             // variables
             return HyperlinkProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3335,7 +3155,7 @@ impl Convertable for ImageProxy<'_> {
             // variables
             return ImageProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3349,7 +3169,7 @@ impl Convertable for ImageProxy<'_> {
             // variables
             return SelectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3363,7 +3183,7 @@ impl Convertable for ImageProxy<'_> {
             // variables
             return TableProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3377,7 +3197,7 @@ impl Convertable for ImageProxy<'_> {
             // variables
             return TableCellProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3391,7 +3211,7 @@ impl Convertable for ImageProxy<'_> {
             // variables
             return TextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3400,16 +3220,12 @@ impl Convertable for ImageProxy<'_> {
     }
     async fn to_editable_text<'a>(&'a self) -> zbus::Result<EditableTextProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::EditableText)
-        {
+        if acc.get_interfaces().await?.contains(Interface::EditableText) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return EditableTextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3423,7 +3239,7 @@ impl Convertable for ImageProxy<'_> {
             // variables
             return CacheProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3437,7 +3253,7 @@ impl Convertable for ImageProxy<'_> {
             // variables
             return ValueProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3451,7 +3267,7 @@ impl Convertable for ImageProxy<'_> {
             // variables
             return RegistryProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3462,16 +3278,12 @@ impl Convertable for ImageProxy<'_> {
         &'a self,
     ) -> zbus::Result<DeviceEventControllerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventController)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventController) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventControllerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3480,16 +3292,12 @@ impl Convertable for ImageProxy<'_> {
     }
     async fn to_device_event_listener<'a>(&'a self) -> zbus::Result<DeviceEventListenerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventListener)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventListener) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventListenerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3503,23 +3311,19 @@ impl Convertable for TextProxy<'_> {
     async fn to_accessible<'a>(&'a self) -> zbus::Result<AccessibleProxy<'a>> {
         AccessibleProxy::builder(self.connection())
             .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+            .cache_properties(CacheProperties::No)
             .path(self.path())?
             .build()
             .await
     }
     async fn to_action<'a>(&'a self) -> zbus::Result<ActionProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::Action)
-        {
+        if acc.get_interfaces().await?.contains(Interface::Action) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return ActionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3533,7 +3337,7 @@ impl Convertable for TextProxy<'_> {
             // variables
             return ApplicationProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3547,7 +3351,7 @@ impl Convertable for TextProxy<'_> {
             // variables
             return CollectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3561,7 +3365,7 @@ impl Convertable for TextProxy<'_> {
             // variables
             return ComponentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3575,7 +3379,7 @@ impl Convertable for TextProxy<'_> {
             // variables
             return DocumentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3589,7 +3393,7 @@ impl Convertable for TextProxy<'_> {
             // variables
             return HypertextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3603,7 +3407,7 @@ impl Convertable for TextProxy<'_> {
             // variables
             return HyperlinkProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3617,7 +3421,7 @@ impl Convertable for TextProxy<'_> {
             // variables
             return ImageProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3631,7 +3435,7 @@ impl Convertable for TextProxy<'_> {
             // variables
             return SelectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3645,7 +3449,7 @@ impl Convertable for TextProxy<'_> {
             // variables
             return TableProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3659,7 +3463,7 @@ impl Convertable for TextProxy<'_> {
             // variables
             return TableCellProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3673,7 +3477,7 @@ impl Convertable for TextProxy<'_> {
             // variables
             return TextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3682,16 +3486,12 @@ impl Convertable for TextProxy<'_> {
     }
     async fn to_editable_text<'a>(&'a self) -> zbus::Result<EditableTextProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::EditableText)
-        {
+        if acc.get_interfaces().await?.contains(Interface::EditableText) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return EditableTextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3705,7 +3505,7 @@ impl Convertable for TextProxy<'_> {
             // variables
             return CacheProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3719,7 +3519,7 @@ impl Convertable for TextProxy<'_> {
             // variables
             return ValueProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3733,7 +3533,7 @@ impl Convertable for TextProxy<'_> {
             // variables
             return RegistryProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3744,16 +3544,12 @@ impl Convertable for TextProxy<'_> {
         &'a self,
     ) -> zbus::Result<DeviceEventControllerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventController)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventController) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventControllerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3762,16 +3558,12 @@ impl Convertable for TextProxy<'_> {
     }
     async fn to_device_event_listener<'a>(&'a self) -> zbus::Result<DeviceEventListenerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventListener)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventListener) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventListenerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3785,23 +3577,19 @@ impl Convertable for TableProxy<'_> {
     async fn to_accessible<'a>(&'a self) -> zbus::Result<AccessibleProxy<'a>> {
         AccessibleProxy::builder(self.connection())
             .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+            .cache_properties(CacheProperties::No)
             .path(self.path())?
             .build()
             .await
     }
     async fn to_action<'a>(&'a self) -> zbus::Result<ActionProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::Action)
-        {
+        if acc.get_interfaces().await?.contains(Interface::Action) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return ActionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3815,7 +3603,7 @@ impl Convertable for TableProxy<'_> {
             // variables
             return ApplicationProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3829,7 +3617,7 @@ impl Convertable for TableProxy<'_> {
             // variables
             return CollectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3843,7 +3631,7 @@ impl Convertable for TableProxy<'_> {
             // variables
             return ComponentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3857,7 +3645,7 @@ impl Convertable for TableProxy<'_> {
             // variables
             return DocumentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3871,7 +3659,7 @@ impl Convertable for TableProxy<'_> {
             // variables
             return HypertextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3885,7 +3673,7 @@ impl Convertable for TableProxy<'_> {
             // variables
             return HyperlinkProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3899,7 +3687,7 @@ impl Convertable for TableProxy<'_> {
             // variables
             return ImageProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3913,7 +3701,7 @@ impl Convertable for TableProxy<'_> {
             // variables
             return SelectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3927,7 +3715,7 @@ impl Convertable for TableProxy<'_> {
             // variables
             return TableProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3941,7 +3729,7 @@ impl Convertable for TableProxy<'_> {
             // variables
             return TableCellProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3955,7 +3743,7 @@ impl Convertable for TableProxy<'_> {
             // variables
             return TextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3964,16 +3752,12 @@ impl Convertable for TableProxy<'_> {
     }
     async fn to_editable_text<'a>(&'a self) -> zbus::Result<EditableTextProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::EditableText)
-        {
+        if acc.get_interfaces().await?.contains(Interface::EditableText) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return EditableTextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -3987,7 +3771,7 @@ impl Convertable for TableProxy<'_> {
             // variables
             return CacheProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4001,7 +3785,7 @@ impl Convertable for TableProxy<'_> {
             // variables
             return ValueProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4015,7 +3799,7 @@ impl Convertable for TableProxy<'_> {
             // variables
             return RegistryProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4026,16 +3810,12 @@ impl Convertable for TableProxy<'_> {
         &'a self,
     ) -> zbus::Result<DeviceEventControllerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventController)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventController) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventControllerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4044,16 +3824,12 @@ impl Convertable for TableProxy<'_> {
     }
     async fn to_device_event_listener<'a>(&'a self) -> zbus::Result<DeviceEventListenerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventListener)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventListener) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventListenerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4067,23 +3843,19 @@ impl Convertable for TableCellProxy<'_> {
     async fn to_accessible<'a>(&'a self) -> zbus::Result<AccessibleProxy<'a>> {
         AccessibleProxy::builder(self.connection())
             .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+            .cache_properties(CacheProperties::No)
             .path(self.path())?
             .build()
             .await
     }
     async fn to_action<'a>(&'a self) -> zbus::Result<ActionProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::Action)
-        {
+        if acc.get_interfaces().await?.contains(Interface::Action) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return ActionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4097,7 +3869,7 @@ impl Convertable for TableCellProxy<'_> {
             // variables
             return ApplicationProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4111,7 +3883,7 @@ impl Convertable for TableCellProxy<'_> {
             // variables
             return CollectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4125,7 +3897,7 @@ impl Convertable for TableCellProxy<'_> {
             // variables
             return ComponentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4139,7 +3911,7 @@ impl Convertable for TableCellProxy<'_> {
             // variables
             return DocumentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4153,7 +3925,7 @@ impl Convertable for TableCellProxy<'_> {
             // variables
             return HypertextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4167,7 +3939,7 @@ impl Convertable for TableCellProxy<'_> {
             // variables
             return HyperlinkProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4181,7 +3953,7 @@ impl Convertable for TableCellProxy<'_> {
             // variables
             return ImageProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4195,7 +3967,7 @@ impl Convertable for TableCellProxy<'_> {
             // variables
             return SelectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4209,7 +3981,7 @@ impl Convertable for TableCellProxy<'_> {
             // variables
             return TableProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4223,7 +3995,7 @@ impl Convertable for TableCellProxy<'_> {
             // variables
             return TableCellProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4237,7 +4009,7 @@ impl Convertable for TableCellProxy<'_> {
             // variables
             return TextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4246,16 +4018,12 @@ impl Convertable for TableCellProxy<'_> {
     }
     async fn to_editable_text<'a>(&'a self) -> zbus::Result<EditableTextProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::EditableText)
-        {
+        if acc.get_interfaces().await?.contains(Interface::EditableText) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return EditableTextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4269,7 +4037,7 @@ impl Convertable for TableCellProxy<'_> {
             // variables
             return CacheProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4283,7 +4051,7 @@ impl Convertable for TableCellProxy<'_> {
             // variables
             return ValueProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4297,7 +4065,7 @@ impl Convertable for TableCellProxy<'_> {
             // variables
             return RegistryProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4308,16 +4076,12 @@ impl Convertable for TableCellProxy<'_> {
         &'a self,
     ) -> zbus::Result<DeviceEventControllerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventController)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventController) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventControllerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4326,16 +4090,12 @@ impl Convertable for TableCellProxy<'_> {
     }
     async fn to_device_event_listener<'a>(&'a self) -> zbus::Result<DeviceEventListenerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventListener)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventListener) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventListenerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4349,23 +4109,19 @@ impl Convertable for ValueProxy<'_> {
     async fn to_accessible<'a>(&'a self) -> zbus::Result<AccessibleProxy<'a>> {
         AccessibleProxy::builder(self.connection())
             .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+            .cache_properties(CacheProperties::No)
             .path(self.path())?
             .build()
             .await
     }
     async fn to_action<'a>(&'a self) -> zbus::Result<ActionProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::Action)
-        {
+        if acc.get_interfaces().await?.contains(Interface::Action) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return ActionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4379,7 +4135,7 @@ impl Convertable for ValueProxy<'_> {
             // variables
             return ApplicationProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4393,7 +4149,7 @@ impl Convertable for ValueProxy<'_> {
             // variables
             return CollectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4407,7 +4163,7 @@ impl Convertable for ValueProxy<'_> {
             // variables
             return ComponentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4421,7 +4177,7 @@ impl Convertable for ValueProxy<'_> {
             // variables
             return DocumentProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4435,7 +4191,7 @@ impl Convertable for ValueProxy<'_> {
             // variables
             return HypertextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4449,7 +4205,7 @@ impl Convertable for ValueProxy<'_> {
             // variables
             return HyperlinkProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4463,7 +4219,7 @@ impl Convertable for ValueProxy<'_> {
             // variables
             return ImageProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4477,7 +4233,7 @@ impl Convertable for ValueProxy<'_> {
             // variables
             return SelectionProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4491,7 +4247,7 @@ impl Convertable for ValueProxy<'_> {
             // variables
             return TableProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4505,7 +4261,7 @@ impl Convertable for ValueProxy<'_> {
             // variables
             return TableCellProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4519,7 +4275,7 @@ impl Convertable for ValueProxy<'_> {
             // variables
             return TextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4528,16 +4284,12 @@ impl Convertable for ValueProxy<'_> {
     }
     async fn to_editable_text<'a>(&'a self) -> zbus::Result<EditableTextProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::EditableText)
-        {
+        if acc.get_interfaces().await?.contains(Interface::EditableText) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return EditableTextProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4551,7 +4303,7 @@ impl Convertable for ValueProxy<'_> {
             // variables
             return CacheProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4565,7 +4317,7 @@ impl Convertable for ValueProxy<'_> {
             // variables
             return ValueProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4579,7 +4331,7 @@ impl Convertable for ValueProxy<'_> {
             // variables
             return RegistryProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4590,16 +4342,12 @@ impl Convertable for ValueProxy<'_> {
         &'a self,
     ) -> zbus::Result<DeviceEventControllerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventController)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventController) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventControllerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;
@@ -4608,16 +4356,12 @@ impl Convertable for ValueProxy<'_> {
     }
     async fn to_device_event_listener<'a>(&'a self) -> zbus::Result<DeviceEventListenerProxy<'a>> {
         let acc = self.to_accessible().await?;
-        if acc
-            .get_interfaces()
-            .await?
-            .contains(Interface::DeviceEventListener)
-        {
+        if acc.get_interfaces().await?.contains(Interface::DeviceEventListener) {
             // you can use self here since converting to accessible does not change the internal
             // variables
             return DeviceEventListenerProxy::builder(self.connection())
                 .destination(self.destination())?
-				.cache_properties(CacheProperties::No)
+                .cache_properties(CacheProperties::No)
                 .path(self.path())?
                 .build()
                 .await;

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -68,7 +68,10 @@ pub struct EventBodyOwned {
 impl From<EventBodyQT> for EventBodyOwned {
     fn from(body: EventBodyQT) -> Self {
         let mut props = HashMap::new();
-        props.insert(body.properties.0, Value::ObjectPath(body.properties.1.into_inner()).to_owned());
+        props.insert(
+            body.properties.0,
+            Value::ObjectPath(body.properties.1.into_inner()).to_owned(),
+        );
         Self {
             kind: body.kind,
             detail1: body.detail1,
@@ -118,10 +121,7 @@ impl Event {
     /// components of the event type. It is meant for logging, etc.
     pub fn event_string(&self) -> String {
         let interface = self.interface().expect("Event should have an interface");
-        let interface = interface
-            .rsplit('.')
-            .next()
-            .expect("Interface should contain a '.'");
+        let interface = interface.rsplit('.').next().expect("Interface should contain a '.'");
         let member = self.member().expect("Event should have a member");
         let kind = self.kind();
         format!("{interface}:{member}:{kind}")

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -15,7 +15,7 @@ use zbus::dbus_proxy;
 #[dbus_proxy(
     interface = "org.a11y.atspi.Socket",
     default_path = "/org/a11y/atspi/accessible/root",
-    default_service = "org.a11y.atspi.Registry",
+    default_service = "org.a11y.atspi.Registry"
 )]
 trait Socket {
     /// Embed method


### PR DESCRIPTION
This PR contains two commits:

- The introduction of a `rustfmt.toml`
  The config introduces a few defaults and, most importantly perhaps, a link to the fustfmt options' documentation.
  The options that were chosen are stable.

- The crate's sources reformatted using the new config.