### PR TITLE
Modernize CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache cargo home
         uses: actions/cache@v2
         env:
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache cargo home
         uses: actions/cache@v2
         env:
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache cargo home
         uses: actions/cache@v2
         env:
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache cargo home
         uses: actions/cache@v2
         env:


### PR DESCRIPTION
Github is displaying multiple warnings about out of date usages of the CI. This PR will attempt to remedy them to use the latest tech from Github:

1. [ ] [https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/](Node v12 -> v16)
2. [ ] [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](Use environment files)

Some of these are on [https://github.com/actions-rs/toolchain](action-rs/toolchain) and (https://github.com/actions-rs/cargo)[actions-rs/cargo), which have only a single maintainer and many, many open PRs.
I've emailed the author hoping for either a response of merging a bunch of the existing PRs, or to allow me to approve PRs myself.
We'll see how that one goes.