### PR TITLE
[draft] Add `set_session_accessibility` (again)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ zbus = { version = "^3.0.0", default-features = false }
 
 [dev-dependencies]
 byteorder = "1.4.3"
+smol = "1.3.0"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -85,7 +85,6 @@ impl Deref for Connection {
 /// * if creation of a [`StatusProxy`] fails
 /// * if the `IsEnabled` property cannot be read
 /// * the `IsEnabled` property cannot be set.
-#[must_use = "AT's are required to set `IsEnabled` on startup."]
 pub async fn set_session_accessibility(
     status: bool,
 ) -> std::result::Result<(), zbus::Error> {

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -18,7 +18,7 @@ use zbus::{
     ProxyDefault,
 };
 
-/// Indicates AT-SPI interfaces an |`crate::accessible::AccessibleProxy`] can implement.
+/// Indicates AT-SPI interfaces an [`crate::accessible::AccessibleProxy`] can implement.
 #[bitflags]
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]


### PR DESCRIPTION
 Set the `IsEnabled` property in the session bus.

 Assistive Technology provider applications (ATs) should set the accessibility
 `IsEnabled` status on the users session bus on startup as applications may monitor this property
 to  enable their accessibility support dynamically.

 See: The [freedesktop - AT-SPI2 wiki](https://www.freedesktop.org/wiki/Accessibility/AT-SPI2/)

- rebased against main
- removed `#[must_use]`. It does something different than I intended. Useful, but not here.  