### PR TITLE
Fix zbus version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ enumflags2 = "^0.7.5"
 futures = { version = "^0.3.25", default-features = false }
 serde = { version = "^1.0", default-features = false, features = ["derive"] }
 tracing = "^0.1.37"
-zbus = { version = "^3.0.0", default-features = false }
+zbus = { version = "^3.6.0", default-features = false }
 
 [dev-dependencies]
 byteorder = "1.4.3"


### PR DESCRIPTION
While fixing #10 on f220104a, the `zbus` version requirement was not updated accordingly. This creates an issue for everyone depending on an older version of `zbus` that doesn't yet support the new attributes and outputs confusing compilation errors. With this fix Cargo should try to find an appropriate `zbus` version to satisfy everyone, or clearly say that a version can't be selected.