### PR TITLE
Trade `smol1` for `futures-lite` in dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,4 @@ zbus = { version = "^3.0.0", default-features = false }
 
 [dev-dependencies]
 byteorder = "1.4.3"
-smol = "1.3.0"
+futures-lite = { version = "1", default-features = false }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -74,10 +74,9 @@ impl Deref for Connection {
 /// 
 ///  ## Example
 /// ```rust
-///     use atspi::set_session_accessibility;
-///     use smol::block_on;
+///     use futures_lite::future::block_on;
 /// 
-///     let result =  block_on( set_session_accessibility(true) );
+///     let result =  block_on( atspi::set_session_accessibility(true) );
 ///     assert!(result.is_ok());
 /// ```
 ///  ## Errors


### PR DESCRIPTION
Reasoning:
`futures-lite` is that part of `smol` that provides the executor we need.

This reduces our footprint.

Before this commit:
```Bash
	cargo tree | wc -l
	239
```
After:
```Bash
	cargo tree | wc -l
	202
```