### PR TITLE
More strictly typed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atspi"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Michael Connor Buchan <mikey@blindcomputing.org>", "Tait Hoyem <tait@tait.tech>", "Alberto Tirla <albertotirla@gmail.com>", "DataTriny <datatriny@gmail.com>", "Luuk Duim <luukvanderduim@gmail.com>"]
 description = "Pure-Rust, zbus-based AT-SPI2 protocol implementation."
 license = "Apache-2.0 OR MIT" # For ease of integration in the Rust ecosystem.

--- a/src/accessible.rs
+++ b/src/accessible.rs
@@ -232,6 +232,8 @@ pub enum Role {
 	ContentInsertion,
 	Mark,
 	Suggestion,
+	PushButtonMenu,
+	LastDefined,
 }
 impl std::fmt::Display for Role {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/text.rs
+++ b/src/text.rs
@@ -12,7 +12,7 @@
 #![allow(clippy::too_many_arguments)]
 // this is to silience clippy due to zbus expanding parameter expressions
 
-use crate::atspi_proxy;
+use crate::{atspi_proxy, CoordType};
 use serde::{Deserialize, Serialize};
 use zbus::zvariant::Type;
 
@@ -60,7 +60,7 @@ trait Text {
 		y: i32,
 		width: i32,
 		height: i32,
-		coord_type: u32,
+		coord_type: CoordType,
 		x_clip_type: u32,
 		y_clip_type: u32,
 	) -> zbus::Result<Vec<(i32, i32, String, zbus::zvariant::OwnedValue)>>;
@@ -72,7 +72,7 @@ trait Text {
 	fn get_character_extents(
 		&self,
 		offset: i32,
-		coord_type: u32,
+		coord_type: CoordType,
 	) -> zbus::Result<(i32, i32, i32, i32)>;
 
 	/// GetDefaultAttributeSet method
@@ -85,14 +85,14 @@ trait Text {
 	fn get_nselections(&self) -> zbus::Result<i32>;
 
 	/// GetOffsetAtPoint method
-	fn get_offset_at_point(&self, x: i32, y: i32, coord_type: u32) -> zbus::Result<i32>;
+	fn get_offset_at_point(&self, x: i32, y: i32, coord_type: CoordType) -> zbus::Result<i32>;
 
 	/// GetRangeExtents method
 	fn get_range_extents(
 		&self,
 		start_offset: i32,
 		end_offset: i32,
-		coord_type: u32,
+		coord_type: CoordType,
 	) -> zbus::Result<(i32, i32, i32, i32)>;
 
 	/// GetSelection method

--- a/src/text.rs
+++ b/src/text.rs
@@ -32,6 +32,15 @@ pub enum Granularity {
 	Paragraph,
 }
 
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[repr(u32)]
+pub enum ClipType {
+	Neither,
+	Min,
+	Max,
+	Both,
+}
+
 #[atspi_proxy(interface = "org.a11y.atspi.Text", assume_defaults = true)]
 trait Text {
 	/// AddSelection method
@@ -61,8 +70,8 @@ trait Text {
 		width: i32,
 		height: i32,
 		coord_type: CoordType,
-		x_clip_type: u32,
-		y_clip_type: u32,
+		x_clip_type: ClipType,
+		y_clip_type: ClipType,
 	) -> zbus::Result<Vec<(i32, i32, String, zbus::zvariant::OwnedValue)>>;
 
 	/// GetCharacterAtOffset method


### PR DESCRIPTION
Add more strict types to `zbus` methods.

Let's see if we can root out all of the C enums, and have them in the Rust code as well.