### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ unstable-traits = ["atspi-macros/unstable_atspi_proxy_macro", "atspi-macros/toki
 
 [dependencies]
 atspi-macros = { version = "0.3.0", path = "atspi-macros" }
-enumflags2 = "^0.7.5"
+enumflags2 = "^0.7.7"
 serde = { version = "^1.0", default-features = false, features = ["derive"] }
 zbus = { version = "^3.6.2", default-features = false }
 # optioanl dependencies


### PR DESCRIPTION
Updates dependency to the patch version of 0.7.7

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0035.html)
[fix](https://github.com/meithecatte/enumflags2/releases/tag/v0.7.7)

(Side note, you don't need to explicitly mention ^ in your dependencies, since cargo does `^` implicitly if just the value is mentioned. I've kept it on for consistency sake but it can be removed form all if needed)