### PR TITLE
Change `Event` validation on messages to `MessageType::Signal` test.

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use futures::stream::{Stream, StreamExt};
-use zbus::{Address, MessageStream};
+use zbus::{Address, MessageStream, MessageType};
 
 use crate::{bus::BusProxy, events::Event, registry::RegistryProxy};
 
@@ -41,13 +41,15 @@ impl Connection {
         Ok(Self { registry })
     }
 
+    // TODO: OPTIMIZATION focus following event stream direct with apps
+
     pub fn event_stream(&self) -> impl Stream<Item = zbus::Result<Event>> {
         MessageStream::from(self.registry.connection()).filter_map(|res| async move {
             let msg = match res {
                 Ok(m) => m,
                 Err(e) => return Some(Err(e)),
             };
-            if msg.interface()?.starts_with("org.a11y.atspi.Event.") {
+            if msg.header().ok()?.primary().msg_type() == MessageType::Signal {
                 Some(Event::try_from(msg))
             } else {
                 None
@@ -65,17 +67,17 @@ impl Deref for Connection {
 }
 
 /// Set the `IsEnabled` property in the session bus.
-/// 
+///
 /// Assistive Technology provider applications (ATs) should set the accessibility
 /// `IsEnabled` status on the users session bus on startup as applications may monitor this property
 /// to  enable their accessibility support dynamically.
-/// 
-/// See: The [freedesktop - AT-SPI2 wiki](https://www.freedesktop.org/wiki/Accessibility/AT-SPI2/) 
-/// 
+///
+/// See: The [freedesktop - AT-SPI2 wiki](https://www.freedesktop.org/wiki/Accessibility/AT-SPI2/)
+///
 ///  ## Example
 /// ```rust
 ///     use futures_lite::future::block_on;
-/// 
+///
 ///     let result =  block_on( atspi::set_session_accessibility(true) );
 ///     assert!(result.is_ok());
 /// ```
@@ -84,12 +86,10 @@ impl Deref for Connection {
 /// * if creation of a [`StatusProxy`] fails
 /// * if the `IsEnabled` property cannot be read
 /// * the `IsEnabled` property cannot be set.
-pub async fn set_session_accessibility(
-    status: bool,
-) -> std::result::Result<(), zbus::Error> {
+pub async fn set_session_accessibility(status: bool) -> std::result::Result<(), zbus::Error> {
     // Get a connection to the session bus.
     let session = zbus::Connection::session().await?;
-    
+
     // Aqcuire a `StatusProxy` for the session bus.
     let status_proxy = crate::bus::StatusProxy::new(&session).await?;
 


### PR DESCRIPTION
Signals are broadcasted Events. So, to test for events, it is sufficient to test if the `Message` is `MessageType::Signal`. This test is likely a little bit cheaper than the string compare, but that is not the point. Point is that we allow 5 more streams to come through `RegistryProxy`:

$ rg ' signal' src/events/ -trust | wc --lines
56

$ rg ' signal' src/ -trust | wc --lines
61

The difference is made up by these events:

src/registry.rs
31:    /// EventListenerDeregistered signal
35:    /// EventListenerRegistered signal

src/cache.rs
59:    /// AddAccessible signal
63:    /// RemoveAccessible signal

src/socket.rs
30:    /// Available signal