### PR TITLE
Update xml and code accordingly

### DIFF
--- a/src/accessibility_connection.rs
+++ b/src/accessibility_connection.rs
@@ -251,7 +251,7 @@ impl AccessibilityConnection {
 	}
 
 	/// Shorthand for a reference to the underlying [`zbus::Connection`]
-	#[must_use]
+	#[must_use = "The reference to the underlying zbus::Connection must be used"]
 	pub fn connection(&self) -> &zbus::Connection {
 		self.registry.connection()
 	}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -26,7 +26,7 @@ pub struct CacheItem {
 	pub index: i32,
 	/// Child count of the accessible  i
 	pub children: i32,
-	/// The exposed interfece(s) set.  as
+	/// The exposed interface(s) set.  as
 	pub ifaces: InterfaceSet,
 	/// The short localized name.  s
 	pub short_name: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,7 +61,7 @@ impl std::fmt::Display for AtspiError {
 		match self {
 			Self::Conversion(e) => f.write_str(&format!("atspi: conversion failure: {e}")),
 			Self::MemberMatch(e) => {
-				f.write_str(format!("atspi: member mismatch in conversion: {e}").as_str())
+				write!(f, "atspi: member mismatch in conversion: {e}")
 			}
 			Self::UnknownBusSignature(s) => {
 				write!(f, "atspi: Unknown bus body signature: {s}")

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,7 +63,9 @@ impl std::fmt::Display for AtspiError {
 			Self::MemberMatch(e) => {
 				f.write_str(format!("atspi: member mismatch in conversion: {e}").as_str())
 			}
-			Self::UnknownBusSignature(s) => f.write_str("atspi: Unknown bus body signature: {s}"),
+			Self::UnknownBusSignature(s) => {
+				write!(f, "atspi: Unknown bus body signature: {s}")
+			}
 			Self::UnknownInterface => f.write_str("Unknown interface."),
 			Self::MissingInterface => f.write_str("Missing> interface."),
 			Self::UnknownSignal => f.write_str("atspi: Unknown signal"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,8 +12,9 @@ pub enum AtspiError {
 	/// On specific types, if the event / message member does not match the Event's name.
 	MemberMatch(String),
 
-	/// To indicate a match or equality test on a signa body signature failed.
-	UnknownBusSignature,
+	/// To indicate a match or equality test on a signal body signature failed.
+	/// The contained string is the signature that was found.
+	UnknownBusSignature(String),
 
 	/// When matching on an unknown interface
 	UnknownInterface,
@@ -62,7 +63,7 @@ impl std::fmt::Display for AtspiError {
 			Self::MemberMatch(e) => {
 				f.write_str(format!("atspi: member mismatch in conversion: {e}").as_str())
 			}
-			Self::UnknownBusSignature => f.write_str("atspi: Unknown bus body signature."),
+			Self::UnknownBusSignature(s) => f.write_str("atspi: Unknown bus body signature: {s}"),
 			Self::UnknownInterface => f.write_str("Unknown interface."),
 			Self::MissingInterface => f.write_str("Missing> interface."),
 			Self::UnknownSignal => f.write_str("atspi: Unknown signal"),

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -421,7 +421,7 @@ pub trait GenericEvent {
 	/// Sender of the signal.
 	///
 	/// ### Errors
-	/// - when deserializeing the header failed, or
+	/// - when deserializing the header failed, or
 	/// - When `zbus::get_field!` finds that 'sender' is an invalid field.
 	fn sender(&self) -> Result<Option<UniqueName>, AtspiError>;
 }
@@ -510,7 +510,7 @@ impl GenericEvent for AtspiEvent {
 
 	/// Identifies the `sender` of the event.
 	/// # Errors
-	/// - when deserializeing the header failed, or
+	/// - when deserializing the header failed, or
 	/// - When `zbus::get_field!` finds that 'sender' is an invalid field.
 	fn sender(&self) -> Result<Option<zbus::names::UniqueName>, crate::AtspiError> {
 		Ok(self.message.header()?.sender()?.cloned())

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -547,14 +547,14 @@ mod tests {
 			detail1: 0,
 			detail2: 0,
 			any_data: Value::U8(0u8).into(),
-			properties: ("".to_string(), ObjectPath::try_from("/").unwrap().into()),
+			properties: (String::new(), ObjectPath::try_from("/").unwrap().into()),
 		}
 	}
 
 	#[test]
 	fn test_event_body_qt_to_event_body_owned_conversion() {
 		let event_body: EventBodyOwned = gen_event_body_qt().into();
-		let props = HashMap::from([("".to_string(), ObjectPath::try_from("/").unwrap().into())]);
+		let props = HashMap::from([(String::new(), ObjectPath::try_from("/").unwrap().into())]);
 		assert_eq!(event_body.properties, props);
 	}
 	#[tokio::test]
@@ -573,12 +573,10 @@ mod tests {
 		.expect("Could not create signal")
 		.sender(unique_bus_name.unwrap())
 		.expect("Could not set sender to {unique_bus_name:?}")
-		.build(
-			&(((
-				":69.420".to_string(),
-				OwnedObjectPath::try_from("/org/a11y/atspi/accessible/remove").unwrap(),
-			),)),
-		)
+		.build(&((
+			":69.420".to_string(),
+			OwnedObjectPath::try_from("/org/a11y/atspi/accessible/remove").unwrap(),
+		),))
 		.unwrap();
 		assert_eq!(msg.body_signature().unwrap(), ACCESSIBLE_PAIR_SIGNATURE);
 		atspi.connection().send_message(msg).await.unwrap();
@@ -592,15 +590,15 @@ mod tests {
 				assert_eq!(event.as_accessible().name.as_str(), ":69.420");
 			}
 			Ok(Some(Ok(another_event))) => {
-				println!("{:?}", another_event);
+				println!("{another_event:?}");
 				panic!("The wrong event was sent");
 			}
 			Ok(e) => {
-				println!("{:?}", e);
+				println!("{e:?}");
 				panic!("Something else happened");
 			}
 			Err(e) => {
-				panic!("An error occured: {:?}", e);
+				panic!("An error occurred: {e:?}");
 			}
 		}
 	}
@@ -635,7 +633,7 @@ mod tests {
 			index: 0,
 			children: 0,
 			ifaces: InterfaceSet::empty(),
-			short_name: "".to_string(),
+			short_name: String::new(),
 			role: Role::Application,
 			name: "Hi".to_string(),
 			states: StateSet::empty(),
@@ -653,19 +651,19 @@ mod tests {
 				assert_eq!(cache_item.app.1.as_str(), "/org/a11y/atspi/accessible/application");
 			}
 			Ok(Some(Ok(another_event))) => {
-				println!("{:?}", another_event);
+				println!("{another_event:?}");
 				panic!("The wrong event was sent");
 			}
 			Ok(Some(Err(e))) => {
-				println!("{:?}", e);
-				panic!("An error occured destructuring the body");
+				println!("{e:?}");
+				panic!("An error occurred destructuring the body");
 			}
 			Ok(e) => {
-				println!("{:?}", e);
+				println!("{e:?}");
 				panic!("Something else happened");
 			}
 			Err(e) => {
-				panic!("An error occured: {:?}", e);
+				panic!("An error occurred: {e:?}");
 			}
 		}
 	}

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -399,7 +399,7 @@ impl TryFrom<Arc<Message>> for Event {
 				let ev = AddAccessibleEvent::try_from(msg)?;
 				Ok(Event::Cache(CacheEvents::Add(ev)))
 			}
-			_ => Err(AtspiError::UnknownBusSignature),
+			_ => Err(AtspiError::UnknownBusSignature(message_signature.to_string())),
 		}
 	}
 }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -685,11 +685,6 @@ mod tests {
 											event.path().unwrap(),
 											"/org/a11y/atspi/accessible/null"
 										);
-										assert_eq!(
-											event.as_accessible().path.as_str(),
-											"/org/a11y/atspi/accessible/add"
-										);
-										assert_eq!(event.as_accessible().name.as_str(), ":69.420");
 									}
 									// Stream yields a Some(Ok(Event)) when a message is received
 									another_event => {

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -276,7 +276,7 @@ impl<'name> PartialEq<MemberName<'name>> for AtspiEvent {
 //  Equality on `AtspiEvent` may be considered ambiguous.
 //
 // Because `AtspiEvent`'s message has eg. a `SerialNumber` in the primary header,
-// only exacly same instances would be equal, _if_ `PartialEq` were derivable.
+// only exactly same instances would be equal, _if_ `PartialEq` were derivable.
 //
 // This PartialEq implements the strictest kind where only same instances are considered the same.
 // Other equalities should be made with PartailEq<T> for AtspiEvent and PartialEq<AtspiEvent> for T
@@ -594,8 +594,7 @@ mod tests {
 				panic!("The wrong event was sent");
 			}
 			Ok(e) => {
-				println!("{e:?}");
-				panic!("Something else happened");
+				panic!("Something else happened: {e:?}");
 			}
 			Err(e) => {
 				panic!("An error occurred: {e:?}");

--- a/src/table_cell.rs
+++ b/src/table_cell.rs
@@ -10,12 +10,18 @@
 //! section of the zbus documentation.
 //!
 
-use crate::atspi_proxy;
+use crate::{accessible::ObjectPair, atspi_proxy};
 
 #[atspi_proxy(interface = "org.a11y.atspi.TableCell", assume_defaults = true)]
 trait TableCell {
+	/// GetColumnHeaderCells method
+	fn get_column_header_cells(&self) -> zbus::Result<Vec<ObjectPair>>;
+
 	/// GetRowColumnSpan method
 	fn get_row_column_span(&self) -> zbus::Result<(bool, i32, i32, i32, i32)>;
+
+	/// GetRowHeaderCells method
+	fn get_row_header_cells(&self) -> zbus::Result<Vec<ObjectPair>>;
 
 	/// ColumnSpan property
 	#[dbus_proxy(property)]

--- a/xml/Accessible.xml
+++ b/xml/Accessible.xml
@@ -67,7 +67,7 @@
     <property name="Locale" type="s" access="read"/>
 
     <!--
-        AccessibleId: application-spcific identifier for the current object.
+        AccessibleId: application-specific identifier for the current object.
 
         You can use this to give a special id to an object to use in tests, for example,
         "my_widget".  Note that there is no way to directly find an object by its id; your
@@ -113,7 +113,8 @@
         GetIndexInParent:
 
         Returns the 0-based index at which the object would be returned by calling
-        GetChildren on its parent.
+        GetChildren on its parent, or -1 if the object has no containing
+        parent or on exception.
     -->
     <method name="GetIndexInParent">
       <arg direction="out" type="i"/>
@@ -293,7 +294,7 @@
 
         12 - ATSPI_ROLE_DATE_EDITOR: An object which allows entry of a date.
 
-        13 - ATSPI_ROLE_DESKTOP_ICON: An inconifed internal frame within a DESKTOP_PANE.
+        13 - ATSPI_ROLE_DESKTOP_ICON: An inconified internal frame within a DESKTOP_PANE.
 
         14 - ATSPI_ROLE_DESKTOP_FRAME: A pane that supports internal frames and
              iconified versions of those internal frames.
@@ -419,7 +420,7 @@
         54 - ATSPI_ROLE_STATUS_BAR: Object displays non-quantitative status information
              (c.f. ATSPI_ROLE_PROGRESS_BAR)
 
-        55 - ATSPI_ROLE_TABLE: An object used to repesent information in terms of rows
+        55 - ATSPI_ROLE_TABLE: An object used to represent information in terms of rows
              and columns.
 
         56 - ATSPI_ROLE_TABLE_CELL: A 'cell' or discrete child within a Table. Note:
@@ -728,7 +729,9 @@
 
         Gets a UTF-8 string corresponding to the name of the role played by an object.
         This method will return useful values for roles that fall outside the
-        enumeration used in the GetRole method.
+        enumeration used in the GetRole method. Implementing this method is
+        optional, and it may be removed in a future version of the API.
+        Libatspi will only call id in the event of an unknown role.
     -->
     <method name="GetRoleName">
       <arg direction="out" type="s"/>
@@ -740,7 +743,9 @@
         Gets a UTF-8 string corresponding to the name of the role played by an object, translated
         to the current locale.
         This method will return useful values for roles that fall outside the
-        enumeration used in the GetRole method.
+        enumeration used in the GetRole method. Implementing this method is
+        optional, and it may be removed in a future version of the API.
+        Libatspi will only call id in the event of an unknown role.
     -->
     <method name="GetLocalizedRoleName">
       <arg direction="out" type="s"/>

--- a/xml/Component.xml
+++ b/xml/Component.xml
@@ -137,7 +137,7 @@
 
         2 - CANVAS: The 'background' layer for most content renderers and UI component containers.
 
-        3 - WIDGET: The layer in which the majority of ordintary 'foreground' widgets reside.
+        3 - WIDGET: The layer in which the majority of ordinary 'foreground' widgets reside.
 
         4 - MDI: A special layer between CANVAS and WIDGET, in which the 'pseudo-windows'
         (e.g. the Multiple-Document Interface frames) reside.  See the GetMDIZOrder

--- a/xml/TableCell.xml
+++ b/xml/TableCell.xml
@@ -22,5 +22,24 @@
       <arg direction="out" name="col_extents" type="i" />
     </method>
 
+    <!--
+        GetColumnHeaderCells:
+
+        Returns a list of the table cell's column header cells.
+    -->
+    <method name="GetColumnHeaderCells">
+      <arg direction="out" type="a(so)"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QSpiObjectReferenceArray"/>
+    </method>
+
+    <!--
+        GetRowHeaderCells:
+
+        Returns a list of the table cell's row header cells.
+    -->
+    <method name="GetRowHeaderCells">
+      <arg direction="out" type="a(so)"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QSpiObjectReferenceArray"/>
+    </method>
   </interface>
 </node>


### PR DESCRIPTION
There have been a few changes in upstream XML protocol descriptions since last time we updated.

Changes are found in: Accessible.xml, Component.xml and TableCell.xml.

Mostly typos, but also a few changes to the API.
TableCell gains the methods GetColumnHeaderCells and GetRowHeaderCells.

Three commits:
- Add changes to XML files
- Add methods to TableCell interface
- A handful of Clippy / spelling fixes.