### PR TITLE
WASM CI Check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,36 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
       - name: Run tests
         run: cargo clippy --workspace --no-deps -- -D warnings 
+  common-crate-wasm-compilation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+      - name: Cache cargo home
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-cargo-home
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-x86_64-unknown-linux-gnu-build-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-x86_64-unknown-linux-gnu-build-${{ env.cache-name }}-
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - name: Install targets
+        run: rustup target add wasm32-unknown-unknow && rustup target add wasm32-wasi
+      - name: Build on WASM (wasm32-unknown-unknown)
+        working-directory: atspi-common
+        run: cargo build --target wasm32-unknown-unknown
+      - name: Build on WASM (wasm32-wasi)
+        working-directory: atspi-common
+        run: cargo build --target wasm32-wasi
   tests:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           toolchain: stable
       - name: Install targets
-        run: rustup target add wasm32-unknown-unknow && rustup target add wasm32-wasi
+        run: rustup target add wasm32-unknown-unknown && rustup target add wasm32-wasi
       - name: Build on WASM (wasm32-unknown-unknown)
         working-directory: atspi-common
         run: cargo build --target wasm32-unknown-unknown

--- a/atspi-client/Cargo.toml
+++ b/atspi-client/Cargo.toml
@@ -20,6 +20,6 @@ async-std = ["atspi-proxies/async-std", "atspi-common/async-std"]
 [dependencies]
 async-trait = "0.1.68"
 static_assertions = "1.1.0"
-atspi-common = { path = "../atspi-common/", version = "0.1.0", default-features = false }
+atspi-common = { path = "../atspi-common/", version = "0.2.0", default-features = false }
 atspi-proxies = { path = "../atspi-proxies", version = "0.1.0", default-features = false, features = ["unstable-traits"] }
 zbus = { workspace = true }

--- a/atspi-common/Cargo.toml
+++ b/atspi-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atspi-common"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 readme = "README.md"
 categories = ["macros", "accessibility"]
@@ -13,16 +13,17 @@ license = "Apache-2.0 OR MIT"
 
 [features]
 default = ["async-std"]
-async-std = ["zbus/async-io", "atspi-connection/async-std", "atspi-common/async-std"]
-tokio = ["zbus/tokio", "atspi-connection/tokio", "atspi-common/tokio"]
+async-std = ["zbus/async-io", "_foreign_conversion", "atspi-connection/async-std", "atspi-common/async-std"]
+tokio = ["zbus/tokio", "_foreign_conversion", "atspi-connection/tokio", "atspi-common/tokio"]
+_foreign_conversion = []
 
 [dependencies]
 enumflags2 = "0.7.7"
 serde = "1.0"
 static_assertions = "1.1.0"
-zbus_names = "2.5.0"
-zvariant = { version = "3", default-features = false }
-zbus = { version = "3", optional = true, default-features = false }
+zbus_names = { version = "2.5.0", default-features = false }
+zvariant = { version = "3.12.0", default-features = false }
+zbus = { version = "3.12.0", optional = true, default-features = false }
 
 [dev-dependencies]
 zbus = { version = "3", default-features = false }

--- a/atspi-common/Cargo.toml
+++ b/atspi-common/Cargo.toml
@@ -33,3 +33,4 @@ byteorder = "1.4.3"
 rename-item = "0.1.0"
 tokio-test = "0.4.2"
 atspi-common = { path = ".", default-features = false, features = ["zbus"]}
+serde_plain = "1.0.1"

--- a/atspi-common/Cargo.toml
+++ b/atspi-common/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0 OR MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["async-std"]
+default = []
 async-std = ["zbus/async-io", "_foreign_conversion", "atspi-connection/async-std", "atspi-common/async-std"]
 tokio = ["zbus/tokio", "_foreign_conversion", "atspi-connection/tokio", "atspi-common/tokio"]
 _foreign_conversion = []

--- a/atspi-common/README.md
+++ b/atspi-common/README.md
@@ -5,3 +5,19 @@ This crate is meant to only contain the absolute lowest common denominator for l
 therefore, it attempts to be able to compile on basically any architecture (including WASM).
 
 Please use the internal documentation to learn how to use these data structures.
+
+## Compiling for WASM
+
+If you'd like to compile this crate for any architecture that implements `std`, then you have to compile it without any feature flags.
+By default, this crate provides a variety of converison methods for foreign error types into its own event type.
+
+## Feature Flags
+
+* `async-std`: build `zbus` with `async-std` support.
+* `tokio`: build `zbus` with `tokio` support.
+
+Either of these flags will enable conversion from zbus error types to the `AtspiError` type.
+
+> Why do I need to specify a runtime to have the conversion methods available to me?
+
+A: Because `zbus` requires you to specify at least one runtime, and it would be annoying to compile an entire second runtime if it is not necessary.

--- a/atspi-common/src/error.rs
+++ b/atspi-common/src/error.rs
@@ -1,11 +1,7 @@
 #[allow(clippy::module_name_repetitions)]
-#[derive(Debug)]
-#[non_exhaustive]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Eq, PartialEq, Clone)]
 /// An error type that can describe atspi and `std` and different `zbus` errors.
 pub enum AtspiError {
-	/// Converting one type into another failure
-	Conversion(&'static str),
-
 	/// When testing on either variant, we might find the we are not interested in.
 	CacheVariantMismatch,
 
@@ -16,10 +12,10 @@ pub enum AtspiError {
 	InterfaceMatch(String),
 
 	/// To indicate a match or equality test on a signa body signature failed.
-	UnknownBusSignature,
+	UnknownBusSignature(String),
 
 	/// When matching on an unknown interface
-	UnknownInterface,
+	UnknownInterface(String),
 
 	/// No interface on event.
 	MissingInterface,
@@ -30,8 +26,11 @@ pub enum AtspiError {
 	/// No name on bus.
 	MissingName,
 
+	/// No path on bus.
+	MissingPath,
+
 	/// The signal that was encountered is unknown.
-	UnknownSignal,
+	UnknownSignal(String),
 
 	/// Other errors.
 	Owned(String),
@@ -39,26 +38,24 @@ pub enum AtspiError {
 	/// A `zbus` or `zbus::Fdo` error. variant.
 	Zbus(String),
 
-	/// A `zbus_names` error variant
-	ZBusNames(zbus_names::Error),
-
-	/// A `zbus_names` error variant
-	Zvariant(zvariant::Error),
-
 	/// Failed to parse a string into an enum variant
-	ParseError(&'static str),
-
-	/// Failed to get the ID of a path.
-	PathConversionError(ObjectPathConversionError),
-
-	/// Std i/o error variant.
-	IO(std::io::Error),
+	ParseError(String),
 
 	/// Failed to convert an integer into another type of integer (usually i32 -> usize).
-	IntConversionError(std::num::TryFromIntError),
+	IntConversionError,
 
 	/// An infallible error; this is just something to satisfy the compiler.
 	Infallible,
+
+	/// An error for when you attempt to extract the incorrect variant of a type.
+	/// For example: [`crate::events::Event`] has many variants and sub-variants that can be extracted.
+	/// If you attempt to convert to a variant which is not the variant contained within the `Event` enum, then you will get this error.
+	InvalidType,
+
+	/// An error type to hold innumerable errors. This includes implementation detail errors like internal zbus errors or serde serialization problems (again internal to zbus).
+	/// Any generic error here *can* be moved into its own variant if requested.
+	/// These errors in general should be fairly rare; if you get this error, something very bad has happened, and you may want to consider [filing a bug](https://github.com/odilia-app/atspi/issues/) with a way to reproduce the bug.
+	Generic(String),
 }
 
 impl std::error::Error for AtspiError {}
@@ -66,33 +63,35 @@ impl std::error::Error for AtspiError {}
 impl std::fmt::Display for AtspiError {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
-			Self::Conversion(e) => f.write_str(&format!("atspi: conversion failure: {e}")),
+			Self::InvalidType => f.write_str("atspi: invalid type conversion"),
 			Self::MemberMatch(e) => {
 				f.write_str(format!("atspi: member mismatch in conversion: {e}").as_str())
 			}
 			Self::InterfaceMatch(e) => {
 				f.write_str(format!("atspi: interface mismatch in conversion: {e}").as_str())
 			}
-			Self::UnknownBusSignature => f.write_str("atspi: Unknown bus body signature."),
-			Self::UnknownInterface => f.write_str("Unknown interface."),
+			Self::UnknownBusSignature(signature) => {
+				f.write_str(&format!("atspi: Unknown bus body signature: {signature}."))
+			}
+			Self::UnknownInterface(interface_name) => {
+				f.write_str(&format!("Unknown interface: {interface_name}."))
+			}
 			Self::MissingInterface => f.write_str("Missing interface."),
 			Self::MissingMember => f.write_str("Missing member."),
-			Self::UnknownSignal => f.write_str("atspi: Unknown signal"),
+			Self::MissingPath => f.write_str("Missing path."),
+			Self::UnknownSignal(signal_name) => {
+				f.write_str(&format!("atspi: Unknown signal: {signal_name}"))
+			}
 			Self::CacheVariantMismatch => f.write_str("atspi: Cache variant mismatch"),
 			Self::Owned(e) => f.write_str(&format!("atspi: other error: {e}")),
 			Self::Zbus(e) => f.write_str(&format!("ZBus Error: {e}")),
-			Self::Zvariant(e) => f.write_str(&format!("Zvariant erron: {e}")),
-			Self::ZBusNames(e) => f.write_str(&format!("ZBus_names Error: {e}")),
 			Self::ParseError(e) => f.write_str(e),
-			Self::PathConversionError(e) => {
-				f.write_str(&format!("ID cannot be extracted from the path: {e}"))
-			}
-			Self::IO(e) => f.write_str(&format!("std IO Error: {e}")),
-			Self::IntConversionError(e) => f.write_str(&format!("Integer conversion error: {e}")),
+			Self::IntConversionError => f.write_str("Integer conversion error."),
 			Self::MissingName => f.write_str("Missing name for a bus."),
 			Self::Infallible => {
 				f.write_str("Infallible; only to trick the compiler. This should never happen.")
 			}
+			Self::Generic(msg) => f.write_str(msg),
 		}
 	}
 }
@@ -103,61 +102,42 @@ impl From<std::convert::Infallible> for AtspiError {
 	}
 }
 impl From<std::num::TryFromIntError> for AtspiError {
-	fn from(e: std::num::TryFromIntError) -> Self {
-		Self::IntConversionError(e)
+	fn from(_e: std::num::TryFromIntError) -> Self {
+		Self::IntConversionError
 	}
 }
 
 #[cfg(feature = "zbus")]
 impl From<zbus::fdo::Error> for AtspiError {
 	fn from(e: zbus::fdo::Error) -> Self {
-		Self::Zbus(format!("{e:?}"))
+		Self::Generic(e.to_string())
 	}
 }
 
 #[cfg(feature = "zbus")]
 impl From<zbus::Error> for AtspiError {
 	fn from(e: zbus::Error) -> Self {
-		Self::Zbus(format!("{e:?}"))
+		Self::Generic(e.to_string())
 	}
 }
 
 impl From<zbus_names::Error> for AtspiError {
 	fn from(e: zbus_names::Error) -> Self {
-		Self::ZBusNames(e)
+		Self::Generic(e.to_string())
 	}
 }
 
 impl From<zvariant::Error> for AtspiError {
-	fn from(e: zvariant::Error) -> Self {
-		Self::Zvariant(e)
+	fn from(zv_err: zvariant::Error) -> Self {
+		match zv_err {
+			zvariant::Error::Message(generic_msg) => Self::Generic(generic_msg),
+			e => Self::Generic(e.to_string()),
+		}
 	}
 }
 
 impl From<std::io::Error> for AtspiError {
 	fn from(e: std::io::Error) -> Self {
-		Self::IO(e)
+		Self::Generic(e.to_string())
 	}
 }
-
-impl From<ObjectPathConversionError> for AtspiError {
-	fn from(e: ObjectPathConversionError) -> AtspiError {
-		Self::PathConversionError(e)
-	}
-}
-
-#[allow(clippy::module_name_repetitions)]
-#[derive(Clone, Debug)]
-pub enum ObjectPathConversionError {
-	NoIdAvailable,
-	ParseError(<i64 as std::str::FromStr>::Err),
-}
-impl std::fmt::Display for ObjectPathConversionError {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		match self {
-			Self::NoIdAvailable => f.write_str("No ID available in the path."),
-			Self::ParseError(e) => f.write_str(&format!("Failure to parse: {e}")),
-		}
-	}
-}
-impl std::error::Error for ObjectPathConversionError {}

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -1,4 +1,5 @@
 use crate::{
+	State,
 	error::AtspiError,
 	events::{Accessible, EventBodyOwned, GenericEvent, HasMatchRule, HasRegistryEventString},
 	Event,
@@ -58,7 +59,7 @@ pub struct LinkSelectedEvent {
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct StateChangedEvent {
 	pub item: crate::events::Accessible,
-	pub state: String,
+	pub state: State,
 	pub enabled: i32,
 }
 
@@ -280,7 +281,7 @@ impl GenericEvent<'_> for StateChangedEvent {
 	type Body = EventBodyOwned;
 
 	fn build(item: Accessible, body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item, state: body.kind, enabled: body.detail1 })
+		Ok(Self { item, state: body.kind.into(), enabled: body.detail1 })
 	}
 	fn sender(&self) -> UniqueName<'_> {
 		self.item.name.clone().into()
@@ -1066,7 +1067,7 @@ impl From<StateChangedEvent> for EventBodyOwned {
 	fn from(event: StateChangedEvent) -> Self {
 		EventBodyOwned {
 			properties: std::collections::HashMap::new(),
-			kind: event.state,
+			kind: event.state.into(),
 			detail1: event.enabled,
 			detail2: i32::default(),
 			any_data: zvariant::Value::U8(0).into(),

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -1,8 +1,7 @@
 use crate::{
-	State,
 	error::AtspiError,
 	events::{Accessible, EventBodyOwned, GenericEvent, HasMatchRule, HasRegistryEventString},
-	Event,
+	Event, State,
 };
 use zbus_names::UniqueName;
 use zvariant::ObjectPath;

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -13,7 +13,7 @@ macro_rules! impl_event_conversions {
 				if let $outer_variant(event_type) = generic_event {
 					Ok(event_type)
 				} else {
-					Err(AtspiError::Conversion("Invalid type"))
+					Err(AtspiError::InvalidType)
 				}
 			}
 		}
@@ -35,7 +35,7 @@ macro_rules! impl_event_conversions {
 				if let $outer_variant($inner_variant(specific_event)) = generic_event {
 					Ok(specific_event)
 				} else {
-					Err(AtspiError::Conversion("Invalid type"))
+					Err(AtspiError::InvalidType)
 				}
 			}
 		}

--- a/atspi-common/src/state.rs
+++ b/atspi-common/src/state.rs
@@ -11,10 +11,11 @@ use zvariant::{Signature, Type};
 /// of an accessibility object.
 #[bitflags]
 #[repr(u64)]
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum State {
 	/// Indicates an invalid state - probably an error condition.
+	#[default]
 	Invalid,
 	/// Indicates a window is currently the active window, or
 	/// an object is the active subelement within a container or table.
@@ -219,6 +220,114 @@ pub enum State {
 	ReadOnly,
 }
 
+impl From<State> for String {
+	fn from(state: State) -> String {
+		match state {
+			State::Invalid => "invalid",
+			State::Active => "active",
+			State::Armed => "armed",
+			State::Busy => "busy",
+			State::Checked => "checked",
+			State::Collapsed => "collapsed",
+			State::Defunct => "defunct",
+			State::Editable => "editable",
+			State::Enabled => "enabled",
+			State::Expandable => "expandable",
+			State::Expanded => "expanded",
+			State::Focusable => "focusable",
+			State::Focused => "focused",
+			State::HasTooltip => "has-tooltip",
+			State::Horizontal => "horizontal",
+			State::Iconified => "iconified",
+			State::Modal => "modal",
+			State::MultiLine => "multi-line",
+			State::Multiselectable => "multiselectable",
+			State::Opaque => "opaque",
+			State::Pressed => "pressed",
+			State::Resizable => "resizable",
+			State::Selectable => "selectable",
+			State::Selected => "selected",
+			State::Sensitive => "sensitive",
+			State::Showing => "showing",
+			State::SingleLine => "single-line",
+			State::Stale => "stale",
+			State::Transient => "transient",
+			State::Vertical => "vertical",
+			State::Visible => "visible",
+			State::ManagesDescendants => "manages-descendants",
+			State::Indeterminate => "indeterminate",
+			State::Required => "required",
+			State::Truncated => "truncated",
+			State::Animated => "animated",
+			State::InvalidEntry => "invalid-entry",
+			State::SupportsAutocompletion => "supports-autocompletion",
+			State::SelectableText => "selectable-text",
+			State::IsDefault => "is-default",
+			State::Visited => "visited",
+			State::Checkable => "checkable",
+			State::HasPopup => "has-popup",
+			State::ReadOnly => "read-only",
+		}.to_string()
+	}
+}
+
+impl From<String> for State {
+	fn from(string: String) -> State {
+		(&*string).into()
+	}
+}
+
+impl From<&str> for State {
+	fn from(string: &str) -> State {
+		match string {
+			"active" => State::Active,
+			"armed" => State::Armed,
+			"busy" => State::Busy,
+			"checked" => State::Checked,
+			"collapsed" => State::Collapsed,
+			"defunct" => State::Defunct,
+			"editable" => State::Editable,
+			"enabled" => State::Enabled,
+			"expandable" => State::Expandable,
+			"expanded" => State::Expanded,
+			"focusable" => State::Focusable,
+			"focused" => State::Focused,
+			"has-tooltip" => State::HasTooltip,
+			"horizontal" => State::Horizontal,
+			"iconified" => State::Iconified,
+			"modal" => State::Modal,
+			"multi-line" => State::MultiLine,
+			"multiselectable" => State::Multiselectable,
+			"opaque" => State::Opaque,
+			"pressed" => State::Pressed,
+			"resizable" => State::Resizable,
+			"selectable" => State::Selectable,
+			"selected" => State::Selected,
+			"sensitive" => State::Sensitive,
+			"showing" => State::Showing,
+			"single-line" => State::SingleLine,
+			"stale" => State::Stale,
+			"transient" => State::Transient,
+			"vertical" => State::Vertical,
+			"visible" => State::Visible,
+			"manages-descendants" => State::ManagesDescendants,
+			"indeterminate" => State::Indeterminate,
+			"required" => State::Required,
+			"truncated" => State::Truncated,
+			"animated" => State::Animated,
+			"invalid-entry" => State::InvalidEntry,
+			"supports-autocompletion" => State::SupportsAutocompletion,
+			"selectable-text" => State::SelectableText,
+			"is-default" => State::IsDefault,
+			"visited" => State::Visited,
+			"checkable" => State::Checkable,
+			"has-popup" => State::HasPopup,
+			"read-only" => State::ReadOnly,
+			_ => State::Invalid,
+		}
+	}
+}
+
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
 /// The bitflag representation of all states an object may have.
@@ -401,6 +510,7 @@ mod tests {
 	use super::*;
 	use byteorder::LE;
 	use zbus::zvariant::{from_slice, to_bytes, EncodingContext as Context};
+	use serde_plain;
 
 	#[test]
 	fn serialize_empty_state_set() {
@@ -484,5 +594,24 @@ mod tests {
 		let ctxt = Context::<LE>::new_dbus(0);
 		let decoded = from_slice::<_, StateSet>(&[8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32], ctxt);
 		assert!(decoded.is_err());
+	}
+
+	#[test]
+	fn convert_state_direct_string() {
+		for state in StateSet::from_bits(0b11111111111111111111111111111111111111111111).unwrap().iter() {
+			let state_str: String = state.into();
+			let state_two: State = state_str.clone().into();
+			assert_eq!(state, state_two, "The {state:?} was serialized as {state_str}, which deserializes to {state_two:?}");
+		}
+	}
+	#[test]
+	fn convert_state_direct_string_is_equal_to_serde_output() {
+		for state in StateSet::from_bits(0b11111111111111111111111111111111111111111111).unwrap().iter() {
+			let serde_state_str: String = serde_plain::to_string(&state).unwrap();
+			let state_str: String = state.into();
+			assert_eq!(serde_state_str, state_str);
+			let state_two: State = serde_plain::from_str(&state_str).unwrap();
+			assert_eq!(state, state_two, "The {state:?} was serialized as {state_str}, which deserializes to {state_two:?} (serde)");
+		}
 	}
 }

--- a/atspi-common/src/state.rs
+++ b/atspi-common/src/state.rs
@@ -267,7 +267,8 @@ impl From<State> for String {
 			State::Checkable => "checkable",
 			State::HasPopup => "has-popup",
 			State::ReadOnly => "read-only",
-		}.to_string()
+		}
+		.to_string()
 	}
 }
 
@@ -509,8 +510,8 @@ impl std::ops::BitAndAssign for StateSet {
 mod tests {
 	use super::*;
 	use byteorder::LE;
-	use zbus::zvariant::{from_slice, to_bytes, EncodingContext as Context};
 	use serde_plain;
+	use zbus::zvariant::{from_slice, to_bytes, EncodingContext as Context};
 
 	#[test]
 	fn serialize_empty_state_set() {
@@ -598,15 +599,24 @@ mod tests {
 
 	#[test]
 	fn convert_state_direct_string() {
-		for state in StateSet::from_bits(0b11111111111111111111111111111111111111111111).unwrap().iter() {
+		for state in StateSet::from_bits(0b11111111111111111111111111111111111111111111)
+			.unwrap()
+			.iter()
+		{
 			let state_str: String = state.into();
 			let state_two: State = state_str.clone().into();
-			assert_eq!(state, state_two, "The {state:?} was serialized as {state_str}, which deserializes to {state_two:?}");
+			assert_eq!(
+				state, state_two,
+				"The {state:?} was serialized as {state_str}, which deserializes to {state_two:?}"
+			);
 		}
 	}
 	#[test]
 	fn convert_state_direct_string_is_equal_to_serde_output() {
-		for state in StateSet::from_bits(0b11111111111111111111111111111111111111111111).unwrap().iter() {
+		for state in StateSet::from_bits(0b11111111111111111111111111111111111111111111)
+			.unwrap()
+			.iter()
+		{
 			let serde_state_str: String = serde_plain::to_string(&state).unwrap();
 			let state_str: String = state.into();
 			assert_eq!(serde_state_str, state_str);

--- a/atspi-connection/Cargo.toml
+++ b/atspi-connection/Cargo.toml
@@ -19,7 +19,7 @@ tokio = ["zbus/tokio", "atspi-proxies/tokio", "atspi-common/tokio"]
 
 [dependencies]
 atspi-proxies = { path = "../atspi-proxies/", version = "0.1.0", default-features = false }
-atspi-common = { path = "../atspi-common/", version = "0.1.0", default-features = false }
+atspi-common = { path = "../atspi-common/", version = "0.2.0", default-features = false }
 futures-lite = "1.13.0"
 zbus.workspace = true
 tracing = { optional = true, workspace = true }

--- a/atspi-proxies/Cargo.toml
+++ b/atspi-proxies/Cargo.toml
@@ -25,7 +25,7 @@ tokio = ["zbus/tokio", "atspi-common/tokio"]
 unstable-traits = ["atspi-macros/unstable_atspi_proxy_macro", "dep:async-trait"]
 
 [dependencies]
-atspi-common = { path = "../atspi-common", version = "0.1.0", default-features = false }
+atspi-common = { path = "../atspi-common", version = "0.2.0", default-features = false }
 atspi-macros = { version = "0.4.0", path = "../atspi-macros" }
 enumflags2.workspace = true
 serde = { version = "^1.0", default-features = false, features = ["derive"] }

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -30,7 +30,7 @@ client-tokio = ["atspi-client/tokio", "client"]
 unstable-proxy-traits = ["atspi-proxies/unstable-traits"]
 
 [dependencies]
-atspi-common = { path = "../atspi-common", version = "0.1.0", default-features = false }
+atspi-common = { path = "../atspi-common", version = "0.2.0", default-features = false }
 atspi-proxies = { path = "../atspi-proxies", version = "0.1.0", default-features = false, optional = true }
 atspi-connection = { path = "../atspi-connection", version = "0.1.0", default-features = false, optional = true }
 atspi-client = { path = "../atspi-client", version = "0.1.0", default-features = false, optional = true }


### PR DESCRIPTION
Add a CI check for the common crate, mandating that it at least compiles for WASM. We can not run the tests for a WASM target because many tests require the use of `zbus`, which can not compile to WASM, yet.

This PR is also blocked on #91 .