### PR TITLE
Session status

### DIFF
--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -612,7 +612,9 @@ impl TryFrom<&zbus::Message> for Event {
 			},
 			// Atspi / Qspi signature
 			"siiva{sv}" | "siiv(so)" => {
-				let Some(interface) = msg.interface() else {  return Err(AtspiError::MissingInterface);  };
+				let Some(interface) = msg.interface() else {
+					return Err(AtspiError::MissingInterface);
+				};
 				match interface.as_str() {
 					"org.a11y.atspi.Event.Document" => {
 						Ok(Event::Document(DocumentEvents::try_from(msg)?))

--- a/atspi-connection/src/lib.rs
+++ b/atspi-connection/src/lib.rs
@@ -333,3 +333,31 @@ pub async fn set_session_accessibility(status: bool) -> std::result::Result<(), 
 	}
 	Ok(())
 }
+
+/// Read the `IsEnabled` accessibility status property on the session bus.
+///
+/// # Examples
+/// ```rust
+///     # tokio_test::block_on( async {
+///     let status = atspi_connection::read_session_accessibility().await;
+///
+///     // The status is either true or false
+///        assert!(status.is_ok());
+///     # });
+/// ```
+///
+/// # Errors
+///
+/// - If no connection with the session bus could be established.
+/// - If creation of a [`atspi_proxies::bus::StatusProxy`] fails.
+/// - If the `IsEnabled` property cannot be read.
+pub async fn read_session_accessibility() -> AtspiResult<bool> {
+	// Get a connection to the session bus.
+	let session = Box::pin(zbus::Connection::session()).await?;
+
+	// Acquire a `StatusProxy` for the session bus.
+	let status_proxy = StatusProxy::new(&session).await?;
+
+	// Read the `IsEnabled` property.
+	status_proxy.is_enabled().await.map_err(Into::into)
+}

--- a/atspi-connection/src/lib.rs
+++ b/atspi-connection/src/lib.rs
@@ -194,7 +194,7 @@ impl AccessibilityConnection {
 	}
 
 	/// Add a registry event.
-	/// This tells accessible applications which events should be forwarded to the accessbility bus.
+	/// This tells accessible applications which events should be forwarded to the accessibility bus.
 	/// This is called by [`Self::register_event`].
 	///
 	/// ```rust
@@ -217,7 +217,7 @@ impl AccessibilityConnection {
 	}
 
 	/// Remove a registry event.
-	/// This tells accessible applications which events should be forwarded to the accessbility bus.
+	/// This tells accessible applications which events should be forwarded to the accessibility bus.
 	/// This is called by [`Self::deregister_event`].
 	/// It may be called like so:
 	///
@@ -240,7 +240,7 @@ impl AccessibilityConnection {
 		Ok(())
 	}
 
-	/// This calls [`Self::add_registry_event`] and [`Self::add_match_rule`], two components necessary to receive accessiblity events.
+	/// This calls [`Self::add_registry_event`] and [`Self::add_match_rule`], two components necessary to receive accessibility events.
 	/// # Errors
 	/// This will only fail if [`Self::add_registry_event`[ or [`Self::add_match_rule`] fails.
 	pub async fn register_event<T: HasRegistryEventString + HasMatchRule>(
@@ -251,7 +251,7 @@ impl AccessibilityConnection {
 		Ok(())
 	}
 
-	/// This calls [`Self::remove_registry_event`] and [`Self::remove_match_rule`], two components necessary to receive accessiblity events.
+	/// This calls [`Self::remove_registry_event`] and [`Self::remove_match_rule`], two components necessary to receive accessibility events.
 	/// # Errors
 	/// This will only fail if [`Self::remove_registry_event`] or [`Self::remove_match_rule`] fails.
 	pub async fn deregister_event<T: HasRegistryEventString + HasMatchRule>(
@@ -267,6 +267,7 @@ impl AccessibilityConnection {
 	pub fn connection(&self) -> &zbus::Connection {
 		self.registry.connection()
 	}
+
 	/// Send an event over the accessibility bus.
 	/// This converts the event into a [`zbus::Message`] using the [`GenericEvent`] trait.
 	///
@@ -325,7 +326,7 @@ pub async fn set_session_accessibility(status: bool) -> std::result::Result<(), 
 	// Get a connection to the session bus.
 	let session = Box::pin(zbus::Connection::session()).await?;
 
-	// Aqcuire a `StatusProxy` for the session bus.
+	// Acquire a `StatusProxy` for the session bus.
 	let status_proxy = StatusProxy::new(&session).await?;
 
 	if status_proxy.is_enabled().await? != status {

--- a/atspi-connection/src/lib.rs
+++ b/atspi-connection/src/lib.rs
@@ -14,6 +14,8 @@ use futures_lite::stream::{Stream, StreamExt};
 use std::ops::Deref;
 use zbus::{fdo::DBusProxy, Address, MatchRule, MessageStream, MessageType};
 
+pub type AtspiResult<T> = std::result::Result<T, AtspiError>;
+
 /// A connection to the at-spi bus
 pub struct AccessibilityConnection {
 	registry: RegistryProxy<'static>,

--- a/atspi-proxies/examples/focused-async-std.rs
+++ b/atspi-proxies/examples/focused-async-std.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 	tokio::pin!(events);
 
 	while let Some(Ok(ev)) = events.next().await {
-		let Ok(change)  = <StateChangedEvent>::try_from(ev) else { continue };
+		let Ok(change) = <StateChangedEvent>::try_from(ev) else { continue };
 
 		if change.state == "focused" && change.enabled == 1 {
 			let bus_name = change.item.name.clone();

--- a/atspi-proxies/examples/focused-tokio.rs
+++ b/atspi-proxies/examples/focused-tokio.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 	tokio::pin!(events);
 
 	while let Some(Ok(ev)) = events.next().await {
-		let Ok(change)  = <StateChangedEvent>::try_from(ev) else { continue };
+		let Ok(change) = <StateChangedEvent>::try_from(ev) else { continue };
 
 		if change.state == "focused" && change.enabled == 1 {
 			let bus_name = change.item.name.clone();


### PR DESCRIPTION
This PR features commits which:

- Add `read_session_accessibility`
- Add `AtspiResult<T>`
- Fixes spelling and formats.

We already have a means to set session accessibility status 
with: `set_session_accessibility`, but no way to read its status.

This adds `read_session_accessibility`

Applications can determine whether to activate their at-spi2 features by
reading the `IsEnabled` property on the `Status` proxy.

Reading `false` when an AT is running should be considered a bug.

AT's should set the `IsEnabled` property before anything else.

Reference: [Freedesktop AT-SPI2 FAQ](https://www.freedesktop.org/wiki/Accessibility/AT-SPI2/)