### PR TITLE
[Luuk's] Fully-Typed Events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 Cargo.lock
+/atspi-macros/target
+/atspi-matcros/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/odilia-app/atspi"
 keywords = ["screen-reader", "accessibility", "a11y", "tts", "linux"]
 categories = ["accessibility", "api-bindings"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*", "README.md"]
+include = ["src/**/*", "atspi-macros/**/*", "LICENSE-*", "README.md"]
 
 [package.metadata.release]
 release = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,14 @@ gvariant = ["zbus/gvariant"]
 tokio = ["zbus/tokio"]
 
 [dependencies]
+atspi-macros = { path="atspi-macros"}
 async-recursion = "^1.0.0"
 async-trait = "^0.1.59"
 enumflags2 = "^0.7.5"
 futures = { version = "^0.3.25", default-features = false }
+quote = "1.0.21"
 serde = { version = "^1.0", default-features = false, features = ["derive"] }
+syn = "1.0.105"
 tracing = "^0.1.37"
 zbus = { version = "^3.0.0", default-features = false }
 

--- a/atspi-macros/Cargo.toml
+++ b/atspi-macros/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "atspi-macros"
+version = "0.1.0"
+edition = "2021"
+authors = ["Luuk van der Duim <luukvanderduim@gmail.com>"]
+description = "Macros to assist in creation of the lunanode crate."
+license = "MIT"
+readme = "README.md"
+keywords = ["macros", "helper"]
+
+[lib]
+proc_macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+syn = { version = "1.0", features = ["full"] }
+quote = "1.0"
+zbus_names = "2.4.0"

--- a/atspi-macros/src/lib.rs
+++ b/atspi-macros/src/lib.rs
@@ -43,7 +43,11 @@ pub fn try_signify(input: TokenStream) -> TokenStream {
             }
         }
 
-        impl Signified for #name {}
+        impl Signified for #name {
+            fn properties(&self) -> &HashMap<String, OwnedValue> {
+                self.inner().properties()
+            }
+        }
     };
 
     // Return the expanded code as a token stream

--- a/atspi-macros/src/lib.rs
+++ b/atspi-macros/src/lib.rs
@@ -36,8 +36,6 @@ pub fn try_signify(input: TokenStream) -> TokenStream {
             }
         }
 
-
-
         impl<'a> Signified for #name {
             type Inner = AtspiEvent;
             fn inner(&self) -> &Self::Inner {
@@ -48,125 +46,6 @@ pub fn try_signify(input: TokenStream) -> TokenStream {
                 self.inner().properties()
             }
         }
-    };
-
-    // Return the expanded code as a token stream
-    TokenStream::from(expanded)
-}
-
-#[proc_macro_derive(Doc)]
-pub fn doc(input: TokenStream) -> TokenStream {
-    // Parse the input token stream into a syntax tree
-    let input = parse_macro_input!(input as DeriveInput);
-
-    // Extract the name of the struct
-    let name = &input.ident;
-
-    // Generate the expanded code
-    let expanded = quote! {
-        impl Doc for #name {}
-    };
-
-    // Return the expanded code as a token stream
-    TokenStream::from(expanded)
-}
-
-#[proc_macro_derive(Win)]
-pub fn win(input: TokenStream) -> TokenStream {
-    // Parse the input token stream into a syntax tree
-    let input = parse_macro_input!(input as DeriveInput);
-
-    // Extract the name of the struct
-    let name = &input.ident;
-
-    // Generate the expanded code
-    let expanded = quote! {
-        impl Win for #name {}
-    };
-
-    // Return the expanded code as a token stream
-    TokenStream::from(expanded)
-}
-
-#[proc_macro_derive(Term)]
-pub fn term(input: TokenStream) -> TokenStream {
-    // Parse the input token stream into a syntax tree
-    let input = parse_macro_input!(input as DeriveInput);
-
-    // Extract the name of the struct
-    let name = &input.ident;
-
-    // Generate the expanded code
-    let expanded = quote! {
-        impl Term for #name {}
-    };
-
-    // Return the expanded code as a token stream
-    TokenStream::from(expanded)
-}
-
-#[proc_macro_derive(Obj)]
-pub fn obj(input: TokenStream) -> TokenStream {
-    // Parse the input token stream into a syntax tree
-    let input = parse_macro_input!(input as DeriveInput);
-
-    // Extract the name of the struct
-    let name = &input.ident;
-
-    // Generate the expanded code
-    let expanded = quote! {
-        impl Obj for #name {}
-    };
-
-    // Return the expanded code as a token stream
-    TokenStream::from(expanded)
-}
-
-#[proc_macro_derive(Mse)]
-pub fn mse(input: TokenStream) -> TokenStream {
-    // Parse the input token stream into a syntax tree
-    let input = parse_macro_input!(input as DeriveInput);
-
-    // Extract the name of the struct
-    let name = &input.ident;
-
-    // Generate the expanded code
-    let expanded = quote! {
-        impl Mse for #name {}
-    };
-
-    // Return the expanded code as a token stream
-    TokenStream::from(expanded)
-}
-
-#[proc_macro_derive(Kbd)]
-pub fn kbd(input: TokenStream) -> TokenStream {
-    // Parse the input token stream into a syntax tree
-    let input = parse_macro_input!(input as DeriveInput);
-
-    // Extract the name of the struct
-    let name = &input.ident;
-
-    // Generate the expanded code
-    let expanded = quote! {
-        impl Kbd for #name {}
-    };
-
-    // Return the expanded code as a token stream
-    TokenStream::from(expanded)
-}
-
-#[proc_macro_derive(Focus)]
-pub fn focus(input: TokenStream) -> TokenStream {
-    // Parse the input token stream into a syntax tree
-    let input = parse_macro_input!(input as DeriveInput);
-
-    // Extract the name of the struct
-    let name = &input.ident;
-
-    // Generate the expanded code
-    let expanded = quote! {
-        impl Focus for #name {}
     };
 
     // Return the expanded code as a token stream

--- a/atspi-macros/src/lib.rs
+++ b/atspi-macros/src/lib.rs
@@ -1,0 +1,159 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+//
+// Derive macro for that implements TryFrom<Event> on a per name / member basis.
+//
+
+#[proc_macro_derive(TrySignify)]
+pub fn try_signify(input: TokenStream) -> TokenStream {
+    // Parse the input token stream into a syntax tree
+    let DeriveInput { ident, .. } = parse_macro_input!(input);
+
+    // Extract the name of the struct
+    let name = &ident;
+
+    // Remove the suffix "Event" from the name of the struct
+    let name_string = name.to_string();
+    let member = name_string.strip_suffix("Event").unwrap();
+
+    // Generate the expanded code
+    let expanded = quote! {
+        impl TryFrom<Event> for #name {
+            type Error = Box<dyn std::error::Error>;
+
+            fn try_from(value: Event) -> Result<Self, Self::Error> {
+                if value.member() == Some(MemberName::from_static_str(#member)?) {
+                    Ok(Self(value))
+                } else {
+                    Err("error signifying event signal type".into())
+                }
+            }
+        }
+
+        impl Signified for #name {}
+    };
+
+    // Return the expanded code as a token stream
+    TokenStream::from(expanded)
+}
+
+#[proc_macro_derive(Doc)]
+pub fn doc(input: TokenStream) -> TokenStream {
+    // Parse the input token stream into a syntax tree
+    let input = parse_macro_input!(input as DeriveInput);
+
+    // Extract the name of the struct
+    let name = &input.ident;
+
+    // Generate the expanded code
+    let expanded = quote! {
+        impl Doc for #name {}
+    };
+
+    // Return the expanded code as a token stream
+    TokenStream::from(expanded)
+}
+
+#[proc_macro_derive(Win)]
+pub fn win(input: TokenStream) -> TokenStream {
+    // Parse the input token stream into a syntax tree
+    let input = parse_macro_input!(input as DeriveInput);
+
+    // Extract the name of the struct
+    let name = &input.ident;
+
+    // Generate the expanded code
+    let expanded = quote! {
+        impl Win for #name {}
+    };
+
+    // Return the expanded code as a token stream
+    TokenStream::from(expanded)
+}
+
+#[proc_macro_derive(Term)]
+pub fn term(input: TokenStream) -> TokenStream {
+    // Parse the input token stream into a syntax tree
+    let input = parse_macro_input!(input as DeriveInput);
+
+    // Extract the name of the struct
+    let name = &input.ident;
+
+    // Generate the expanded code
+    let expanded = quote! {
+        impl Term for #name {}
+    };
+
+    // Return the expanded code as a token stream
+    TokenStream::from(expanded)
+}
+
+#[proc_macro_derive(Obj)]
+pub fn obj(input: TokenStream) -> TokenStream {
+    // Parse the input token stream into a syntax tree
+    let input = parse_macro_input!(input as DeriveInput);
+
+    // Extract the name of the struct
+    let name = &input.ident;
+
+    // Generate the expanded code
+    let expanded = quote! {
+        impl Obj for #name {}
+    };
+
+    // Return the expanded code as a token stream
+    TokenStream::from(expanded)
+}
+
+#[proc_macro_derive(Mse)]
+pub fn mse(input: TokenStream) -> TokenStream {
+    // Parse the input token stream into a syntax tree
+    let input = parse_macro_input!(input as DeriveInput);
+
+    // Extract the name of the struct
+    let name = &input.ident;
+
+    // Generate the expanded code
+    let expanded = quote! {
+        impl Mse for #name {}
+    };
+
+    // Return the expanded code as a token stream
+    TokenStream::from(expanded)
+}
+
+#[proc_macro_derive(Kbd)]
+pub fn kbd(input: TokenStream) -> TokenStream {
+    // Parse the input token stream into a syntax tree
+    let input = parse_macro_input!(input as DeriveInput);
+
+    // Extract the name of the struct
+    let name = &input.ident;
+
+    // Generate the expanded code
+    let expanded = quote! {
+        impl Kbd for #name {}
+    };
+
+    // Return the expanded code as a token stream
+    TokenStream::from(expanded)
+}
+
+#[proc_macro_derive(Focus)]
+pub fn focus(input: TokenStream) -> TokenStream {
+    // Parse the input token stream into a syntax tree
+    let input = parse_macro_input!(input as DeriveInput);
+
+    // Extract the name of the struct
+    let name = &input.ident;
+
+    // Generate the expanded code
+    let expanded = quote! {
+        impl Focus for #name {}
+    };
+
+    // Return the expanded code as a token stream
+    TokenStream::from(expanded)
+}

--- a/atspi-macros/src/lib.rs
+++ b/atspi-macros/src/lib.rs
@@ -24,7 +24,7 @@ pub fn try_signify(input: TokenStream) -> TokenStream {
             type Error = crate::AtspiError;
 
             fn try_from(msg: AtspiEvent) -> Result<Self, Self::Error> {
-                let msg_member = msg.member();
+                let msg_member = msg.message.member();
                 if msg_member == Some(MemberName::from_static_str(#member)?) {
                     return Ok(Self(msg));
                 };
@@ -37,13 +37,13 @@ pub fn try_signify(input: TokenStream) -> TokenStream {
         }
 
 
-        impl<'a> #name {
-            fn inner(&'a self) -> &'a AtspiEvent {
+
+        impl<'a> Signified for #name {
+            type Inner = AtspiEvent;
+            fn inner(&self) -> &Self::Inner {
                 &self.0
             }
-        }
 
-        impl Signified for #name {
             fn properties(&self) -> &HashMap<String, OwnedValue> {
                 self.inner().properties()
             }

--- a/atspi-macros/src/lib.rs
+++ b/atspi-macros/src/lib.rs
@@ -32,7 +32,7 @@ pub fn try_signify(input: TokenStream) -> TokenStream {
                 let tname = std::any::type_name::<Self>().to_string();
                 let member = tname.strip_suffix("Event").unwrap();
                 let error = format!("specific type's member: {} != msg type member: {:?}", member, msg_member);
-                Err(crate::AtspiError::MemberMatchError(error))
+                Err(crate::AtspiError::MemberMatch(error))
             }
         }
 

--- a/atspi-macros/src/lib.rs
+++ b/atspi-macros/src/lib.rs
@@ -20,10 +20,10 @@ pub fn try_signify(input: TokenStream) -> TokenStream {
 
     // Generate the expanded code
     let expanded = quote! {
-        impl TryFrom<Event> for #name {
+        impl TryFrom<AtspiEvent> for #name {
             type Error = Box<dyn std::error::Error>;
 
-            fn try_from(value: Event) -> Result<Self, Self::Error> {
+            fn try_from(value: AtspiEvent) -> Result<Self, Self::Error> {
                 if value.member() == Some(MemberName::from_static_str(#member)?) {
                     Ok(Self(value))
                 } else {

--- a/src/accessible.rs
+++ b/src/accessible.rs
@@ -358,6 +358,15 @@ trait Accessible {
     fn parent(&self) -> zbus::Result<(String, zbus::zvariant::OwnedObjectPath)>;
 }
 
+/// Creates an `AccessibleProxy`;
+/// a handle to an Accessob;e pbkect wothin an application on the bus.
+///
+/// Sender: the emitter of a signal is also known as the sender.
+/// A path is a string that uniquely refers to an object in an application.
+///
+/// # Errors
+/// If `destination` on the `ProxyBuilder` fails to parse its argument, or
+/// if `path` on the `ProxyBuilder` fails to parse its argument.
 pub async fn new<'a>(
     conn: &Connection,
     sender: UniqueName<'_>,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -9,28 +9,29 @@ use serde::{Deserialize, Serialize};
 use zbus::dbus_proxy;
 use zbus::zvariant::{OwnedObjectPath, Type};
 
+/// The item type provided by `Cache:Add` signals
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Debug, Serialize, Deserialize, Type, PartialEq, Eq, Hash)]
 pub struct CacheItem {
-    // The accessible object (within the application)   (so)
+    /// The accessible object (within the application)   (so)
     pub object: (String, OwnedObjectPath),
-    // The application (root object(?)    (so)
+    /// The application (root object(?)    (so)
     pub app: (String, OwnedObjectPath),
-    // The parent object.  (so)
+    /// The parent object.  (so)
     pub parent: (String, OwnedObjectPath),
-    // The accessbile index in parent.  i
+    /// The accessbile index in parent.  i
     pub index: i32,
-    // Child count of the accessible  i
+    /// Child count of the accessible  i
     pub children: i32,
-    // The exposed interfece(s) set.  as
+    /// The exposed interfece(s) set.  as
     pub ifaces: InterfaceSet,
-    // The short localized name.  s
+    /// The short localized name.  s
     pub short_name: String,
-    // Accessible role. u
+    /// Accessible role. u
     pub role: Role,
-    // More detailed localized name.
+    /// More detailed localized name.
     pub name: String,
-    // The states applicable to the accessible.  au
+    /// The states applicable to the accessible.  au
     pub states: StateSet,
 }
 
@@ -51,7 +52,7 @@ fn zvariant_type_signature_of_cache_item() {
 // }
 //
 
-#[dbus_proxy(interface = "org.a11y.atspi.Cache", default_path="/org/a11y/atspi/cache")]
+#[dbus_proxy(interface = "org.a11y.atspi.Cache", default_path = "/org/a11y/atspi/cache")]
 trait Cache {
     /// GetItems method
     fn get_items(&self) -> zbus::Result<Vec<CacheItem>>;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -18,8 +18,8 @@ use zbus::{zvariant::Signature, Address, MessageStream, MessageType};
 //  DEVICE_EVENT marks a type for both registerering and deregistering device events (? citation needed)
 pub const ATSPI_EVENT: Signature<'_> = Signature::from_static_str_unchecked("siiva{sv}");
 pub const QSPI_EVENT: Signature<'_> = Signature::from_static_str_unchecked("siiv(so)");
-pub const AVAILABLE: Signature<'_> = Signature::from_static_str_unchecked("so");
-pub const EVENT_LISTENER: Signature<'_> = Signature::from_static_str_unchecked("ss");
+pub const AVAILABLE: Signature<'_> = Signature::from_static_str_unchecked("(so)");
+pub const EVENT_LISTENER: Signature<'_> = Signature::from_static_str_unchecked("(ss)");
 pub const CACHE_ADD: Signature<'_> =
     Signature::from_static_str_unchecked("((so)(so)(so)iiassusau)");
 pub const CACHE_REM: Signature<'_> = Signature::from_static_str_unchecked("(so)");

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -76,7 +76,7 @@ impl Connection {
         MessageStream::from(self.registry.connection()).filter_map(|res| async move {
             let msg = match res {
                 Ok(m) => m,
-                Err(e) => return Some(Box::new(Err(e))),
+                Err(e) => return Some(Err(e)),
             };
             match msg.message_type() {
                 // TOCO: Checkme: dot-ok is not-ok

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{error::Error, ops::Deref};
 
 use futures::stream::{Stream, StreamExt};
 use zbus::{
@@ -7,39 +7,31 @@ use zbus::{
 
 use crate::{bus::BusProxy, events::Event, registry::RegistryProxy};
 
-// Event body signatures: These outline the event specific deserialized event type.
-// Safety: These are evaluated at compile time, the downstream user will not unwrap at runtime.
+// Event body signatures: These outline the event specific deserialized event types.
+// Safety: These are evaluated at compile time.
 // ----
 // The signal signature "(so)" (an Accessible) is ambiguous, because it is used in:
 // -  Cache : RemoveAccessible
 // -  Socket: Available
-//  Both specify an `Accessible`, however their purpose is different.
 //
-// These two are separated streams, grouping these two semantically little sense.
-//
-// ATSPI- and QSPI both describe generic events. These can be converted into
-// specific signal typs with TryFrom implementations.
+// ATSPI- and QSPI both describe the generic events. These can be converted into
+// specific signal types with TryFrom implementations. See crate::[`identify`]
 //  AVAILABLE signals the availability of the `Registry` daeomon.
 //  EVENT_LISTENER is a type signature used to notify when events are registered or deregistered.
 //  CACHE_ADD and *_REMOVE have very different types
 //  DEVICE_EVENT marks a type for both registerering and deregistering device events (? citation needed)
-const ATSPI_EVENT: Signature = Signature::from_static_str_unchecked("siiva{sv}");
-const QSPI_EVENT: Signature = Signature::from_static_str_unchecked("siiv(so)");
-const AVAILABLE: Signature = Signature::from_static_str_unchecked("(so)");
-const EVENT_LISTENER: Signature = Signature::from_static_str_unchecked("(ss)");
-const CACHE_ADD: Signature = Signature::from_static_str_unchecked("((so)(so)(so)iiassusau)");
-const CACHE_REM: Signature = Signature::from_static_str_unchecked("(so)");
-const DEVICE_EVENT: Signature = Signature::from_static_str_unchecked("(souua(iisi)u(bbb))");
+pub const ATSPI_EVENT: Signature<'_> = Signature::from_static_str_unchecked("siiva{sv}");
+pub const QSPI_EVENT: Signature<'_> = Signature::from_static_str_unchecked("siiv(so)");
+pub const AVAILABLE: Signature<'_> = Signature::from_static_str_unchecked("(so)");
+pub const EVENT_LISTENER: Signature<'_> = Signature::from_static_str_unchecked("(ss)");
+pub const CACHE_ADD: Signature<'_> =
+    Signature::from_static_str_unchecked("((so)(so)(so)iiassusau)");
+pub const CACHE_REM: Signature<'_> = Signature::from_static_str_unchecked("(so)");
+pub const DEVICE_EVENT: Signature<'_> = Signature::from_static_str_unchecked("(souua(iisi)u(bbb))");
 
 /// A connection to the at-spi bus
-///
-/// A number of types identified on ther bus:
-///
 pub struct Connection {
     registry: RegistryProxy<'static>,
-}
-pub fn valid_msg(msg: Message, sig: Signature) -> bool {
-    msg.body_signature() == Ok(sig) && msg.primary_header().msg_type() == MessageType::Signal
 }
 
 impl Connection {
@@ -73,233 +65,26 @@ impl Connection {
         Ok(Self { registry })
     }
 
-    /// Stream yielding `AtspiEvent` types.
+    /// Stream yielding all `Event` types.
     ///
-    /// Monitor this stream to be notified and receive `QspiEvent` events.
-    ///
-    /// # Example
-    /// ```
-    /// todo!()
-    /// ```
-    pub fn atspi_events(&self) -> impl Stream<Item = zbus::Result<Event>> {
-        MessageStream::from(self.registry.connection()).filter_map(|res| async move {
-            let msg = match res {
-                Ok(m) => m,
-                Err(e) => return Some(Err(e)),
-            };
-            let valid = || {
-                (*msg).body_signature() == Ok(ATSPI_EVENT)
-                    && msg.primary_header().msg_type() == MessageType::Signal
-            };
-            if valid() {
-                Some(crate::events::Event::try_from(msg))
-            } else {
-                None
-            }
-        })
-    }
-
-    /// Stream yielding `QspiEvent` types.
-    ///
-    /// Monitor this stream to be notified and receive `QspiEvent` events.
+    /// Monitor this stream to be notified and receive events on the a11y bus.
     ///
     /// # Example
     /// ```
     /// todo!()
     /// ```
-    pub fn qtspi_events(&self) -> impl Stream<Item = zbus::Result<Event>> {
+    pub fn event_stream(&self) -> impl Stream<Item = Result<Event, Box<dyn Error>>> {
         MessageStream::from(self.registry.connection()).filter_map(|res| async move {
-            let msg = match res {
-                Ok(m) => m,
-                Err(e) => return Some(Err(e)),
-            };
-            let valid = || {
-                (*msg).body_signature() == Ok(QSPI_EVENT)
-                    && msg.primary_header().msg_type() == MessageType::Signal
-            };
-            if valid() {
-                Some(crate::events::Event::try_from(msg))
-            } else {
-                None
+            let msg = res
+                .map_err(|e| return Some(Box::new(Err::<std::sync::Arc<Message>, zbus::Error>(e))))
+                .ok()?;
+            match msg.message_type() {
+                // TOCO: Checkme: dot-ok is not-ok
+                MessageType::Signal => Some(Event::try_from(msg)),
+                _ => None,
             }
         })
     }
-
-    /// Stream yielding `CacheAdd` event types.
-    ///
-    /// Monitor this stream to be notified of `CacheAdd` events.
-    ///
-    /// # Example
-    /// ```
-    /// todo!()
-    /// ```
-    pub fn cache_added_events(&self) -> impl Stream<Item = zbus::Result<Event>> {
-        MessageStream::from(self.registry.connection()).filter_map(|res| async move {
-            let msg = match res {
-                Ok(m) => m,
-                Err(e) => return Some(Err(e)),
-            };
-            let valid = || {
-                (*msg).body_signature() == Ok(CACHE_ADD)
-                    && msg.primary_header().msg_type() == MessageType::Signal
-            };
-            if valid() {
-                Some(crate::events::Event::try_from(msg))
-            } else {
-                None
-            }
-        })
-    }
-
-    /// Stream yielding `CacheRemove` events.
-    ///
-    /// You want to monitor this stream if you want to be notified of `CacheRemove` events.
-    ///
-    /// # Example
-    /// ```
-    /// todo!()
-    /// ```
-    pub fn cache_removed_events(&self) -> impl Stream<Item = zbus::Result<Event>> {
-        MessageStream::from(self.registry.connection()).filter_map(|res| async move {
-            let msg = match res {
-                Ok(m) => m,
-                Err(e) => return Some(Err(e)),
-            };
-            let msg_header = match msg.header() {
-                Ok(hdr) => hdr,
-                Err(e) => return Some(Err(e)),
-            };
-            if msg_header.interface()
-                != Ok(Some(&InterfaceName::from_static_str("org.a11y.atspi.Socket").unwrap()))
-            {
-                return None;
-            }
-            let valid = || {
-                (*msg).body_signature() == Ok(CACHE_REM)
-                    && msg.primary_header().msg_type() == MessageType::Signal
-            };
-            if valid() {
-                Some(crate::events::Event::try_from(msg))
-            } else {
-                None
-            }
-        })
-    }
-
-    /// Stream yielding `DeviceEvent`s.
-    ///
-    /// This yields events of both `Register` and `Deregister` kinds.
-    /// You want to monitor this stream if you want to be notified of these events.
-    ///
-    /// # Example
-    /// ```
-    /// todo!()
-    /// ```
-    pub fn device_events(&self) -> impl Stream<Item = zbus::Result<Event>> {
-        MessageStream::from(self.registry.connection()).filter_map(|res| async move {
-            let msg = match res {
-                Ok(m) => m,
-                Err(e) => return Some(Err(e)),
-            };
-            let valid = || {
-                (*msg).body_signature() == Ok(DEVICE_EVENT)
-                    && msg.primary_header().msg_type() == MessageType::Signal
-            };
-            if valid() {
-                Some(crate::events::Event::try_from(msg))
-            } else {
-                None
-            }
-        })
-    }
-
-    /// Stream yielding the `Available` bus types.
-    ///
-    ///  The `Registry` interface,provided by the registry daemon,
-    /// becomes available on the a11y bus.
-    /// The registry daemon emits this signal upon startup.
-    ///
-    /// Monitor this stream to be notified of bus registry availability
-    /// and receive corresponding `Available` events.
-    ///
-    /// # Example
-    /// ```
-    /// todo!()
-    /// ```
-    pub fn registry_available(&self) -> impl Stream<Item = zbus::Result<Event>> {
-        MessageStream::from(self.registry.connection()).filter_map(|res| async move {
-            let msg = match res {
-                Ok(m) => m,
-                Err(e) => return Some(Err(e)),
-            };
-            let msg_header = match msg.header() {
-                Ok(hdr) => hdr,
-                Err(e) => return Some(Err(e)),
-            };
-            if msg_header.interface()
-                != Ok(Some(&InterfaceName::from_static_str("org.a11y.atspi.Socket").unwrap()))
-            // TODO: Static InterfaceName to avoid unwrap please
-            {
-                return None;
-            }
-            let valid = || {
-                (*msg).body_signature() == Ok(AVAILABLE)
-                    && msg.primary_header().msg_type() == MessageType::Signal
-            };
-            if valid() {
-                // TODO: Create Deserialized type that fits this stream (so)
-                Some(crate::events::Event::try_from(msg))
-            } else {
-                None
-            }
-        })
-    }
-
-    /// Stream yielding the `EventListenerRegister` and `EventListenerDeregister` bus types.
-    ///
-    /// Monitor this stream to be notified of bus `EventListenerRegister` and
-    /// `EventListenerDeregister` tyoes.
-    ///
-    /// # Example
-    /// ```
-    /// todo!()
-    /// ```
-    pub fn event_listener_events(&self) -> impl Stream<Item = zbus::Result<Event>> {
-        MessageStream::from(self.registry.connection()).filter_map(|res| async move {
-            let msg = match res {
-                Ok(m) => m,
-                Err(e) => return Some(Err(e)),
-            };
-            let __msg_header = match msg.header() {
-                Ok(hdr) => hdr,
-                Err(e) => return Some(Err(e)),
-            };
-            let valid = || {
-                (*msg).body_signature() == Ok(EVENT_LISTENER)
-                    && msg.primary_header().msg_type() == MessageType::Signal
-            };
-            if valid() {
-                // TODO: Create Deserialized type that fits this stream (ss)
-                Some(crate::events::Event::try_from(msg))
-            } else {
-                None
-            }
-        })
-    }
-
-    // pub fn compound_event_stream(&self) -> impl Stream<Item = zbus::Result<AtspiEvent>> {
-    //     MessageStream::from(self.registry.connection()).filter_map(|res| async move {
-    //         let msg = match res {
-    //             Ok(m) => m,
-    //             Err(e) => return Some(Err(e)),
-    //         };
-    //         if msg.header().ok()?.primary().msg_type() == MessageType::Signal {
-    //             Some(AtspiEvent::try_from(msg))
-    //         } else {
-    //             None
-    //         }
-    //     })
-    // }
 }
 
 impl Deref for Connection {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -20,9 +20,10 @@ pub const ATSPI_EVENT: Signature<'_> = Signature::from_static_str_unchecked("sii
 pub const QSPI_EVENT: Signature<'_> = Signature::from_static_str_unchecked("siiv(so)");
 pub const AVAILABLE: Signature<'_> = Signature::from_static_str_unchecked("so");
 pub const EVENT_LISTENER: Signature<'_> = Signature::from_static_str_unchecked("ss");
-pub const CACHE_ADD: Signature<'_> = Signature::from_static_str_unchecked("(so)(so)(so)iiassusau");
-pub const CACHE_REM: Signature<'_> = Signature::from_static_str_unchecked("so");
-pub const DEVICE_EVENT: Signature<'_> = Signature::from_static_str_unchecked("souua(iisi)u(bbb)");
+pub const CACHE_ADD: Signature<'_> =
+    Signature::from_static_str_unchecked("((so)(so)(so)iiassusau)");
+pub const CACHE_REM: Signature<'_> = Signature::from_static_str_unchecked("(so)");
+pub const DEVICE_EVENT: Signature<'_> = Signature::from_static_str_unchecked("(souua(iisi)u(bbb))");
 
 /// A connection to the at-spi bus
 pub struct Connection {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -14,14 +14,12 @@ use zbus::{zvariant::Signature, Address, MessageStream, MessageType};
 // specific signal types with TryFrom implementations. See crate::[`identify`]
 //  EVENT_LISTENER is a type signature used to notify when events are registered or deregistered.
 //  CACHE_ADD and *_REMOVE have very different types
-//  DEVICE_EVENT marks a type for both registerering and deregistering device events (? citation needed)
 pub const ATSPI_EVENT: Signature<'_> = Signature::from_static_str_unchecked("siiva{sv}");
 pub const QSPI_EVENT: Signature<'_> = Signature::from_static_str_unchecked("siiv(so)");
 pub const ACCESSIBLE: Signature<'_> = Signature::from_static_str_unchecked("(so)");
 pub const EVENT_LISTENER: Signature<'_> = Signature::from_static_str_unchecked("(ss)");
 pub const CACHE_ADD: Signature<'_> =
     Signature::from_static_str_unchecked("((so)(so)(so)iiassusau)");
-pub const DEVICE_EVENT: Signature<'_> = Signature::from_static_str_unchecked("(souua(iisi)u(bbb))");
 
 /// A connection to the at-spi bus
 pub struct Connection {
@@ -49,7 +47,7 @@ impl Connection {
         Self::connect(addr).await
     }
 
-    /// Errors
+    /// # Errors
     /// TODO
     pub async fn connect(bus_addr: Address) -> zbus::Result<Self> {
         tracing::debug!("Connecting to a11y bus");

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -8,21 +8,19 @@ use zbus::{zvariant::Signature, Address, MessageStream, MessageType};
 // ----
 // The signal signature "(so)" (an Accessible) is ambiguous, because it is used in:
 // -  Cache : RemoveAccessible
-// -  Socket: Available
+// -  Socket: Available  *( signals the availability of the `Registry` daeomon.)
 //
 // ATSPI- and QSPI both describe the generic events. These can be converted into
 // specific signal types with TryFrom implementations. See crate::[`identify`]
-//  AVAILABLE signals the availability of the `Registry` daeomon.
 //  EVENT_LISTENER is a type signature used to notify when events are registered or deregistered.
 //  CACHE_ADD and *_REMOVE have very different types
 //  DEVICE_EVENT marks a type for both registerering and deregistering device events (? citation needed)
 pub const ATSPI_EVENT: Signature<'_> = Signature::from_static_str_unchecked("siiva{sv}");
 pub const QSPI_EVENT: Signature<'_> = Signature::from_static_str_unchecked("siiv(so)");
-pub const AVAILABLE: Signature<'_> = Signature::from_static_str_unchecked("(so)");
+pub const ACCESSIBLE: Signature<'_> = Signature::from_static_str_unchecked("(so)");
 pub const EVENT_LISTENER: Signature<'_> = Signature::from_static_str_unchecked("(ss)");
 pub const CACHE_ADD: Signature<'_> =
     Signature::from_static_str_unchecked("((so)(so)(so)iiassusau)");
-pub const CACHE_REM: Signature<'_> = Signature::from_static_str_unchecked("(so)");
 pub const DEVICE_EVENT: Signature<'_> = Signature::from_static_str_unchecked("(souua(iisi)u(bbb))");
 
 /// A connection to the at-spi bus

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,75 @@
+#[allow(clippy::module_name_repetitions)]
+#[derive(Debug)]
+#[non_exhaustive]
+/// The aggregate error type for atspi and `std` and different `zbus` errors.
+pub enum AtspiError {
+    /// Converting one type into another failure
+    Conversion(&'static str),
+
+    /// Add Atspi Errors as we identify them, rather than (ab)using 'Other'.
+
+    /// Other errors.
+    Other(&'static str),
+
+    /// A `zbus` error. variant.
+    Zbus(zbus::Error),
+
+    /// A `zbus_names` error variant
+    ZBusNames(zbus::names::Error),
+
+    /// The `D-Bus` standard interfaces `zbus` error variant.
+    /// as defined in ` zbus::fdo`.
+    ZbusFdo(Box<dyn std::error::Error>),
+
+    /// Failed to parse a string into an enum variant
+    ParseError(&'static str),
+
+    /// Std i/o error variant.
+    IO(std::io::Error),
+}
+
+impl std::error::Error for AtspiError {}
+
+impl std::fmt::Display for AtspiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AtspiError::Conversion(e) => f.write_str(&format!("atspi: conversion failure: {e}")),
+            AtspiError::Other(e) => f.write_str(&format!("atspi: other error: {e}")),
+            AtspiError::Zbus(e) => f.write_str(&format!("ZBus Error: {e}")),
+            AtspiError::ZBusNames(e) => f.write_str(&format!("ZBus_names Error: {e}")),
+            AtspiError::ZbusFdo(e) => f.write_str(&format!("D-Bus standard interfaces Error: {e}")),
+            AtspiError::ParseError(e) => f.write_str(e),
+            AtspiError::IO(e) => f.write_str(&format!("std IO Error: {e}")),
+        }
+    }
+}
+
+impl From<zbus::fdo::Error> for AtspiError {
+    fn from(e: zbus::fdo::Error) -> Self {
+        Self::ZbusFdo(Box::new(e))
+    }
+}
+
+impl From<zbus::Error> for AtspiError {
+    fn from(e: zbus::Error) -> Self {
+        Self::Zbus(e)
+    }
+}
+
+impl From<zbus::names::Error> for AtspiError {
+    fn from(e: zbus::names::Error) -> Self {
+        Self::ZBusNames(e)
+    }
+}
+
+impl From<zbus::zvariant::Error> for AtspiError {
+    fn from(e: zbus::zvariant::Error) -> Self {
+        Self::Zbus(zbus::Error::Variant(e))
+    }
+}
+
+impl From<std::io::Error> for AtspiError {
+    fn from(e: std::io::Error) -> Self {
+        Self::IO(e)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,8 +6,17 @@ pub enum AtspiError {
     /// Converting one type into another failure
     Conversion(&'static str),
 
+    /// When testing on either variant, we might find the we are not interested in.
+    CacheVariantMismatch,
+
     /// On specific types, if the event / message member does not match the Event's name.
-    MemberMatchError(String), //TODO try specified lifetime parameter &'a str, with AtspiError<'a>
+    MemberMatch(String),
+
+    ///
+    UnknownBusSignature,
+
+    ///
+    UnknownSignal,
 
     /// Add Atspi Errors as we identify them, rather than (ab)using 'Other'.
 
@@ -37,9 +46,13 @@ impl std::fmt::Display for AtspiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             AtspiError::Conversion(e) => f.write_str(&format!("atspi: conversion failure: {e}")),
-            AtspiError::MemberMatchError(e) => {
+
+            Self::MemberMatch(e) => {
                 f.write_str(format!("atspi: member mismatch in conversion: {e}").as_str())
             }
+            UnknownBusSignature => f.write_str(&format!("atspi: Unknown bus body signature.")),
+            Self::UnknownSignal => f.write_str(&format!("atspi: Unknown signal")),
+            CacheVariantMismatch => f.write_str(&format!("atspi: Cache variant mismatch")),
             AtspiError::Owned(e) => f.write_str(&format!("atspi: other error: {e}")),
             AtspiError::Zbus(e) => f.write_str(&format!("ZBus Error: {e}")),
             AtspiError::ZBusNames(e) => f.write_str(&format!("ZBus_names Error: {e}")),

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,20 +45,19 @@ impl std::error::Error for AtspiError {}
 impl std::fmt::Display for AtspiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AtspiError::Conversion(e) => f.write_str(&format!("atspi: conversion failure: {e}")),
-
+            Self::Conversion(e) => f.write_str(&format!("atspi: conversion failure: {e}")),
             Self::MemberMatch(e) => {
                 f.write_str(format!("atspi: member mismatch in conversion: {e}").as_str())
             }
-            UnknownBusSignature => f.write_str(&format!("atspi: Unknown bus body signature.")),
-            Self::UnknownSignal => f.write_str(&format!("atspi: Unknown signal")),
-            CacheVariantMismatch => f.write_str(&format!("atspi: Cache variant mismatch")),
-            AtspiError::Owned(e) => f.write_str(&format!("atspi: other error: {e}")),
-            AtspiError::Zbus(e) => f.write_str(&format!("ZBus Error: {e}")),
-            AtspiError::ZBusNames(e) => f.write_str(&format!("ZBus_names Error: {e}")),
-            AtspiError::ZbusFdo(e) => f.write_str(&format!("D-Bus standard interfaces Error: {e}")),
-            AtspiError::ParseError(e) => f.write_str(e),
-            AtspiError::IO(e) => f.write_str(&format!("std IO Error: {e}")),
+            Self::UnknownBusSignature => f.write_str("atspi: Unknown bus body signature."),
+            Self::UnknownSignal => f.write_str("atspi: Unknown signal"),
+            Self::CacheVariantMismatch => f.write_str("atspi: Cache variant mismatch"),
+            Self::Owned(e) => f.write_str(&format!("atspi: other error: {e}")),
+            Self::Zbus(e) => f.write_str(&format!("ZBus Error: {e}")),
+            Self::ZBusNames(e) => f.write_str(&format!("ZBus_names Error: {e}")),
+            Self::ZbusFdo(e) => f.write_str(&format!("D-Bus standard interfaces Error: {e}")),
+            Self::ParseError(e) => f.write_str(e),
+            Self::IO(e) => f.write_str(&format!("std IO Error: {e}")),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,7 @@ pub enum AtspiError {
     /// Add Atspi Errors as we identify them, rather than (ab)using 'Other'.
 
     /// Other errors.
-    Other(&'static str),
+    Owned(String),
 
     /// A `zbus` error. variant.
     Zbus(zbus::Error),
@@ -34,7 +34,7 @@ impl std::fmt::Display for AtspiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             AtspiError::Conversion(e) => f.write_str(&format!("atspi: conversion failure: {e}")),
-            AtspiError::Other(e) => f.write_str(&format!("atspi: other error: {e}")),
+            AtspiError::Owned(e) => f.write_str(&format!("atspi: other error: {e}")),
             AtspiError::Zbus(e) => f.write_str(&format!("ZBus Error: {e}")),
             AtspiError::ZBusNames(e) => f.write_str(&format!("ZBus_names Error: {e}")),
             AtspiError::ZbusFdo(e) => f.write_str(&format!("D-Bus standard interfaces Error: {e}")),

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,9 @@ pub enum AtspiError {
     /// Converting one type into another failure
     Conversion(&'static str),
 
+    /// On specific types, if the event / message member does not match the Event's name.
+    MemberMatchError(String), //TODO try specified lifetime parameter &'a str, with AtspiError<'a>
+
     /// Add Atspi Errors as we identify them, rather than (ab)using 'Other'.
 
     /// Other errors.
@@ -34,6 +37,9 @@ impl std::fmt::Display for AtspiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             AtspiError::Conversion(e) => f.write_str(&format!("atspi: conversion failure: {e}")),
+            AtspiError::MemberMatchError(e) => {
+                f.write_str(format!("atspi: member mismatch in conversion: {e}").as_str())
+            }
             AtspiError::Owned(e) => f.write_str(&format!("atspi: other error: {e}")),
             AtspiError::Zbus(e) => f.write_str(&format!("ZBus Error: {e}")),
             AtspiError::ZBusNames(e) => f.write_str(&format!("ZBus_names Error: {e}")),

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -135,6 +135,11 @@ pub struct Accessible {
     path: OwnedObjectPath,
 }
 
+#[test]
+fn test_accessible_signature() {
+    assert_eq!(Accessible::signature(), "(so)");
+}
+
 impl TryFrom<Arc<Message>> for CacheRemoveEvent {
     type Error = AtspiError;
 
@@ -200,24 +205,36 @@ impl TryFrom<Arc<Message>> for Event {
     type Error = AtspiError;
 
     fn try_from(message: Arc<Message>) -> Result<Event, AtspiError> {
-        if message.body_signature() == Ok(connection::ATSPI_EVENT) {
+        let signature = message.body_signature()?;
+        if signature == connection::ATSPI_EVENT {
             let ev = AtspiEvent::try_from(message)?;
             return Ok(Event::Atspi(ev));
         }
-        if message.body_signature() == Ok(connection::QSPI_EVENT) {
+        if signature == connection::QSPI_EVENT {
             let ev = AtspiEvent::try_from(message)?;
             return Ok(Event::Atspi(ev));
         }
-        if message.body_signature() == Ok(connection::CACHE_ADD) {
+        if signature == connection::CACHE_ADD {
             let ev = CacheEvent::try_from(message)?;
             return Ok(Event::Cache(ev));
         }
-        if message.body_signature() == Ok(connection::CACHE_REM) {
+        if signature == connection::CACHE_REM {
             let ev = CacheEvent::try_from(message)?;
             return Ok(Event::Cache(ev));
+        }
+        if signature == connection::AVAILABLE {
+            todo!()
+        }
+        if signature == connection::DEVICE_EVENT {
+            todo!()
+        }
+        if signature == connection::EVENT_LISTENER {
+            todo!()
         }
 
-        Err(AtspiError::Conversion("invalid body signature in TryFrom<Arc<Message>> for Event"))
+        let signature = signature.to_string();
+        let s = format!("invalid body signature: {signature}");
+        Err(AtspiError::Owned(s))
     }
 }
 

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -312,7 +312,7 @@ impl TryFrom<Arc<Message>> for AtspiEvent {
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct EventListener {
     pub bus_name: OwnedUniqueName,
-    pub path: OwnedObjectPath,
+    pub path: String,
 }
 
 #[test]
@@ -330,7 +330,7 @@ pub enum EventListenerEvent {
 #[derive(Clone, Debug)]
 pub struct EventListenerDeregisteredEvent {
     pub(crate) message: Arc<Message>,
-    body: EventListener,
+    pub body: EventListener,
 }
 
 impl GenericEvent for EventListenerDeregisteredEvent {
@@ -382,7 +382,7 @@ impl TryFrom<Arc<Message>> for EventListenerDeregisteredEvent {
 #[derive(Clone, Debug)]
 pub struct EventListenerRegisteredEvent {
     pub(crate) message: Arc<Message>,
-    body: EventListener,
+    pub body: EventListener,
 }
 
 impl TryFrom<Arc<Message>> for EventListenerRegisteredEvent {
@@ -439,7 +439,7 @@ pub struct AvailableEvent {
 }
 
 impl AvailableEvent {
-    fn registry(&self) -> &Accessible {
+    pub fn registry(&self) -> &Accessible {
         &self.body
     }
 }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -106,6 +106,121 @@ impl TryFrom<Arc<Message>> for Event {
     }
 }
 
+// The signal signatures found on the a11y bus.
+const QT_EVENT: Signature<'static> = Signature::try_from("siiv(so)").unwrap();
+const EVENT_SIG: Signature<'static> = Signature::try_from("siiva{sv}").unwrap();
+const CACHE_ADD: Signature<'static> = Signature::try_from("(so)(so)(so)iiassusau").unwrap();
+const CACHE_REM: Signature<'static> = Signature::try_from("so").unwrap();
+ 
+
+impl TryFrom<Arc<Message>> for AtspiEvent {
+    type Error = zbus::Error;
+
+    fn try_from(message: Arc<Message>) -> zbus::Result<Self> {
+        let body: EventBodyOwned = match message.body_signature()? {
+            QT_EVENT => {
+                let body = EventBodyOwned::from(message.body::<EventBodyQT>()?);
+                let atspi_event: AtspiEvent = body.try_into()?;
+            }
+            EVENT_SIG => {
+                let body = message.body::<EventBodyOwned>()?;
+                let atspi_event: AtspiEvent = body.try_into()?;
+            }
+            CACHE_ADD => {todo!()},
+            CACHE_REM => {todo!()},
+
+        };
+        Ok(Self { message, body })
+    }
+}
+
+// we may want to have this live somewhere else
+/// Compound type that aggregates a11y bus events.
+#[derive(Clone, Debug, Eq)]
+pub enum AtspiEvent {
+    // Processed
+        AddAccessible(()),
+        RemoveAccessible(()),
+        EventListenerRegistered(()),
+        EventListenerDeregistered(()),
+    // Registry
+        EventListenerRegistered(()),
+        EventListenerDeregistered(()),
+    // DeviceEventListener
+        KeystrokeListenerRegistered(()),
+        KeystrokeListenerDeregistered(()),
+    // (Object).Event
+        PropertyChange(()),
+        BoundsChanged(()),
+        LinkSelected(()),
+        StateChanged(()),
+        ChildrenChanged(()),
+        VisibleDataChanged(()),
+        SelectionChanged(()),
+        ModelChanged(()),
+        ActiveDescendantChanged(()),
+        Announcement(()),
+        AttributesChanged(()),
+        RowInserted(()),
+        RowReordered(()),
+        RowDeleted(()),
+        ColumnInserted(()),
+        ColumnReordered(()),
+        ColumnDeleted(()),
+        TextBoundsChanged(()),
+        TextSelectionChanged(()),
+        TextChanged(()),
+        TextAttributesChanged(()),
+        TextCaretMoved(()),
+        PropertyChange(()),
+        Minimize(()),
+        Maximize(()),
+        Restore(()),
+        Close(()),
+        Create(()),
+        Reparent(()),
+        DesktopCreate(()),
+        DesktopDestroy(()),
+        Destroy(()),
+        Activate(()),
+        Deactivate(()),
+        Raise(()),
+        Lower(()),
+        Move(()),
+        Resize(()),
+        Shade(()),
+        uUshade(()),
+        Restyle(()),
+        Abs(()),
+        Rel(()),
+        Button(()),
+        Modifiers(()),
+        LineChanged(()),
+        ColumncountChanged(()),
+        LinecountChanged(()),
+        ApplicationChanged(()),
+        CharwidthChanged(()),
+        LoadComplete(()),
+        Reload(()),
+        LoadStopped(()),
+        ContentChanged(()),
+        AttributesChanged(()),
+        PageChanged(()),
+        Focus(()),
+    //  Cache.xml
+        AddAccessible(()),
+        RemoveAccessible(()),
+    // Socket    
+        Available(()),
+}
+
+// we get meny of these atspi leaf-types
+struct AtspiEventStruct;
+
+impl TryFrom<EventBodyOwned> for At
+
+
+
 impl Event {
     /// Identifies the `sender` of the `Event`.
     /// # Errors

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -107,10 +107,16 @@ impl TryFrom<Arc<Message>> for Event {
 }
 
 impl Event {
+    /// Identifies the `sender` of the `Event`.
+    /// # Errors
+    /// - when deserializeing the header failed, or
+    /// - When `zbus::get_field!` finds that 'sender' is an invalid field.
     pub fn sender(&self) -> zbus::Result<Option<UniqueName>> {
         Ok(self.message.header()?.sender()?.cloned())
     }
 
+    /// The object path to the object where the signal is emitted from.
+    #[must_use]
     pub fn path(&self) -> Option<zvariant::ObjectPath> {
         self.message.path()
     }
@@ -119,6 +125,7 @@ impl Event {
     ///
     /// This should not be used for matching on events as it needlessly allocates and copies the 3
     /// components of the event type. It is meant for logging, etc.
+    #[must_use]
     pub fn event_string(&self) -> String {
         let interface = self.interface().expect("Event should have an interface");
         let interface = interface.rsplit('.').next().expect("Interface should contain a '.'");
@@ -133,38 +140,48 @@ impl Event {
     /// name, not to the lifetime of the message as it should be. In future, this will return only
     /// the last component of the interface name (I.E. "Object" from
     /// "org.a11y.atspi.Event.Object").
+    #[must_use]
     pub fn interface(&self) -> Option<InterfaceName<'_>> {
         self.message.interface()
     }
 
+    // Identifies this `Event`'s member (signal-) name on the bus.
+    #[must_use]
     pub fn member(&self) -> Option<MemberName<'_>> {
         self.message.member()
     }
 
+    #[must_use]
     pub fn kind(&self) -> &str {
         &self.body.kind
     }
 
+    #[must_use]
     pub fn detail1(&self) -> i32 {
         self.body.detail1
     }
 
+    #[must_use]
     pub fn detail2(&self) -> i32 {
         self.body.detail2
     }
 
+    #[must_use]
     pub fn any_data(&self) -> &zvariant::OwnedValue {
         &self.body.any_data
     }
 
+    #[must_use]
     pub fn properties(&self) -> &HashMap<String, zvariant::OwnedValue> {
         &self.body.properties
     }
 
+    #[must_use]
     pub fn message(&self) -> &Arc<Message> {
         &self.message
     }
 
+    #[must_use]
     pub fn body(&self) -> &EventBodyOwned {
         &self.body
     }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -110,9 +110,10 @@ impl TryFrom<Arc<Message>> for CacheEvent {
         if let Ok(rem) = CacheRemoveEvent::try_from(message.clone()) {
             return Ok(CacheEvent::Remove(rem));
         }
-        if let Ok(add) = CacheAddEvent::try_from(message) {
+        if let Ok(add) = CacheAddEvent::try_from(message.clone()) {
             return Ok(CacheEvent::Add(add));
         }
+
         Err(AtspiError::Conversion("Conversion to cache variant failed"))
     }
 }
@@ -143,15 +144,15 @@ fn test_accessible_signature() {
 impl TryFrom<Arc<Message>> for CacheRemoveEvent {
     type Error = AtspiError;
 
-    fn try_from(value: Arc<Message>) -> Result<Self, Self::Error> {
+    fn try_from(message: Arc<Message>) -> Result<Self, Self::Error> {
         // TODO: iface static string should be from the enum elsewhere. (Or, perhapps const interface names..)
         let iface = InterfaceName::from_static_str("org.a11y.atspi.Cache")?;
-        if value.interface() != Some(iface) {
+        if message.interface() != Some(iface) {
             return Err(AtspiError::Conversion("incorrect interface, not Cache"));
         }
-        if value.member() == Some(MemberName::from_static_str("Remove").unwrap()) {
-            let body = value.body::<Accessible>()?;
-            Ok(Self { message: value, body })
+        if message.member() == Some(MemberName::from_static_str("RemoveAccessible").unwrap()) {
+            let body = message.body::<Accessible>()?;
+            Ok(Self { message, body })
         } else {
             Err(AtspiError::Conversion("convert to CacheRemoveEvent failed"))
         }
@@ -161,15 +162,15 @@ impl TryFrom<Arc<Message>> for CacheRemoveEvent {
 impl TryFrom<Arc<Message>> for CacheAddEvent {
     type Error = AtspiError;
 
-    fn try_from(value: Arc<Message>) -> Result<Self, Self::Error> {
+    fn try_from(message: Arc<Message>) -> Result<Self, Self::Error> {
         // TODO: iface static string should be from the enum elsewhere. (Or, perhapps const interface names..)
         let iface = InterfaceName::from_static_str("org.a11y.atspi.Cache")?;
-        if value.interface() != Some(iface) {
+        if message.interface() != Some(iface) {
             return Err(AtspiError::Conversion("incorrect interface, not Cache"));
         }
-        if value.member() == Some(MemberName::from_static_str("Add")?) {
-            let body = value.body::<CacheItem>()?;
-            Ok(Self { message: value, body })
+        if message.member() == Some(MemberName::from_static_str("AddAccessible")?) {
+            let body = message.body::<CacheItem>()?;
+            Ok(Self { message, body })
         } else {
             Err(AtspiError::Conversion("conversion to CacheAddEvent failed"))
         }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -106,13 +106,15 @@ impl TryFrom<Arc<Message>> for Event {
     }
 }
 
+// TODO Complete list
 // The signal signatures found on the a11y bus.
 const QT_EVENT: Signature<'static> = Signature::try_from("siiv(so)").unwrap();
 const EVENT_SIG: Signature<'static> = Signature::try_from("siiva{sv}").unwrap();
 const CACHE_ADD: Signature<'static> = Signature::try_from("(so)(so)(so)iiassusau").unwrap();
 const CACHE_REM: Signature<'static> = Signature::try_from("so").unwrap();
- 
 
+ 
+// TODO complete match
 impl TryFrom<Arc<Message>> for AtspiEvent {
     type Error = zbus::Error;
 
@@ -149,7 +151,7 @@ pub enum AtspiEvent {
     // DeviceEventListener
         KeystrokeListenerRegistered(()),
         KeystrokeListenerDeregistered(()),
-    // (Object).Event
+    // Event
         PropertyChange(()),
         BoundsChanged(()),
         LinkSelected(()),
@@ -214,8 +216,6 @@ pub enum AtspiEvent {
         Available(()),
 }
 
-// we get meny of these atspi leaf-types
-struct AtspiEventStruct;
 
 impl TryFrom<EventBodyOwned> for At
 

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -98,11 +98,6 @@ pub enum Event {
     Available(AvailableEvent),
     /// Both `CacheAdd` and `CacheRemove` signals
     Cache(CacheEvent),
-
-    /// Emitted on `KeystrokeListenerRegistered` and `KeystrokeListenerDeragistered
-    /// `(souua(iisi)u(bbb)
-    //  Device(DeviceEvent)
-
     /// Emitted on registry or deregristry of event listeners.,
     ///
     /// (eg. "Cache:AddAccessible:")
@@ -489,12 +484,6 @@ impl TryFrom<Arc<Message>> for AvailableEvent {
         Ok(Self { message, body })
     }
 }
-
-#[derive(Debug, Clone, Serialize, Deserialize, Type)]
-pub struct Key {}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Type)]
-pub struct KeyStrokeItem {}
 
 impl TryFrom<Arc<Message>> for Event {
     type Error = AtspiError;

--- a/src/identify.rs
+++ b/src/identify.rs
@@ -286,7 +286,7 @@ impl TryFrom<AtspiEvent> for ObjectAttributesChangedEvent {
 
         let error =
             format!("specific type's member: AttributesChanged != msg type member: {msg_member:?}");
-        Err(crate::AtspiError::MemberMatchError(error))
+        Err(crate::AtspiError::MemberMatch(error))
     }
 }
 
@@ -387,7 +387,7 @@ impl TryFrom<AtspiEvent> for WindowPropertyChangeEvent {
 
         let error =
             format!("specific type's member: PropertyChange != msg type member: {msg_member:?}");
-        Err(crate::AtspiError::MemberMatchError(error))
+        Err(crate::AtspiError::MemberMatch(error))
     }
 }
 

--- a/src/identify.rs
+++ b/src/identify.rs
@@ -1,0 +1,477 @@
+//! ## Signified signal types
+//!
+//! The generic `Event` has a specific meaning depending on its origin.
+//! This module offers the signified signal types and their conversions from a generic `Event`.
+//!
+//! The `TrySignify` macro implements a `TryFrom<Event>` on a per-name and member basis
+//!
+
+use crate::{events::Event, State};
+use atspi_macros::*;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::ops::Deref;
+use zbus::names::MemberName;
+use zbus::zvariant;
+use zvariant::OwnedValue;
+
+trait Signified {}
+
+/// Shared functionality
+trait GenericEvent {
+    fn properties(&self) -> &HashMap<String, OwnedValue>;
+}
+
+impl<T> GenericEvent for T
+where
+    T: Signified,
+{
+    fn properties(&self) -> &HashMap<String, OwnedValue> {
+        (*self).properties()
+    }
+}
+
+// All types T : AtspiEvent should deref to [`crate::Event`]
+//  This ensures all methods on Event are available for all.
+impl Deref for dyn GenericEvent {
+    type Target = crate::events::Event;
+
+    fn deref(&self) -> &Self::Target {
+        &*(self)
+    }
+}
+
+/// Trait to allow grouping of `Document` signals
+/// May contain any variant pertaining `Document` events.
+///
+/// If you are interested in `Event.Document` events, this enum
+/// may help you select for these:
+///
+/// # Example
+/// ```
+/// // Boilerplate omitted.
+/// use crate::identify::DocumentEvent;
+///
+/// while let Ok(Some(ev)) = event_stream.next().await? {
+///     let doc_ev: DocumentEvent = ev.try_into()?;
+/// }
+///  ```
+/// The event details encoded in the de-generalized types.
+///
+///
+/// TODO Catch signals and repair table below please!
+///
+/// | Interface  | Member  |  Kind  | Detail1   | Detail2  | Any_data |
+/// |:-:|---|---|---|---|---|
+/// | Document | LoadComplete  |   |   |   |
+/// | Document | Reload |   |   |   |
+/// | Document | LoadStopped |   |   |   |
+/// | Document | ContentChanged  |   |   |   |
+/// | Document | AttributesChanged  |   |   |   |
+/// | Document | PageChanged  |   |   |   |
+pub trait Doc {}
+
+/// Trait to allow grouping of `Object` signals
+pub trait Obj {}
+
+/// Trait to allow grouping of `Win` signals
+pub trait Win {}
+
+/// Trait to allow grouping of `Mse` signals
+/// Contains any variant pertaining `MouseEvent` events.
+///
+/// Those interested in `Event.Mouse` events, this enum
+/// may help select and specify for those on a stream:
+///
+/// # Example
+/// ```
+/// // Boilerplate omitted.
+/// use crate::identify::MouseEvent;
+///
+/// while let Ok(Some(ev)) = event_stream.next().await? {
+///   let mse_ev: MouseEvent = ev.try_into()?;
+/// }
+///  ```
+///
+/// | Interface  | Member  |  kind | Detail1   | Detail2  | Any_data |
+/// |:-:|---|---|---|---|---|
+/// | Mouse |Abs |   | x | y |   |
+/// | Mouse | Rel |   | delta_x  | delta_y   |   |
+/// | Mouse | Button | p\[1..=5\] | x  | y  |   |
+/// | Mouse | Button | r\[1..=5\] | x  | y  |   |
+pub trait Mse {}
+
+/// Trait to allow grouping of `Term` signals
+/// May contain any variant pertaining `Terminal` events.
+///
+/// If you are interested in `Event.Terminal` events, this enum
+/// may, for instance, help you select for those on a stream:
+///
+/// # Example
+/// ```
+/// // Boilerplate omitted.
+/// use crate::identify::TerminalEvent;
+///
+/// while let Ok(Some(ev)) = event_stream.next().await? {
+///   let term_ev: TerminalEvent = ev.try_into()?;
+/// }
+///  ```
+/// | Interface  | Member  |  Detail1   | Detail2  | Any_data |
+/// |:-:|---|---|---|---|
+/// | Terminal | LineChanged  |   |   |   |
+/// | Terminal | ColumncountChanged  |   |   |   |
+/// | Terminal |LinecountChanged|   |   |   |
+/// | Terminal | CharwidthChanged  |   |   |   |
+pub trait Term {}
+
+/// Trait to allow grouping of `Focus` signals
+/// ## Deprecation notice!!
+/// since: AT-SPI 2.9.4
+/// This signal is deprecated and may be removed in the near future.
+/// Monitor `StateChanged::Focused` signals instead.
+///
+/// TODO: Catch an event, check table below.
+///
+/// | Interface  | Member  |  Kind | Detail1   | Detail2  | Any_data |
+/// |:-:|---|---|---|---|---|
+/// | Focus  | Focus |   |   |   |    |
+pub trait Focus {}
+
+/// Trait to allow grouping of `Kbd` signals
+/// Contain any variant pertaining `Keyboard` events.
+///
+/// If you are interested in `Event.Keyboard` events, this enum
+/// may, for instance, help you select for those on a stream:
+///
+/// # Example
+/// ```
+/// // Boilerplate omitted.
+/// use crate::identify::KeyboardEvent;
+///
+/// while let Ok(Some(ev)) = event_stream.next().await? {
+///   let kb_ev: KeyboardEvent = ev.try_into()?;
+/// }
+///  ```
+/// | Interface  | Member  | Kind |  Detail1   | Detail2  | Any_data |
+/// |:-:|---|---|---|---|---|
+/// | Keyboard | Modifiers>  |   |  |   |   |
+pub trait Kbd {}
+
+#[derive(Debug, TrySignify, Obj)]
+pub struct PropertyChangeEvent(Event);
+
+impl PropertyChangeEvent {
+    fn property(&self) -> &str {
+        self.0.kind()
+    }
+    fn value(&self) -> &OwnedValue {
+        self.0.any_data()
+    }
+}
+
+#[derive(Debug, Clone, Obj)]
+pub struct BoundsChangedEvent(Event);
+impl TryFrom<Event> for BoundsChangedEvent {
+    type Error = Box<dyn std::error::Error>;
+
+    fn try_from(value: Event) -> Result<Self, Self::Error> {
+        if value.member() == Some(MemberName::from_static_str("BoundsChanged")?) {
+            Ok(Self(value))
+        } else {
+            Err("error signifying event signal type".into())
+        }
+    }
+}
+
+impl Signified for BoundsChangedEvent {}
+
+#[derive(Debug, Clone, Obj)]
+pub struct LinkSelectedEvent(Event);
+
+#[derive(Debug, Clone, Obj)]
+pub struct StateChangedEvent(Event);
+impl StateChangedEvent {
+    fn state(&self) -> &str {
+        self.0.kind()
+    }
+    //TODO checkme please!!
+    fn enabled(&self) -> bool {
+        self.0.detail1() == 0
+    }
+}
+
+#[derive(Debug, Clone, Obj)]
+pub struct ChildrenChangedEvent(Event);
+impl ChildrenChangedEvent {
+    fn operation(&self) -> &str {
+        self.0.kind()
+    }
+    fn index_in_parent(&self) -> i32 {
+        self.0.detail1()
+    } // usizes ?
+    fn child(&self) -> &OwnedValue {
+        self.0.any_data()
+    }
+}
+
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct VisibleDataChangedEvent(Event);
+
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct SelectionChangedEvent(Event);
+
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct ModelChangedEvent(Event);
+
+// TODO Check my impl please.
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct ActiveDescendantChangedEvent(Event);
+impl ActiveDescendantChangedEvent {
+    fn child(&self) -> &zvariant::OwnedValue {
+        self.0.any_data() // TODO Make me a beter returner!
+    }
+}
+
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct AnnouncementEvent(Event);
+impl AnnouncementEvent {
+    fn text(&self) -> &str {
+        self.0.kind()
+    }
+}
+
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct AttributesChangedEvent(Event);
+
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct RowInsertedEvent(Event);
+
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct RowReorderedEvent(Event);
+
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct RowDeletedEvent(Event);
+
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct ColumnInsertedEvent(Event);
+
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct ColumnReorderedEvent(Event);
+
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct ColumnDeletedEvent(Event);
+
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct TextBoundsChangedEvent(Event);
+
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct TextSelectionChangedEvent(Event);
+
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct TextChangedEvent(Event);
+impl TextChangedEvent {
+    fn detail(&self) -> &str {
+        self.0.kind()
+    }
+    fn start_pos(&self) -> i32 {
+        self.0.detail1()
+    }
+    fn end_pos(&self) -> i32 {
+        self.0.detail2()
+    }
+    // TODO zvariant::Value -> String me please
+    fn text(&self) -> &OwnedValue {
+        self.0.any_data()
+    }
+}
+
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct TextAttributesChangedEvent(Event);
+
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct TextCaretMovedEvent(Event);
+
+impl TextCaretMovedEvent {
+    fn position(&self) -> i32 {
+        self.0.detail1()
+    }
+}
+
+// ----------<- end of Obj signals
+// ----------> Start of Win
+
+mod win {
+    use super::Win;
+    use crate::events::Event;
+    use crate::identify::MemberName;
+    use crate::identify::Signified;
+    use atspi_macros::TrySignify;
+
+    //TODO Check my impl with bus signal
+    #[derive(Debug, TrySignify, Win)]
+    pub struct PropertyChangeEvent(Event);
+    impl PropertyChangeEvent {
+        fn property(&self) -> &str {
+            self.0.kind()
+        }
+    }
+
+    #[derive(Debug, TrySignify, Win)]
+    pub struct MinimizeEvent(Event);
+
+    #[derive(Debug, TrySignify, Win)]
+    pub struct MaximizeEvent(Event);
+
+    #[derive(Debug, TrySignify, Win)]
+    pub struct RestoreEvent(Event);
+
+    #[derive(Debug, TrySignify, Win)]
+    pub struct CloseEvent(Event);
+
+    #[derive(Debug, TrySignify, Win)]
+    pub struct CreateEvent(Event);
+
+    #[derive(Debug, TrySignify, Win)]
+    pub struct ReparentEvent(Event);
+
+    #[derive(Debug, TrySignify, Win)]
+    pub struct DesktopCreateEvent(Event);
+
+    #[derive(Debug, TrySignify, Win)]
+    pub struct DesktopDestroyEvent(Event);
+
+    #[derive(Debug, TrySignify, Win)]
+    pub struct DestroyEvent(Event);
+
+    #[derive(Debug, TrySignify, Win)]
+    pub struct ActivateEvent(Event);
+
+    #[derive(Debug, TrySignify, Win)]
+    pub struct DeactivateEvent(Event);
+
+    #[derive(Debug, TrySignify, Win)]
+    pub struct RaiseEvent(Event);
+
+    #[derive(Debug, TrySignify, Win)]
+    pub struct LowerEvent(Event);
+
+    #[derive(Debug, TrySignify, Win)]
+    pub struct MoveEvent(Event);
+
+    #[derive(Debug, TrySignify, Win)]
+    pub struct ResizeEvent(Event);
+
+    #[derive(Debug, TrySignify, Win)]
+    pub struct ShadeEvent(Event);
+
+    #[allow(non_camel_case_types)]
+    #[derive(Debug, TrySignify, Win)]
+    pub struct uUshadeEvent(Event);
+
+    #[derive(Debug, TrySignify, Win)]
+    pub struct RestyleEvent(Event);
+}
+
+// ----------<- end of Win signals
+// ----------> Start of Mse
+
+#[derive(Debug, Clone, TrySignify, Mse)]
+pub struct AbsEvent(Event);
+impl AbsEvent {
+    fn dx(&self) -> i32 {
+        self.0.body().detail1
+    }
+    fn dy(&self) -> i32 {
+        self.0.body().detail2
+    }
+}
+
+#[derive(Debug, Clone, TrySignify, Mse)]
+pub struct RelEvent(Event);
+impl RelEvent {
+    fn dx(&self) -> i32 {
+        self.0.body().detail1
+    }
+    fn dy(&self) -> i32 {
+        self.0.body().detail2
+    }
+}
+
+#[derive(Debug, Clone, TrySignify, Mse)]
+pub struct ButtonEvent(Event);
+impl ButtonEvent {
+    fn button(&self) -> &str {
+        self.0.kind()
+    }
+    fn x(&self) -> i32 {
+        self.0.body().detail1
+    }
+    fn y(&self) -> i32 {
+        self.0.body().detail2
+    }
+}
+
+// ----------<- end of Mse signals
+// ----------> Start of Kbd
+
+#[derive(Debug, Clone, TrySignify, Kbd)]
+pub struct ModifiersEvent(Event);
+impl ModifiersEvent {
+    fn previous_modifiers(&self) -> i32 {
+        self.0.body().detail1
+    }
+    fn current_modifiers(&self) -> i32 {
+        self.0.body().detail2
+    }
+}
+
+// ----------<- end of Kbd signals
+// ----------> Start of Term
+
+#[derive(Debug, Clone, TrySignify, Term)]
+pub struct LineChangedEvent(Event);
+
+#[derive(Debug, Clone, TrySignify, Term)]
+pub struct ColumncountChangedEvent(Event);
+
+#[derive(Debug, Clone, TrySignify, Term)]
+pub struct LinecountChangedEvent(Event);
+
+#[derive(Debug, Clone, TrySignify, Term)]
+pub struct ApplicationChangedEvent(Event);
+
+#[derive(Debug, Clone, TrySignify, Term)]
+pub struct CharwidthChangedEvent(Event);
+
+// ----------<- end of Term signals
+// ----------> Start of Doc
+
+mod doc {
+    use super::Doc;
+    use crate::identify::MemberName;
+    use crate::identify::Signified;
+    use atspi_macros::TrySignify;
+
+    use crate::identify::Event;
+
+    #[derive(Debug, Clone, TrySignify, Doc)]
+    pub struct LoadCompleteEvent(Event);
+
+    #[derive(Debug, Clone, TrySignify, Doc)]
+    pub struct ReloadEvent(Event);
+
+    #[derive(Debug, Clone, TrySignify, Doc)]
+    pub struct LoadStoppedEvent(Event);
+
+    #[derive(Debug, Clone, TrySignify, Doc)]
+    pub struct ContentChangedEvent(Event);
+
+    #[derive(Debug, Clone, TrySignify, Doc)]
+    pub struct AttributesChangedEvent(Event);
+
+    #[derive(Debug, Clone, TrySignify, Doc)]
+    pub struct PageChangedEvent(Event);
+}
+
+#[derive(Debug, Clone, TrySignify, Focus)]
+pub struct FocusEvent(Event);

--- a/src/identify.rs
+++ b/src/identify.rs
@@ -8,38 +8,28 @@
 
 use atspi_macros::{Doc, Focus, Kbd, Mse, Obj, Term, TrySignify, Win};
 use std::collections::HashMap;
-use std::ops::Deref;
 use zbus::names::MemberName;
 use zbus::zvariant;
 use zvariant::OwnedValue;
 
 use crate::events::AtspiEvent;
 
-pub trait Signified {}
-
-/// Shared functionality
-pub trait GenericEvent {
+/// Exposes shared functionality over all Atspi / Qspi Signal events
+/// on the non-generic / signified types.
+pub trait Signified {
     fn properties(&self) -> &HashMap<String, OwnedValue>;
+}
+
+/// Shared functionality of Events, through its `Message` header
+pub trait GenericEvent {
+    //   fn properties(&self) -> &HashMap<String, OwnedValue>;
 }
 
 impl<T> GenericEvent for T
 where
     T: Signified,
 {
-    fn properties(&self) -> &HashMap<String, OwnedValue> {
-        (*self).properties()
-    }
-}
-
-// CONSIDERED BAD PRACTICE!
-// All types T : AtspiEvent should deref to [`crate::Event`]
-//  This ensures all methods on Event are available for all.
-impl Deref for dyn GenericEvent {
-    type Target = crate::events::AtspiEvent;
-
-    fn deref(&self) -> &Self::Target {
-        &**self
-    }
+    // TODO: The Event impl from mod goes partly here
 }
 
 /// Trait to allow grouping of `Document` signals
@@ -262,7 +252,11 @@ impl<'a> ObjectAttributesChangedEvent {
     }
 }
 
-impl Signified for ObjectAttributesChangedEvent {}
+impl Signified for ObjectAttributesChangedEvent {
+    fn properties(&self) -> &HashMap<String, OwnedValue> {
+        self.inner().properties()
+    }
+}
 
 #[derive(Debug, Clone, TrySignify, Obj)]
 pub struct RowInsertedEvent(AtspiEvent);
@@ -354,7 +348,11 @@ impl<'a> WindowPropertyChangeEvent {
     }
 }
 
-impl Signified for WindowPropertyChangeEvent {}
+impl Signified for WindowPropertyChangeEvent {
+    fn properties(&self) -> &HashMap<String, OwnedValue> {
+        self.inner().properties()
+    }
+}
 
 #[derive(Debug, TrySignify, Win)]
 pub struct MinimizeEvent(AtspiEvent);

--- a/src/identify.rs
+++ b/src/identify.rs
@@ -6,19 +6,17 @@
 //! The `TrySignify` macro implements a `TryFrom<Event>` on a per-name and member basis
 //!
 
-use crate::{events::Event, State};
-use atspi_macros::*;
-use serde::{Deserialize, Serialize};
+use atspi_macros::{Doc, Focus, Kbd, Mse, Obj, Term, TrySignify, Win};
 use std::collections::HashMap;
 use std::ops::Deref;
 use zbus::names::MemberName;
 use zbus::zvariant;
 use zvariant::OwnedValue;
 
-trait Signified {}
+pub trait Signified {}
 
 /// Shared functionality
-trait GenericEvent {
+pub trait GenericEvent {
     fn properties(&self) -> &HashMap<String, OwnedValue>;
 }
 
@@ -31,13 +29,14 @@ where
     }
 }
 
+// CONSIDERED BAD PRACTICE!
 // All types T : AtspiEvent should deref to [`crate::Event`]
 //  This ensures all methods on Event are available for all.
 impl Deref for dyn GenericEvent {
-    type Target = crate::events::Event;
+    type Target = crate::events::AtspiEvent;
 
     fn deref(&self) -> &Self::Target {
-        &*(self)
+        &**self
     }
 }
 
@@ -158,128 +157,128 @@ pub trait Focus {}
 pub trait Kbd {}
 
 #[derive(Debug, TrySignify, Obj)]
-pub struct PropertyChangeEvent(AtspiEvent);
+pub struct PropertyChangeEvent(pub(crate) AtspiEvent);
 
 impl PropertyChangeEvent {
-    fn property(&self) -> &str {
+    pub fn property(&self) -> &str {
         self.0.kind()
     }
-    fn value(&self) -> &OwnedValue {
+    pub fn value(&self) -> &OwnedValue {
         self.0.any_data()
     }
 }
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct BoundsChangedEvent(AtspiEvent);
+pub struct BoundsChangedEvent(pub(crate) AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct LinkSelectedEvent(AtspiEvent);
+pub struct LinkSelectedEvent(pub(crate) AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct StateChangedEvent(AtspiEvent);
+pub struct StateChangedEvent(pub(crate) AtspiEvent);
 impl StateChangedEvent {
-    fn state(&self) -> &str {
+    pub fn state(&self) -> &str {
         self.0.kind()
     }
     //TODO checkme please!!
-    fn enabled(&self) -> bool {
+    pub fn enabled(&self) -> bool {
         self.0.detail1() == 0
     }
 }
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct ChildrenChangedEvent(AtspiEvent);
+pub struct ChildrenChangedEvent(pub(crate) AtspiEvent);
 impl ChildrenChangedEvent {
-    fn operation(&self) -> &str {
+    pub fn operation(&self) -> &str {
         self.0.kind()
     }
-    fn index_in_parent(&self) -> i32 {
+    pub fn index_in_parent(&self) -> i32 {
         self.0.detail1()
     } // usizes ?
-    fn child(&self) -> &OwnedValue {
+    pub fn child(&self) -> &OwnedValue {
         self.0.any_data()
     }
 }
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct VisibleDataChangedEvent(AtspiEvent);
+pub struct VisibleDataChangedEvent(pub(crate) AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct SelectionChangedEvent(AtspiEvent);
+pub struct SelectionChangedEvent(pub(crate) AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct ModelChangedEvent(AtspiEvent);
+pub struct ModelChangedEvent(pub(crate) AtspiEvent);
 
 // TODO Check my impl please.
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct ActiveDescendantChangedEvent(AtspiEvent);
+pub struct ActiveDescendantChangedEvent(pub(crate) AtspiEvent);
 impl ActiveDescendantChangedEvent {
-    fn child(&self) -> &zvariant::OwnedValue {
+    pub fn child(&self) -> &zvariant::OwnedValue {
         self.0.any_data() // TODO Make me a beter returner!
     }
 }
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct AnnouncementEvent(AtspiEvent);
+pub struct AnnouncementEvent(pub(crate) AtspiEvent);
 impl AnnouncementEvent {
-    fn text(&self) -> &str {
+    pub fn text(&self) -> &str {
         self.0.kind()
     }
 }
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct AttributesChangedEvent(AtspiEvent);
+pub struct AttributesChangedEvent(pub(crate) AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct RowInsertedEvent(AtspiEvent);
+pub struct RowInsertedEvent(pub(crate) AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct RowReorderedEvent(AtspiEvent);
+pub struct RowReorderedEvent(pub(crate) AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct RowDeletedEvent(AtspiEvent);
+pub struct RowDeletedEvent(pub(crate) AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct ColumnInsertedEvent(AtspiEvent);
+pub struct ColumnInsertedEvent(pub(crate) AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct ColumnReorderedEvent(AtspiEvent);
+pub struct ColumnReorderedEvent(pub(crate) AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct ColumnDeletedEvent(AtspiEvent);
+pub struct ColumnDeletedEvent(pub(crate) AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct TextBoundsChangedEvent(AtspiEvent);
+pub struct TextBoundsChangedEvent(pub(crate) AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct TextSelectionChangedEvent(AtspiEvent);
+pub struct TextSelectionChangedEvent(pub(crate) AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct TextChangedEvent(AtspiEvent);
+pub struct TextChangedEvent(pub(crate) AtspiEvent);
 impl TextChangedEvent {
-    fn detail(&self) -> &str {
+    pub fn detail(&self) -> &str {
         self.0.kind()
     }
-    fn start_pos(&self) -> i32 {
+    pub fn start_pos(&self) -> i32 {
         self.0.detail1()
     }
-    fn end_pos(&self) -> i32 {
+    pub fn end_pos(&self) -> i32 {
         self.0.detail2()
     }
     // TODO zvariant::Value -> String me please
-    fn text(&self) -> &OwnedValue {
+    pub fn text(&self) -> &OwnedValue {
         self.0.any_data()
     }
 }
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct TextAttributesChangedEvent(AtspiEvent);
+pub struct TextAttributesChangedEvent(pub(crate) AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct TextCaretMovedEvent(AtspiEvent);
+pub struct TextCaretMovedEvent(pub(crate) AtspiEvent);
 
 impl TextCaretMovedEvent {
-    fn position(&self) -> i32 {
+    pub fn position(&self) -> i32 {
         self.0.detail1()
     }
 }
@@ -296,104 +295,104 @@ mod win {
 
     //TODO Check my impl with bus signal
     #[derive(Debug, TrySignify, Win)]
-    pub struct PropertyChangeEvent(AtspiEvent);
+    pub struct PropertyChangeEvent(pub(crate) AtspiEvent);
     impl PropertyChangeEvent {
-        fn property(&self) -> &str {
+        pub fn property(&self) -> &str {
             self.0.kind()
         }
     }
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct MinimizeEvent(AtspiEvent);
+    pub struct MinimizeEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct MaximizeEvent(AtspiEvent);
+    pub struct MaximizeEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct RestoreEvent(AtspiEvent);
+    pub struct RestoreEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct CloseEvent(AtspiEvent);
+    pub struct CloseEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct CreateEvent(AtspiEvent);
+    pub struct CreateEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct ReparentEvent(AtspiEvent);
+    pub struct ReparentEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct DesktopCreateEvent(AtspiEvent);
+    pub struct DesktopCreateEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct DesktopDestroyEvent(AtspiEvent);
+    pub struct DesktopDestroyEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct DestroyEvent(AtspiEvent);
+    pub struct DestroyEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct ActivateEvent(AtspiEvent);
+    pub struct ActivateEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct DeactivateEvent(AtspiEvent);
+    pub struct DeactivateEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct RaiseEvent(AtspiEvent);
+    pub struct RaiseEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct LowerEvent(AtspiEvent);
+    pub struct LowerEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct MoveEvent(AtspiEvent);
+    pub struct MoveEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct ResizeEvent(AtspiEvent);
+    pub struct ResizeEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct ShadeEvent(AtspiEvent);
+    pub struct ShadeEvent(pub(crate) AtspiEvent);
 
     #[allow(non_camel_case_types)]
     #[derive(Debug, TrySignify, Win)]
-    pub struct uUshadeEvent(AtspiEvent);
+    pub struct uUshadeEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct RestyleEvent(AtspiEvent);
+    pub struct RestyleEvent(pub(crate) AtspiEvent);
 }
 
 // ----------<- end of Win signals
 // ----------> Start of Mse
 
 #[derive(Debug, Clone, TrySignify, Mse)]
-pub struct AbsEvent(AtspiEvent);
+pub struct AbsEvent(pub(crate) AtspiEvent);
 impl AbsEvent {
-    fn dx(&self) -> i32 {
+    pub fn x(&self) -> i32 {
         self.0.body().detail1
     }
-    fn dy(&self) -> i32 {
+    pub fn y(&self) -> i32 {
         self.0.body().detail2
     }
 }
 
 #[derive(Debug, Clone, TrySignify, Mse)]
-pub struct RelEvent(AtspiEvent);
+pub struct RelEvent(pub(crate) AtspiEvent);
 impl RelEvent {
-    fn dx(&self) -> i32 {
+    pub fn dx(&self) -> i32 {
         self.0.body().detail1
     }
-    fn dy(&self) -> i32 {
+    pub fn dy(&self) -> i32 {
         self.0.body().detail2
     }
 }
 
 #[derive(Debug, Clone, TrySignify, Mse)]
-pub struct ButtonEvent(AtspiEvent);
+pub struct ButtonEvent(pub(crate) AtspiEvent);
 impl ButtonEvent {
-    fn button(&self) -> &str {
+    pub fn button(&self) -> &str {
         self.0.kind()
     }
-    fn x(&self) -> i32 {
+    pub fn x(&self) -> i32 {
         self.0.body().detail1
     }
-    fn y(&self) -> i32 {
+    pub fn y(&self) -> i32 {
         self.0.body().detail2
     }
 }
@@ -402,12 +401,12 @@ impl ButtonEvent {
 // ----------> Start of Kbd
 
 #[derive(Debug, Clone, TrySignify, Kbd)]
-pub struct ModifiersEvent(AtspiEvent);
+pub struct ModifiersEvent(pub(crate) AtspiEvent);
 impl ModifiersEvent {
-    fn previous_modifiers(&self) -> i32 {
+    pub fn previous_modifiers(&self) -> i32 {
         self.0.body().detail1
     }
-    fn current_modifiers(&self) -> i32 {
+    pub fn current_modifiers(&self) -> i32 {
         self.0.body().detail2
     }
 }
@@ -416,19 +415,19 @@ impl ModifiersEvent {
 // ----------> Start of Term
 
 #[derive(Debug, Clone, TrySignify, Term)]
-pub struct LineChangedEvent(AtspiEvent);
+pub struct LineChangedEvent(pub(crate) AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Term)]
-pub struct ColumncountChangedEvent(AtspiEvent);
+pub struct ColumncountChangedEvent(pub(crate) AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Term)]
-pub struct LinecountChangedEvent(AtspiEvent);
+pub struct LinecountChangedEvent(pub(crate) AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Term)]
-pub struct ApplicationChangedEvent(AtspiEvent);
+pub struct ApplicationChangedEvent(pub(crate) AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Term)]
-pub struct CharwidthChangedEvent(AtspiEvent);
+pub struct CharwidthChangedEvent(pub(crate) AtspiEvent);
 
 // ----------<- end of Term signals
 // ----------> Start of Doc
@@ -440,28 +439,26 @@ mod doc {
     use crate::identify::Signified;
     use atspi_macros::TrySignify;
 
-    use crate::identify::Event;
+    #[derive(Debug, Clone, TrySignify, Doc)]
+    pub struct LoadCompleteEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, Clone, TrySignify, Doc)]
-    pub struct LoadCompleteEvent(AtspiEvent);
+    pub struct ReloadEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, Clone, TrySignify, Doc)]
-    pub struct ReloadEvent(AtspiEvent);
+    pub struct LoadStoppedEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, Clone, TrySignify, Doc)]
-    pub struct LoadStoppedEvent(AtspiEvent);
+    pub struct ContentChangedEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, Clone, TrySignify, Doc)]
-    pub struct ContentChangedEvent(AtspiEvent);
+    pub struct AttributesChangedEvent(pub(crate) AtspiEvent);
 
     #[derive(Debug, Clone, TrySignify, Doc)]
-    pub struct AttributesChangedEvent(AtspiEvent);
-
-    #[derive(Debug, Clone, TrySignify, Doc)]
-    pub struct PageChangedEvent(AtspiEvent);
+    pub struct PageChangedEvent(pub(crate) AtspiEvent);
 }
 
 use crate::events::AtspiEvent;
 
 #[derive(Debug, Clone, TrySignify, Focus)]
-pub struct FocusEvent(AtspiEvent);
+pub struct FocusEvent(pub(crate) AtspiEvent);

--- a/src/identify.rs
+++ b/src/identify.rs
@@ -1,7 +1,7 @@
 //! ## Signified signal types
 //!
-//! The generic `Event` has a specific meaning depending on its origin.
-//! This module offers the signified signal types and their conversions from a generic `Event`.
+//! The generic `AtspiEvent` has a specific meaning depending on its origin.
+//! This module offers the signified types and their conversions from a generic `AtpiEvent`.
 //!
 //! The `TrySignify` macro implements a `TryFrom<Event>` on a per-name and member basis
 //!
@@ -158,7 +158,7 @@ pub trait Focus {}
 pub trait Kbd {}
 
 #[derive(Debug, TrySignify, Obj)]
-pub struct PropertyChangeEvent(Event);
+pub struct PropertyChangeEvent(AtspiEvent);
 
 impl PropertyChangeEvent {
     fn property(&self) -> &str {
@@ -169,27 +169,14 @@ impl PropertyChangeEvent {
     }
 }
 
-#[derive(Debug, Clone, Obj)]
-pub struct BoundsChangedEvent(Event);
-impl TryFrom<Event> for BoundsChangedEvent {
-    type Error = Box<dyn std::error::Error>;
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct BoundsChangedEvent(AtspiEvent);
 
-    fn try_from(value: Event) -> Result<Self, Self::Error> {
-        if value.member() == Some(MemberName::from_static_str("BoundsChanged")?) {
-            Ok(Self(value))
-        } else {
-            Err("error signifying event signal type".into())
-        }
-    }
-}
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct LinkSelectedEvent(AtspiEvent);
 
-impl Signified for BoundsChangedEvent {}
-
-#[derive(Debug, Clone, Obj)]
-pub struct LinkSelectedEvent(Event);
-
-#[derive(Debug, Clone, Obj)]
-pub struct StateChangedEvent(Event);
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct StateChangedEvent(AtspiEvent);
 impl StateChangedEvent {
     fn state(&self) -> &str {
         self.0.kind()
@@ -200,8 +187,8 @@ impl StateChangedEvent {
     }
 }
 
-#[derive(Debug, Clone, Obj)]
-pub struct ChildrenChangedEvent(Event);
+#[derive(Debug, Clone, TrySignify, Obj)]
+pub struct ChildrenChangedEvent(AtspiEvent);
 impl ChildrenChangedEvent {
     fn operation(&self) -> &str {
         self.0.kind()
@@ -215,17 +202,17 @@ impl ChildrenChangedEvent {
 }
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct VisibleDataChangedEvent(Event);
+pub struct VisibleDataChangedEvent(AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct SelectionChangedEvent(Event);
+pub struct SelectionChangedEvent(AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct ModelChangedEvent(Event);
+pub struct ModelChangedEvent(AtspiEvent);
 
 // TODO Check my impl please.
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct ActiveDescendantChangedEvent(Event);
+pub struct ActiveDescendantChangedEvent(AtspiEvent);
 impl ActiveDescendantChangedEvent {
     fn child(&self) -> &zvariant::OwnedValue {
         self.0.any_data() // TODO Make me a beter returner!
@@ -233,7 +220,7 @@ impl ActiveDescendantChangedEvent {
 }
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct AnnouncementEvent(Event);
+pub struct AnnouncementEvent(AtspiEvent);
 impl AnnouncementEvent {
     fn text(&self) -> &str {
         self.0.kind()
@@ -241,34 +228,34 @@ impl AnnouncementEvent {
 }
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct AttributesChangedEvent(Event);
+pub struct AttributesChangedEvent(AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct RowInsertedEvent(Event);
+pub struct RowInsertedEvent(AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct RowReorderedEvent(Event);
+pub struct RowReorderedEvent(AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct RowDeletedEvent(Event);
+pub struct RowDeletedEvent(AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct ColumnInsertedEvent(Event);
+pub struct ColumnInsertedEvent(AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct ColumnReorderedEvent(Event);
+pub struct ColumnReorderedEvent(AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct ColumnDeletedEvent(Event);
+pub struct ColumnDeletedEvent(AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct TextBoundsChangedEvent(Event);
+pub struct TextBoundsChangedEvent(AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct TextSelectionChangedEvent(Event);
+pub struct TextSelectionChangedEvent(AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct TextChangedEvent(Event);
+pub struct TextChangedEvent(AtspiEvent);
 impl TextChangedEvent {
     fn detail(&self) -> &str {
         self.0.kind()
@@ -286,10 +273,10 @@ impl TextChangedEvent {
 }
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct TextAttributesChangedEvent(Event);
+pub struct TextAttributesChangedEvent(AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Obj)]
-pub struct TextCaretMovedEvent(Event);
+pub struct TextCaretMovedEvent(AtspiEvent);
 
 impl TextCaretMovedEvent {
     fn position(&self) -> i32 {
@@ -302,14 +289,14 @@ impl TextCaretMovedEvent {
 
 mod win {
     use super::Win;
-    use crate::events::Event;
+    use crate::events::AtspiEvent;
     use crate::identify::MemberName;
     use crate::identify::Signified;
     use atspi_macros::TrySignify;
 
     //TODO Check my impl with bus signal
     #[derive(Debug, TrySignify, Win)]
-    pub struct PropertyChangeEvent(Event);
+    pub struct PropertyChangeEvent(AtspiEvent);
     impl PropertyChangeEvent {
         fn property(&self) -> &str {
             self.0.kind()
@@ -317,66 +304,66 @@ mod win {
     }
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct MinimizeEvent(Event);
+    pub struct MinimizeEvent(AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct MaximizeEvent(Event);
+    pub struct MaximizeEvent(AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct RestoreEvent(Event);
+    pub struct RestoreEvent(AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct CloseEvent(Event);
+    pub struct CloseEvent(AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct CreateEvent(Event);
+    pub struct CreateEvent(AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct ReparentEvent(Event);
+    pub struct ReparentEvent(AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct DesktopCreateEvent(Event);
+    pub struct DesktopCreateEvent(AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct DesktopDestroyEvent(Event);
+    pub struct DesktopDestroyEvent(AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct DestroyEvent(Event);
+    pub struct DestroyEvent(AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct ActivateEvent(Event);
+    pub struct ActivateEvent(AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct DeactivateEvent(Event);
+    pub struct DeactivateEvent(AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct RaiseEvent(Event);
+    pub struct RaiseEvent(AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct LowerEvent(Event);
+    pub struct LowerEvent(AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct MoveEvent(Event);
+    pub struct MoveEvent(AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct ResizeEvent(Event);
+    pub struct ResizeEvent(AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct ShadeEvent(Event);
+    pub struct ShadeEvent(AtspiEvent);
 
     #[allow(non_camel_case_types)]
     #[derive(Debug, TrySignify, Win)]
-    pub struct uUshadeEvent(Event);
+    pub struct uUshadeEvent(AtspiEvent);
 
     #[derive(Debug, TrySignify, Win)]
-    pub struct RestyleEvent(Event);
+    pub struct RestyleEvent(AtspiEvent);
 }
 
 // ----------<- end of Win signals
 // ----------> Start of Mse
 
 #[derive(Debug, Clone, TrySignify, Mse)]
-pub struct AbsEvent(Event);
+pub struct AbsEvent(AtspiEvent);
 impl AbsEvent {
     fn dx(&self) -> i32 {
         self.0.body().detail1
@@ -387,7 +374,7 @@ impl AbsEvent {
 }
 
 #[derive(Debug, Clone, TrySignify, Mse)]
-pub struct RelEvent(Event);
+pub struct RelEvent(AtspiEvent);
 impl RelEvent {
     fn dx(&self) -> i32 {
         self.0.body().detail1
@@ -398,7 +385,7 @@ impl RelEvent {
 }
 
 #[derive(Debug, Clone, TrySignify, Mse)]
-pub struct ButtonEvent(Event);
+pub struct ButtonEvent(AtspiEvent);
 impl ButtonEvent {
     fn button(&self) -> &str {
         self.0.kind()
@@ -415,7 +402,7 @@ impl ButtonEvent {
 // ----------> Start of Kbd
 
 #[derive(Debug, Clone, TrySignify, Kbd)]
-pub struct ModifiersEvent(Event);
+pub struct ModifiersEvent(AtspiEvent);
 impl ModifiersEvent {
     fn previous_modifiers(&self) -> i32 {
         self.0.body().detail1
@@ -429,25 +416,26 @@ impl ModifiersEvent {
 // ----------> Start of Term
 
 #[derive(Debug, Clone, TrySignify, Term)]
-pub struct LineChangedEvent(Event);
+pub struct LineChangedEvent(AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Term)]
-pub struct ColumncountChangedEvent(Event);
+pub struct ColumncountChangedEvent(AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Term)]
-pub struct LinecountChangedEvent(Event);
+pub struct LinecountChangedEvent(AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Term)]
-pub struct ApplicationChangedEvent(Event);
+pub struct ApplicationChangedEvent(AtspiEvent);
 
 #[derive(Debug, Clone, TrySignify, Term)]
-pub struct CharwidthChangedEvent(Event);
+pub struct CharwidthChangedEvent(AtspiEvent);
 
 // ----------<- end of Term signals
 // ----------> Start of Doc
 
 mod doc {
     use super::Doc;
+    use crate::events::AtspiEvent;
     use crate::identify::MemberName;
     use crate::identify::Signified;
     use atspi_macros::TrySignify;
@@ -455,23 +443,25 @@ mod doc {
     use crate::identify::Event;
 
     #[derive(Debug, Clone, TrySignify, Doc)]
-    pub struct LoadCompleteEvent(Event);
+    pub struct LoadCompleteEvent(AtspiEvent);
 
     #[derive(Debug, Clone, TrySignify, Doc)]
-    pub struct ReloadEvent(Event);
+    pub struct ReloadEvent(AtspiEvent);
 
     #[derive(Debug, Clone, TrySignify, Doc)]
-    pub struct LoadStoppedEvent(Event);
+    pub struct LoadStoppedEvent(AtspiEvent);
 
     #[derive(Debug, Clone, TrySignify, Doc)]
-    pub struct ContentChangedEvent(Event);
+    pub struct ContentChangedEvent(AtspiEvent);
 
     #[derive(Debug, Clone, TrySignify, Doc)]
-    pub struct AttributesChangedEvent(Event);
+    pub struct AttributesChangedEvent(AtspiEvent);
 
     #[derive(Debug, Clone, TrySignify, Doc)]
-    pub struct PageChangedEvent(Event);
+    pub struct PageChangedEvent(AtspiEvent);
 }
 
+use crate::events::AtspiEvent;
+
 #[derive(Debug, Clone, TrySignify, Focus)]
-pub struct FocusEvent(Event);
+pub struct FocusEvent(AtspiEvent);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub mod document;
 pub mod editable_text;
 pub mod events;
 pub mod identify;
-pub use events::EventBody;
+pub use events::{Event, EventBody};
 pub mod hyperlink;
 pub mod hypertext;
 pub mod image;
@@ -40,10 +40,13 @@ pub use interfaces::*;
 mod state;
 pub use state::*;
 
+pub mod error;
+pub use error::AtspiError;
+
 pub use zbus;
+use zbus::zvariant::Type;
 
 use serde::{Deserialize, Serialize};
-use zbus::zvariant::Type;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Type)]
 #[repr(u32)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod device_event_listener;
 pub mod document;
 pub mod editable_text;
 pub mod events;
+pub mod identify;
 pub use events::EventBody;
 pub mod hyperlink;
 pub mod hypertext;

--- a/xml/generate-introspection.py
+++ b/xml/generate-introspection.py
@@ -7,7 +7,8 @@ RUST_TYPE_FROM_DBUS_TYPE = {
   "i": "i32",
   "u": "u32",
   "v": "OwnedValue",
-  "a{sv}": "HashMap<String, OwnedValue>"
+  "a{sv}": "HashMap<String, OwnedValue>",
+  "o": "OwnedPath"
 }
 
 for interface in root:


### PR DESCRIPTION
- `#[must_use]` attribute indicates that the user or the method must do something with the return type.
- Functions that Result<> should document when the functon `Err`'s

You could also choose to tell Clippy not to complain about it, but either way, I find the squigllies distracting.