### PR TITLE
Add Semver Cheks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          profile: stable
+          toolchain: stable
       - name: Check Semver Compatibility
         uses: obi1kenobi/cargo-semver-checks-action@v1
         with:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::all, clippy::pedantic, clippy::cargo, unsafe_code)]
 // #![deny(clippy::missing_docs)]
+#![allow(clippy::multiple_crate_versions)]
 
 pub mod accessible;
 pub mod action;


### PR DESCRIPTION
This will allow us to know (more-or-less) if a breaking change has been made. For now, we'll use this as a warning to update the version number, but in the future this could be helpful to stop PRs from accidentally modifying the public API.