### PR TITLE
Replace the `futures` crate by `futures-lite`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ atspi-macros = { version = "0.1.0", path = "atspi-macros" }
 async-recursion = "^1.0.0"
 async-trait = "^0.1.59"
 enumflags2 = "^0.7.5"
-futures = { version = "^0.3.25", default-features = false }
+futures-lite = { version = "1.12", default-features = false }
 serde = { version = "^1.0", default-features = false, features = ["derive"] }
 tracing = "^0.1.37"
 zbus = { version = "^3.6.0", default-features = false }
@@ -35,4 +35,3 @@ zbus_names = "2.4.0"
 
 [dev-dependencies]
 byteorder = "1.4.3"
-futures-lite = { version = "1", default-features = false }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,5 +1,5 @@
 use crate::{bus::BusProxy, events::Event, registry::RegistryProxy, AtspiError};
-use futures::stream::{Stream, StreamExt};
+use futures_lite::stream::{Stream, StreamExt};
 use std::ops::Deref;
 use zbus::{zvariant::Signature, Address, MessageStream, MessageType};
 
@@ -77,7 +77,7 @@ impl Connection {
     /// todo!()
     /// ```
     pub fn event_stream(&self) -> impl Stream<Item = Result<Event, AtspiError>> {
-        MessageStream::from(self.registry.connection()).filter_map(|res| async move {
+        MessageStream::from(self.registry.connection()).filter_map(|res| {
             let msg = match res {
                 Ok(m) => m,
                 Err(e) => return Some(Err(e.into())),


### PR DESCRIPTION
This slightly reduces the amount of dependencies and should speed up compile time a bit.