### PR TITLE
Add an include directive to minimize the published package size of `atspi`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/odilia-app/atspi"
 keywords = ["screen-reader", "accessibility", "a11y", "tts", "linux"]
 categories = ["accessibility", "api-bindings"]
 edition = "2021"
+include = ["src/**/*", "LICENSE-*", "README.md"]
 
 [package.metadata.release]
 release = true


### PR DESCRIPTION
Crates that added `atspi` as a dependency do not need all of the repository. Adding an [include or exclude directive](https://doc.rust-lang.org/cargo/reference/manifest.html?highlight=include%20directive#the-exclude-and-include-fields) allows for minimizing the projects published size.

This PR reduces the published version of atspi by 27% or 120.3 KB in 26 files (of 447.5 KB and 75 files in entire crate)

Achieved with the help of [cargo-diet](https://crates.io/crates/cargo-diet)