### PR TITLE
Remove `ObjectPair` and `(String, OwnedObejctPath)`, replace with `Accessible`

### DIFF
--- a/atspi-common/src/accessible.rs
+++ b/atspi-common/src/accessible.rs
@@ -1,7 +1,6 @@
-use crate::{AtspiError, events::signatures_are_eq};
+use crate::events::signatures_are_eq;
 use serde::{Serialize, Deserialize};
 use zvariant::{Type, OwnedObjectPath, ObjectPath, Signature};
-use zbus_names::{OwnedBusName, BusName};
 
 pub const ACCESSIBLE_PAIR_SIGNATURE: Signature<'_> = Signature::from_static_str_unchecked("(so)");
 

--- a/atspi-common/src/accessible.rs
+++ b/atspi-common/src/accessible.rs
@@ -1,6 +1,6 @@
 use crate::events::signatures_are_eq;
-use serde::{Serialize, Deserialize};
-use zvariant::{Type, OwnedObjectPath, ObjectPath, Signature};
+use serde::{Deserialize, Serialize};
+use zvariant::{ObjectPath, OwnedObjectPath, Signature, Type};
 
 pub const ACCESSIBLE_PAIR_SIGNATURE: Signature<'_> = Signature::from_static_str_unchecked("(so)");
 
@@ -54,5 +54,9 @@ impl Default for Accessible {
 
 #[test]
 fn test_accessible_signature() {
-	assert_eq!(Accessible::signature(), ACCESSIBLE_PAIR_SIGNATURE, "Accessible does not have the correct type.");
+	assert_eq!(
+		Accessible::signature(),
+		ACCESSIBLE_PAIR_SIGNATURE,
+		"Accessible does not have the correct type."
+	);
 }

--- a/atspi-common/src/accessible.rs
+++ b/atspi-common/src/accessible.rs
@@ -1,0 +1,59 @@
+use crate::{AtspiError, events::signatures_are_eq};
+use serde::{Serialize, Deserialize};
+use zvariant::{Type, OwnedObjectPath, ObjectPath, Signature};
+use zbus_names::{OwnedBusName, BusName};
+
+pub const ACCESSIBLE_PAIR_SIGNATURE: Signature<'_> = Signature::from_static_str_unchecked("(so)");
+
+// TODO: Try to make borrowed versions work,
+// check where the lifetimes of the borrow are tied to, see also: comment on `interface()` method
+// in `DefaultEvent` impl
+// then rename into Owned for this one.
+/// Owned Accessible type
+/// Emitted by `CacheRemove` and `Available`
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq, Hash)]
+pub struct Accessible {
+	pub name: String,
+	pub path: OwnedObjectPath,
+}
+impl TryFrom<zvariant::OwnedValue> for Accessible {
+	type Error = AtspiError;
+	fn try_from<'a>(value: zvariant::OwnedValue) -> Result<Self, Self::Error> {
+		match &*value {
+			zvariant::Value::Structure(s) => {
+				if !signatures_are_eq(&s.signature(), &ACCESSIBLE_PAIR_SIGNATURE) {
+					return Err(zvariant::Error::SignatureMismatch(s.signature(), format!("To turn a zvariant::Value into an atspi::Accessible, it must be of type {}", ACCESSIBLE_PAIR_SIGNATURE.as_str())).into());
+				}
+				let fields = s.fields();
+				let name: String =
+					fields.get(0).ok_or(zvariant::Error::IncorrectType)?.try_into()?;
+				let path_value: ObjectPath<'_> =
+					fields.get(1).ok_or(zvariant::Error::IncorrectType)?.try_into()?;
+				Ok(Accessible { name, path: path_value.into() })
+			}
+			_ => Err(zvariant::Error::IncorrectType.into()),
+		}
+	}
+}
+
+impl From<Accessible> for zvariant::Structure<'_> {
+	fn from(accessible: Accessible) -> Self {
+		(accessible.name.as_str().to_string(), accessible.path).into()
+	}
+}
+
+impl Default for Accessible {
+	fn default() -> Self {
+		Accessible {
+			name: ":0.0".into(),
+			path: ObjectPath::from_static_str("/org/a11y/atspi/accessible/null")
+				.unwrap()
+				.into(),
+		}
+	}
+}
+
+#[test]
+fn test_accessible_signature() {
+	assert_eq!(Accessible::signature(), ACCESSIBLE_PAIR_SIGNATURE, "Accessible does not have the correct type.");
+}

--- a/atspi-common/src/accessible.rs
+++ b/atspi-common/src/accessible.rs
@@ -17,12 +17,12 @@ pub struct Accessible {
 	pub path: OwnedObjectPath,
 }
 impl TryFrom<zvariant::OwnedValue> for Accessible {
-	type Error = AtspiError;
+	type Error = zvariant::Error;
 	fn try_from<'a>(value: zvariant::OwnedValue) -> Result<Self, Self::Error> {
 		match &*value {
 			zvariant::Value::Structure(s) => {
 				if !signatures_are_eq(&s.signature(), &ACCESSIBLE_PAIR_SIGNATURE) {
-					return Err(zvariant::Error::SignatureMismatch(s.signature(), format!("To turn a zvariant::Value into an atspi::Accessible, it must be of type {}", ACCESSIBLE_PAIR_SIGNATURE.as_str())).into());
+					return Err(zvariant::Error::SignatureMismatch(s.signature(), format!("To turn a zvariant::Value into an atspi::Accessible, it must be of type {}", ACCESSIBLE_PAIR_SIGNATURE.as_str())));
 				}
 				let fields = s.fields();
 				let name: String =
@@ -31,7 +31,7 @@ impl TryFrom<zvariant::OwnedValue> for Accessible {
 					fields.get(1).ok_or(zvariant::Error::IncorrectType)?.try_into()?;
 				Ok(Accessible { name, path: path_value.into() })
 			}
-			_ => Err(zvariant::Error::IncorrectType.into()),
+			_ => Err(zvariant::Error::IncorrectType),
 		}
 	}
 }

--- a/atspi-common/src/cache.rs
+++ b/atspi-common/src/cache.rs
@@ -4,7 +4,7 @@
 //! Source: `Cache.xml`.
 //!
 
-use crate::{InterfaceSet, ObjectPair, Role, StateSet};
+use crate::{InterfaceSet, Accessible, Role, StateSet};
 use serde::{Deserialize, Serialize};
 use zvariant::Type;
 
@@ -13,11 +13,11 @@ use zvariant::Type;
 #[derive(Clone, Debug, Serialize, Deserialize, Type, PartialEq, Eq, Hash)]
 pub struct CacheItem {
 	/// The accessible object (within the application)   (so)
-	pub object: ObjectPair,
+	pub object: Accessible,
 	/// The application (root object(?)    (so)
-	pub app: ObjectPair,
+	pub app: Accessible,
 	/// The parent object.  (so)
-	pub parent: ObjectPair,
+	pub parent: Accessible,
 	/// The accessbile index in parent.  i
 	pub index: i32,
 	/// Child count of the accessible  i
@@ -36,9 +36,18 @@ pub struct CacheItem {
 impl Default for CacheItem {
 	fn default() -> Self {
 		Self {
-			object: (":0.0".to_string(), "/org/a11y/atspi/accessible/object".try_into().unwrap()),
-			app: (":0.0".to_string(), "/org/a11y/atspi/accessible/application".try_into().unwrap()),
-			parent: (":0.0".to_string(), "/org/a11y/atspi/accessible/parent".try_into().unwrap()),
+			object: Accessible {
+				name: ":0.0".into(),
+				path: "/org/a11y/atspi/accessible/object".try_into().unwrap()
+			},
+			app: Accessible {
+				name: ":0.0".into(),
+				path: "/org/a11y/atspi/accessible/application".try_into().unwrap()
+			},
+			parent: Accessible {
+				name: ":0.0".into(),
+				path: "/org/a11y/atspi/accessible/parent".try_into().unwrap()
+			},
 			index: 0,
 			children: 0,
 			ifaces: InterfaceSet::empty(),
@@ -63,13 +72,13 @@ fn zvariant_type_signature_of_cache_item() {
 #[derive(Clone, Debug, Serialize, Deserialize, Type, PartialEq, Eq, Hash)]
 pub struct LegacyCacheItem {
 	/// The accessible object (within the application)   (so)
-	pub object: ObjectPair,
+	pub object: Accessible,
 	/// The application (root object(?)    (so)
-	pub app: ObjectPair,
+	pub app: Accessible,
 	/// The parent object.  (so)
-	pub parent: ObjectPair,
-	/// List of references to the accessible's children.  (so)
-	pub children: Vec<ObjectPair>,
+	pub parent: Accessible,
+	/// List of references to the accessible's children.  a(so)
+	pub children: Vec<Accessible>,
 	/// The exposed interfece(s) set.  as
 	pub ifaces: InterfaceSet,
 	/// The short localized name.  s
@@ -84,9 +93,18 @@ pub struct LegacyCacheItem {
 impl Default for LegacyCacheItem {
 	fn default() -> Self {
 		Self {
-			object: (":0.0".to_string(), "/org/a11y/atspi/accessible/object".try_into().unwrap()),
-			app: (":0.0".to_string(), "/org/a11y/atspi/accessible/application".try_into().unwrap()),
-			parent: (":0.0".to_string(), "/org/a11y/atspi/accessible/parent".try_into().unwrap()),
+			object: Accessible {
+				name: ":0.0".into(),
+				path: "/org/a11y/atspi/accessible/object".try_into().unwrap(),
+			},
+			app: Accessible {
+				name: ":0.0".into(),
+				path: "/org/a11y/atspi/accessible/application".try_into().unwrap(),
+			},
+			parent: Accessible {
+				name: ":0.0".into(),
+				path: "/org/a11y/atspi/accessible/parent".try_into().unwrap(),
+			},
 			children: Vec::new(),
 			ifaces: InterfaceSet::empty(),
 			short_name: String::default(),

--- a/atspi-common/src/cache.rs
+++ b/atspi-common/src/cache.rs
@@ -4,7 +4,7 @@
 //! Source: `Cache.xml`.
 //!
 
-use crate::{InterfaceSet, Accessible, Role, StateSet};
+use crate::{Accessible, InterfaceSet, Role, StateSet};
 use serde::{Deserialize, Serialize};
 use zvariant::Type;
 
@@ -38,15 +38,15 @@ impl Default for CacheItem {
 		Self {
 			object: Accessible {
 				name: ":0.0".into(),
-				path: "/org/a11y/atspi/accessible/object".try_into().unwrap()
+				path: "/org/a11y/atspi/accessible/object".try_into().unwrap(),
 			},
 			app: Accessible {
 				name: ":0.0".into(),
-				path: "/org/a11y/atspi/accessible/application".try_into().unwrap()
+				path: "/org/a11y/atspi/accessible/application".try_into().unwrap(),
 			},
 			parent: Accessible {
 				name: ":0.0".into(),
-				path: "/org/a11y/atspi/accessible/parent".try_into().unwrap()
+				path: "/org/a11y/atspi/accessible/parent".try_into().unwrap(),
 			},
 			index: 0,
 			children: 0,

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -65,8 +65,8 @@ impl GenericEvent<'_> for LoadCompleteEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -89,8 +89,8 @@ impl GenericEvent<'_> for ReloadEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -113,8 +113,8 @@ impl GenericEvent<'_> for LoadStoppedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -137,8 +137,8 @@ impl GenericEvent<'_> for ContentChangedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -161,8 +161,8 @@ impl GenericEvent<'_> for AttributesChangedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -185,8 +185,8 @@ impl GenericEvent<'_> for PageChangedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -3,7 +3,6 @@ use crate::{
 	events::{Accessible, EventBodyOwned, GenericEvent, HasMatchRule, HasRegistryEventString},
 	Event,
 };
-use zbus_names::UniqueName;
 use zvariant::ObjectPath;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -34,8 +34,8 @@ impl GenericEvent<'_> for FocusEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -3,7 +3,6 @@ use crate::{
 	events::{Accessible, EventBodyOwned, GenericEvent, HasMatchRule, HasRegistryEventString},
 	Event,
 };
-use zbus_names::UniqueName;
 use zvariant::ObjectPath;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -37,8 +37,8 @@ impl GenericEvent<'_> for ModifiersEvent {
 	fn build(item: Accessible, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, previous_modifiers: body.detail1, current_modifiers: body.detail2 })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -3,7 +3,6 @@ use crate::{
 	events::{Accessible, EventBodyOwned, GenericEvent, HasMatchRule, HasRegistryEventString},
 	Event,
 };
-use zbus_names::UniqueName;
 use zvariant::ObjectPath;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -656,11 +656,12 @@ pub trait HasRegistryEventString {
 #[cfg(test)]
 mod tests {
 	use atspi_common::events::{
-		AddAccessibleEvent, CacheEvents, Event, EventBodyOwned, EventBodyQT,
-		RemoveAccessibleEvent, ATSPI_EVENT_SIGNATURE,
-		CACHE_ADD_SIGNATURE, QSPI_EVENT_SIGNATURE,
+		AddAccessibleEvent, CacheEvents, Event, EventBodyOwned, EventBodyQT, RemoveAccessibleEvent,
+		ATSPI_EVENT_SIGNATURE, CACHE_ADD_SIGNATURE, QSPI_EVENT_SIGNATURE,
 	};
-	use atspi_common::{Accessible, accessible::ACCESSIBLE_PAIR_SIGNATURE, CacheItem, InterfaceSet, Role, StateSet};
+	use atspi_common::{
+		accessible::ACCESSIBLE_PAIR_SIGNATURE, Accessible, CacheItem, InterfaceSet, Role, StateSet,
+	};
 	use atspi_connection::AccessibilityConnection;
 	use std::{collections::HashMap, time::Duration};
 	use tokio_stream::StreamExt;
@@ -803,7 +804,8 @@ mod tests {
 				},
 				app: Accessible {
 					name: ":1.1".to_string(),
-					path: OwnedObjectPath::try_from("/org/a11y/atspi/accessible/application").unwrap(),
+					path: OwnedObjectPath::try_from("/org/a11y/atspi/accessible/application")
+						.unwrap(),
 				},
 				parent: Accessible {
 					name: ":1.1".to_string(),

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -32,7 +32,7 @@ use zbus_names::{OwnedUniqueName, UniqueName};
 use zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Signature, Type, Value};
 
 use crate::{
-	accessible::{Accessible, ACCESSIBLE_PAIR_SIGNATURE},
+	accessible::Accessible,
 	cache::{CacheItem, LegacyCacheItem},
 	events::{
 		document::DocumentEvents, focus::FocusEvents, keyboard::KeyboardEvents, mouse::MouseEvents,
@@ -42,6 +42,7 @@ use crate::{
 };
 //use atspi_macros::try_from_zbus_message;
 
+#[must_use]
 pub fn signatures_are_eq(lhs: &Signature, rhs: &Signature) -> bool {
 	fn has_outer_parentheses(bytes: &[u8]) -> bool {
 		bytes.starts_with(&[b'('])

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -20,7 +20,6 @@ pub mod window;
 pub const ATSPI_EVENT_SIGNATURE: Signature<'_> =
 	Signature::from_static_str_unchecked("(siiva{sv})");
 pub const QSPI_EVENT_SIGNATURE: Signature<'_> = Signature::from_static_str_unchecked("(siiv(so))");
-pub const ACCESSIBLE_PAIR_SIGNATURE: Signature<'_> = Signature::from_static_str_unchecked("(so)");
 pub const EVENT_LISTENER_SIGNATURE: Signature<'_> = Signature::from_static_str_unchecked("(ss)");
 pub const CACHE_ADD_SIGNATURE: Signature<'_> =
 	Signature::from_static_str_unchecked("((so)(so)(so)iiassusau)");
@@ -33,6 +32,7 @@ use zbus_names::{OwnedUniqueName, UniqueName};
 use zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Signature, Type, Value};
 
 use crate::{
+	accessible::{Accessible, ACCESSIBLE_PAIR_SIGNATURE},
 	cache::{CacheItem, LegacyCacheItem},
 	events::{
 		document::DocumentEvents, focus::FocusEvents, keyboard::KeyboardEvents, mouse::MouseEvents,
@@ -42,7 +42,7 @@ use crate::{
 };
 //use atspi_macros::try_from_zbus_message;
 
-fn signatures_are_eq(lhs: &Signature, rhs: &Signature) -> bool {
+pub fn signatures_are_eq(lhs: &Signature, rhs: &Signature) -> bool {
 	fn has_outer_parentheses(bytes: &[u8]) -> bool {
 		bytes.starts_with(&[b'('])
 			&& bytes.ends_with(&[b')'])
@@ -297,37 +297,6 @@ impl GenericEvent<'_> for RemoveAccessibleEvent {
 impl_from_dbus_message!(RemoveAccessibleEvent);
 impl_to_dbus_message!(RemoveAccessibleEvent);
 
-// TODO: Try to make borrowed versions work,
-// check where the lifetimes of the borrow are tied to, see also: comment on `interface()` method
-// in `DefaultEvent` impl
-// then rename into Owned for this one.
-/// Owned Accessible type
-/// Emitted by `CacheRemove` and `Available`
-#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq, Hash)]
-pub struct Accessible {
-	pub name: String,
-	pub path: OwnedObjectPath,
-}
-impl TryFrom<zvariant::OwnedValue> for Accessible {
-	type Error = AtspiError;
-	fn try_from<'a>(value: zvariant::OwnedValue) -> Result<Self, Self::Error> {
-		match &*value {
-			zvariant::Value::Structure(s) => {
-				if !signatures_are_eq(&s.signature(), &ACCESSIBLE_PAIR_SIGNATURE) {
-					return Err(zvariant::Error::SignatureMismatch(s.signature(), format!("To turn a zvariant::Value into an atspi::Accessible, it must be of type {}", ACCESSIBLE_PAIR_SIGNATURE.as_str())).into());
-				}
-				let fields = s.fields();
-				let name: String =
-					fields.get(0).ok_or(zvariant::Error::IncorrectType)?.try_into()?;
-				let path_value: ObjectPath<'_> =
-					fields.get(1).ok_or(zvariant::Error::IncorrectType)?.try_into()?;
-				Ok(Accessible { name, path: path_value.into() })
-			}
-			_ => Err(zvariant::Error::IncorrectType.into()),
-		}
-	}
-}
-
 #[cfg(test)]
 pub mod accessible_deserialization_tests {
 	use crate::events::Accessible;
@@ -355,21 +324,6 @@ pub mod accessible_deserialization_tests {
 	fn try_from_value() {}
 }
 
-impl From<Accessible> for zvariant::Structure<'_> {
-	fn from(accessible: Accessible) -> Self {
-		(accessible.name.as_str().to_string(), accessible.path).into()
-	}
-}
-impl Default for Accessible {
-	fn default() -> Self {
-		Accessible {
-			name: ":0.0".into(),
-			path: ObjectPath::from_static_str("/org/a11y/atspi/accessible/null")
-				.unwrap()
-				.into(),
-		}
-	}
-}
 #[cfg(test)]
 pub mod accessible_tests {
 	use super::Accessible;
@@ -701,11 +655,11 @@ pub trait HasRegistryEventString {
 #[cfg(test)]
 mod tests {
 	use atspi_common::events::{
-		Accessible, AddAccessibleEvent, CacheEvents, Event, EventBodyOwned, EventBodyQT,
-		RemoveAccessibleEvent, ACCESSIBLE_PAIR_SIGNATURE, ATSPI_EVENT_SIGNATURE,
+		AddAccessibleEvent, CacheEvents, Event, EventBodyOwned, EventBodyQT,
+		RemoveAccessibleEvent, ATSPI_EVENT_SIGNATURE,
 		CACHE_ADD_SIGNATURE, QSPI_EVENT_SIGNATURE,
 	};
-	use atspi_common::{CacheItem, InterfaceSet, Role, StateSet};
+	use atspi_common::{Accessible, accessible::ACCESSIBLE_PAIR_SIGNATURE, CacheItem, InterfaceSet, Role, StateSet};
 	use atspi_connection::AccessibilityConnection;
 	use std::{collections::HashMap, time::Duration};
 	use tokio_stream::StreamExt;

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -356,11 +356,6 @@ impl TryFrom<&zbus::Message> for Accessible {
 	}
 }
 
-#[test]
-fn test_accessible_signature() {
-	assert_eq_signatures!(&Accessible::signature(), &ACCESSIBLE_PAIR_SIGNATURE);
-}
-
 #[cfg(feature = "zbus")]
 impl TryFrom<&zbus::Message> for EventBodyOwned {
 	type Error = AtspiError;
@@ -666,7 +661,6 @@ mod tests {
 	use std::{collections::HashMap, time::Duration};
 	use tokio_stream::StreamExt;
 	use zbus::MessageBuilder;
-	use zbus_names::OwnedUniqueName;
 	use zvariant::{ObjectPath, OwnedObjectPath, Signature, Type};
 
 	use super::signatures_are_eq;

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -796,18 +796,18 @@ mod tests {
 			let unique_bus_name = atspi.connection().unique_name().unwrap();
 
 			let add_body = CacheItem {
-				object: (
-					":1.1".to_string(),
-					OwnedObjectPath::try_from("/org/a11y/atspi/accessible/object").unwrap(),
-				),
-				app: (
-					":1.1".to_string(),
-					OwnedObjectPath::try_from("/org/a11y/atspi/accessible/application").unwrap(),
-				),
-				parent: (
-					":1.1".to_string(),
-					OwnedObjectPath::try_from("/org/a11y/atspi/accessible/parent").unwrap(),
-				),
+				object: Accessible {
+					name: ":1.1".to_string(),
+					path: OwnedObjectPath::try_from("/org/a11y/atspi/accessible/object").unwrap(),
+				},
+				app: Accessible {
+					name: ":1.1".to_string(),
+					path: OwnedObjectPath::try_from("/org/a11y/atspi/accessible/application").unwrap(),
+				},
+				parent: Accessible {
+					name: ":1.1".to_string(),
+					path: OwnedObjectPath::try_from("/org/a11y/atspi/accessible/parent").unwrap(),
+				},
 				index: 0,
 				children: 0,
 				ifaces: InterfaceSet::empty(),
@@ -851,15 +851,15 @@ mod tests {
 								node_added: cache_item,
 							})) => {
 								assert_eq!(
-									cache_item.object.1.as_str(),
+									cache_item.object.path.as_str(),
 									"/org/a11y/atspi/accessible/object"
 								);
 								assert_eq!(
-									cache_item.app.1.as_str(),
+									cache_item.app.path.as_str(),
 									"/org/a11y/atspi/accessible/application"
 								);
 								assert_eq!(
-									cache_item.parent.1.as_str(),
+									cache_item.parent.path.as_str(),
 									"/org/a11y/atspi/accessible/parent"
 								);
 								break;

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -3,7 +3,6 @@ use crate::{
 	events::{Accessible, EventBodyOwned, GenericEvent, HasMatchRule, HasRegistryEventString},
 	Event,
 };
-use zbus_names::UniqueName;
 use zvariant::ObjectPath;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -53,8 +53,8 @@ impl GenericEvent<'_> for AbsEvent {
 	fn build(item: Accessible, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, x: body.detail1, y: body.detail2 })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -77,8 +77,8 @@ impl GenericEvent<'_> for RelEvent {
 	fn build(item: Accessible, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, x: body.detail1, y: body.detail2 })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -101,8 +101,8 @@ impl GenericEvent<'_> for ButtonEvent {
 	fn build(item: Accessible, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, detail: body.kind, mouse_x: body.detail1, mouse_y: body.detail2 })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -3,7 +3,6 @@ use crate::{
 	events::{Accessible, EventBodyOwned, GenericEvent, HasMatchRule, HasRegistryEventString},
 	Event, State,
 };
-use zbus_names::UniqueName;
 use zvariant::ObjectPath;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -174,8 +174,8 @@ impl GenericEvent<'_> for PropertyChangeEvent {
 	fn build(item: Accessible, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, property: body.kind, value: body.any_data.try_into()? })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -198,8 +198,8 @@ impl GenericEvent<'_> for BoundsChangedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -222,8 +222,8 @@ impl GenericEvent<'_> for LinkSelectedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -246,8 +246,8 @@ impl GenericEvent<'_> for StateChangedEvent {
 	fn build(item: Accessible, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, state: body.kind.into(), enabled: body.detail1 })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -275,8 +275,8 @@ impl GenericEvent<'_> for ChildrenChangedEvent {
 			child: body.any_data.try_into()?,
 		})
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -299,8 +299,8 @@ impl GenericEvent<'_> for VisibleDataChangedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -323,8 +323,8 @@ impl GenericEvent<'_> for SelectionChangedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -347,8 +347,8 @@ impl GenericEvent<'_> for ModelChangedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -371,8 +371,8 @@ impl GenericEvent<'_> for ActiveDescendantChangedEvent {
 	fn build(item: Accessible, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, child: body.any_data.try_into()? })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -395,8 +395,8 @@ impl GenericEvent<'_> for AnnouncementEvent {
 	fn build(item: Accessible, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, text: body.kind })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -419,8 +419,8 @@ impl GenericEvent<'_> for AttributesChangedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -443,8 +443,8 @@ impl GenericEvent<'_> for RowInsertedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -467,8 +467,8 @@ impl GenericEvent<'_> for RowReorderedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -491,8 +491,8 @@ impl GenericEvent<'_> for RowDeletedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -515,8 +515,8 @@ impl GenericEvent<'_> for ColumnInsertedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -539,8 +539,8 @@ impl GenericEvent<'_> for ColumnReorderedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -563,8 +563,8 @@ impl GenericEvent<'_> for ColumnDeletedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -587,8 +587,8 @@ impl GenericEvent<'_> for TextBoundsChangedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -611,8 +611,8 @@ impl GenericEvent<'_> for TextSelectionChangedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -641,8 +641,8 @@ impl GenericEvent<'_> for TextChangedEvent {
 			text: body.any_data.try_into()?,
 		})
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -665,8 +665,8 @@ impl GenericEvent<'_> for TextAttributesChangedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -689,8 +689,8 @@ impl GenericEvent<'_> for TextCaretMovedEvent {
 	fn build(item: Accessible, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, position: body.detail1 })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -59,8 +59,8 @@ impl GenericEvent<'_> for LineChangedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -83,8 +83,8 @@ impl GenericEvent<'_> for ColumnCountChangedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -107,8 +107,8 @@ impl GenericEvent<'_> for LineCountChangedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -131,8 +131,8 @@ impl GenericEvent<'_> for ApplicationChangedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -155,8 +155,8 @@ impl GenericEvent<'_> for CharWidthChangedEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -3,7 +3,6 @@ use crate::{
 	events::{Accessible, EventBodyOwned, GenericEvent, HasMatchRule, HasRegistryEventString},
 	Event,
 };
-use zbus_names::UniqueName;
 use zvariant::ObjectPath;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -3,7 +3,6 @@ use crate::{
 	events::{Accessible, EventBodyOwned, GenericEvent, HasMatchRule, HasRegistryEventString},
 	Event,
 };
-use zbus_names::UniqueName;
 use zvariant::ObjectPath;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -143,8 +143,8 @@ impl GenericEvent<'_> for PropertyChangeEvent {
 	fn build(item: Accessible, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, property: body.kind })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -167,8 +167,8 @@ impl GenericEvent<'_> for MinimizeEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -191,8 +191,8 @@ impl GenericEvent<'_> for MaximizeEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -215,8 +215,8 @@ impl GenericEvent<'_> for RestoreEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -239,8 +239,8 @@ impl GenericEvent<'_> for CloseEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -263,8 +263,8 @@ impl GenericEvent<'_> for CreateEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -287,8 +287,8 @@ impl GenericEvent<'_> for ReparentEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -311,8 +311,8 @@ impl GenericEvent<'_> for DesktopCreateEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -335,8 +335,8 @@ impl GenericEvent<'_> for DesktopDestroyEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -359,8 +359,8 @@ impl GenericEvent<'_> for DestroyEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -383,8 +383,8 @@ impl GenericEvent<'_> for ActivateEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -407,8 +407,8 @@ impl GenericEvent<'_> for DeactivateEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -431,8 +431,8 @@ impl GenericEvent<'_> for RaiseEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -455,8 +455,8 @@ impl GenericEvent<'_> for LowerEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -479,8 +479,8 @@ impl GenericEvent<'_> for MoveEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -503,8 +503,8 @@ impl GenericEvent<'_> for ResizeEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -527,8 +527,8 @@ impl GenericEvent<'_> for ShadeEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -551,8 +551,8 @@ impl GenericEvent<'_> for UUshadeEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -575,8 +575,8 @@ impl GenericEvent<'_> for RestyleEvent {
 	fn build(item: Accessible, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> UniqueName<'_> {
-		self.item.name.clone().into()
+	fn sender(&self) -> String {
+		self.item.name.clone()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()

--- a/atspi-common/src/lib.rs
+++ b/atspi-common/src/lib.rs
@@ -26,10 +26,6 @@ pub use relation_type::RelationType;
 use serde::{Deserialize, Serialize};
 use zvariant::Type;
 
-/// A pair of (`sender`, `object path with id`) which constitutes the fundemental parts of an Accessible object in `atspi`.
-/// NOTE: If you update the name of this type alias, also update the constant in `atspi_macros::OBJECT_PAIR_NAME`.
-pub type ObjectPair = (String, zvariant::OwnedObjectPath);
-
 pub type MatchArgs<'a> = (
 	&'a [i32],
 	MatchType,

--- a/atspi-common/src/lib.rs
+++ b/atspi-common/src/lib.rs
@@ -6,6 +6,8 @@ extern crate static_assertions;
 #[macro_use]
 pub(crate) mod macros;
 
+pub mod accessible;
+pub use accessible::Accessible;
 pub mod interface;
 pub use interface::{Interface, InterfaceSet};
 pub mod state;

--- a/atspi-proxies/src/accessible.rs
+++ b/atspi-proxies/src/accessible.rs
@@ -12,7 +12,7 @@
 
 use crate::atspi_proxy;
 use crate::AtspiError;
-use atspi_common::{InterfaceSet, Accessible, RelationType, Role, StateSet};
+use atspi_common::{Accessible, InterfaceSet, RelationType, Role, StateSet};
 
 #[atspi_proxy(interface = "org.a11y.atspi.Accessible", assume_defaults = true)]
 trait Accessible {
@@ -80,7 +80,7 @@ impl TryFrom<AccessibleProxy<'_>> for Accessible {
 	fn try_from(proxy: AccessibleProxy<'_>) -> Result<Accessible, Self::Error> {
 		Ok(Accessible {
 			name: proxy.destination().to_string(),
-			path: proxy.path().to_string().try_into()?
+			path: proxy.path().to_string().try_into()?,
 		})
 	}
 }
@@ -89,7 +89,7 @@ impl TryFrom<&AccessibleProxy<'_>> for Accessible {
 	fn try_from(proxy: &AccessibleProxy<'_>) -> Result<Accessible, Self::Error> {
 		Ok(Accessible {
 			name: proxy.destination().to_string(),
-			path: proxy.path().to_string().try_into()?
+			path: proxy.path().to_string().try_into()?,
 		})
 	}
 }

--- a/atspi-proxies/src/accessible.rs
+++ b/atspi-proxies/src/accessible.rs
@@ -12,21 +12,21 @@
 
 use crate::atspi_proxy;
 use crate::AtspiError;
-use atspi_common::{InterfaceSet, ObjectPair, RelationType, Role, StateSet};
+use atspi_common::{InterfaceSet, Accessible, RelationType, Role, StateSet};
 
 #[atspi_proxy(interface = "org.a11y.atspi.Accessible", assume_defaults = true)]
 trait Accessible {
 	/// GetApplication method
-	fn get_application(&self) -> zbus::Result<ObjectPair>;
+	fn get_application(&self) -> zbus::Result<Accessible>;
 
 	/// GetAttributes method
 	fn get_attributes(&self) -> zbus::Result<std::collections::HashMap<String, String>>;
 
 	/// GetChildAtIndex method
-	fn get_child_at_index(&self, index: i32) -> zbus::Result<ObjectPair>;
+	fn get_child_at_index(&self, index: i32) -> zbus::Result<Accessible>;
 
 	/// GetChildren method
-	fn get_children(&self) -> zbus::Result<Vec<ObjectPair>>;
+	fn get_children(&self) -> zbus::Result<Vec<Accessible>>;
 
 	/// GetIndexInParent method; this will give an index between 0 and n, where n is the number of children in the parent.
 	fn get_index_in_parent(&self) -> zbus::Result<i32>;
@@ -38,7 +38,7 @@ trait Accessible {
 	fn get_localized_role_name(&self) -> zbus::Result<String>;
 
 	/// GetRelationSet method
-	fn get_relation_set(&self) -> zbus::Result<Vec<(RelationType, Vec<ObjectPair>)>>;
+	fn get_relation_set(&self) -> zbus::Result<Vec<(RelationType, Vec<Accessible>)>>;
 
 	/// GetRole method
 	fn get_role(&self) -> zbus::Result<Role>;
@@ -72,19 +72,25 @@ trait Accessible {
 
 	/// Parent property
 	#[dbus_proxy(property)]
-	fn parent(&self) -> zbus::Result<ObjectPair>;
+	fn parent(&self) -> zbus::Result<Accessible>;
 }
 
-impl TryFrom<AccessibleProxy<'_>> for ObjectPair {
+impl TryFrom<AccessibleProxy<'_>> for Accessible {
 	type Error = AtspiError;
-	fn try_from(proxy: AccessibleProxy<'_>) -> Result<ObjectPair, Self::Error> {
-		Ok((proxy.destination().to_string(), proxy.path().to_string().try_into()?))
+	fn try_from(proxy: AccessibleProxy<'_>) -> Result<Accessible, Self::Error> {
+		Ok(Accessible {
+			name: proxy.destination().to_string(),
+			path: proxy.path().to_string().try_into()?
+		})
 	}
 }
-impl TryFrom<&AccessibleProxy<'_>> for ObjectPair {
+impl TryFrom<&AccessibleProxy<'_>> for Accessible {
 	type Error = AtspiError;
-	fn try_from(proxy: &AccessibleProxy<'_>) -> Result<ObjectPair, Self::Error> {
-		Ok((proxy.destination().to_string(), proxy.path().to_string().try_into()?))
+	fn try_from(proxy: &AccessibleProxy<'_>) -> Result<Accessible, Self::Error> {
+		Ok(Accessible {
+			name: proxy.destination().to_string(),
+			path: proxy.path().to_string().try_into()?
+		})
 	}
 }
 

--- a/atspi-proxies/src/collection.rs
+++ b/atspi-proxies/src/collection.rs
@@ -13,12 +13,12 @@
 // this allow zbus to change the number of parameters in a function without setting off clippy
 
 use crate::atspi_proxy;
-use atspi_common::{MatchArgs, SortOrder, TreeTraversalType};
+use atspi_common::{Accessible, MatchArgs, SortOrder, TreeTraversalType};
 
 #[atspi_proxy(interface = "org.a11y.atspi.Collection", assume_defaults = true)]
 trait Collection {
 	/// GetActiveDescendant method
-	fn get_active_descendant(&self) -> zbus::Result<(String, zbus::zvariant::OwnedObjectPath)>;
+	fn get_active_descendant(&self) -> zbus::Result<Accessible>;
 
 	/* ROLE fields:
 	  &[i32]: AtspiStateSet,
@@ -38,7 +38,7 @@ trait Collection {
 		sortby: SortOrder,
 		count: i32,
 		traverse: bool,
-	) -> zbus::Result<Vec<(String, zbus::zvariant::OwnedObjectPath)>>;
+	) -> zbus::Result<Vec<Accessible>>;
 
 	/// GetMatchesFrom method
 	fn get_matches_from(
@@ -49,7 +49,7 @@ trait Collection {
 		tree: TreeTraversalType,
 		count: i32,
 		traverse: bool,
-	) -> zbus::Result<Vec<(String, zbus::zvariant::OwnedObjectPath)>>;
+	) -> zbus::Result<Vec<Accessible>>;
 
 	/// GetMatchesTo method
 	fn get_matches_to(
@@ -61,5 +61,5 @@ trait Collection {
 		limit_scope: bool,
 		count: i32,
 		traverse: bool,
-	) -> zbus::Result<Vec<(String, zbus::zvariant::OwnedObjectPath)>>;
+	) -> zbus::Result<Vec<Accessible>>;
 }

--- a/atspi-proxies/src/component.rs
+++ b/atspi-proxies/src/component.rs
@@ -11,7 +11,7 @@
 //!
 
 use crate::atspi_proxy;
-use atspi_common::{CoordType, Layer, ScrollType};
+use atspi_common::{Accessible, CoordType, Layer, ScrollType};
 
 #[atspi_proxy(interface = "org.a11y.atspi.Component", assume_defaults = true)]
 trait Component {
@@ -24,7 +24,7 @@ trait Component {
 		x: i32,
 		y: i32,
 		coord_type: CoordType,
-	) -> zbus::Result<(String, zbus::zvariant::OwnedObjectPath)>;
+	) -> zbus::Result<Accessible>;
 
 	/// GetAlpha method
 	fn get_alpha(&self) -> zbus::Result<f64>;

--- a/atspi-proxies/src/hyperlink.rs
+++ b/atspi-proxies/src/hyperlink.rs
@@ -11,11 +11,12 @@
 //!
 
 use crate::atspi_proxy;
+use atspi_common::Accessible;
 
 #[atspi_proxy(interface = "org.a11y.atspi.Hyperlink", assume_defaults = true)]
 trait Hyperlink {
 	/// GetObject method
-	fn get_object(&self, i: i32) -> zbus::Result<(String, zbus::zvariant::OwnedObjectPath)>;
+	fn get_object(&self, i: i32) -> zbus::Result<Accessible>;
 
 	/// GetURI method
 	fn get_uri(&self, i: i32) -> zbus::Result<String>;

--- a/atspi-proxies/src/hypertext.rs
+++ b/atspi-proxies/src/hypertext.rs
@@ -11,11 +11,12 @@
 //!
 
 use crate::atspi_proxy;
+use atspi_common::Accessible;
 
 #[atspi_proxy(interface = "org.a11y.atspi.Hypertext", assume_defaults = true)]
 trait Hypertext {
 	/// GetLink method
-	fn get_link(&self, link_index: i32) -> zbus::Result<(String, zbus::zvariant::OwnedObjectPath)>;
+	fn get_link(&self, link_index: i32) -> zbus::Result<Accessible>;
 
 	/// GetLinkIndex method
 	fn get_link_index(&self, character_index: i32) -> zbus::Result<i32>;

--- a/atspi-proxies/src/selection.rs
+++ b/atspi-proxies/src/selection.rs
@@ -11,6 +11,7 @@
 //!
 
 use crate::atspi_proxy;
+use atspi_common::Accessible;
 
 #[atspi_proxy(interface = "org.a11y.atspi.Selection", assume_defaults = true)]
 trait Selection {
@@ -27,7 +28,7 @@ trait Selection {
 	fn get_selected_child(
 		&self,
 		selected_child_index: i32,
-	) -> zbus::Result<(String, zbus::zvariant::OwnedObjectPath)>;
+	) -> zbus::Result<Accessible>;
 
 	/// IsChildSelected method
 	fn is_child_selected(&self, child_index: i32) -> zbus::Result<bool>;

--- a/atspi-proxies/src/selection.rs
+++ b/atspi-proxies/src/selection.rs
@@ -25,10 +25,7 @@ trait Selection {
 	fn deselect_selected_child(&self, selected_child_index: i32) -> zbus::Result<bool>;
 
 	/// GetSelectedChild method
-	fn get_selected_child(
-		&self,
-		selected_child_index: i32,
-	) -> zbus::Result<Accessible>;
+	fn get_selected_child(&self, selected_child_index: i32) -> zbus::Result<Accessible>;
 
 	/// IsChildSelected method
 	fn is_child_selected(&self, child_index: i32) -> zbus::Result<bool>;

--- a/atspi-proxies/src/socket.rs
+++ b/atspi-proxies/src/socket.rs
@@ -11,6 +11,7 @@
 //!
 
 use crate::atspi_proxy;
+use atspi_common::Accessible;
 
 #[atspi_proxy(
 	interface = "org.a11y.atspi.Socket",
@@ -22,7 +23,7 @@ trait Socket {
 	fn embed(
 		&self,
 		plug: &(&str, zbus::zvariant::ObjectPath<'_>),
-	) -> zbus::Result<(String, zbus::zvariant::OwnedObjectPath)>;
+	) -> zbus::Result<Accessible>;
 
 	/// Unembed method
 	fn unembed(&self, plug: &(&str, zbus::zvariant::ObjectPath<'_>)) -> zbus::Result<()>;

--- a/atspi-proxies/src/socket.rs
+++ b/atspi-proxies/src/socket.rs
@@ -20,10 +20,7 @@ use atspi_common::Accessible;
 )]
 trait Socket {
 	/// Embed method
-	fn embed(
-		&self,
-		plug: &(&str, zbus::zvariant::ObjectPath<'_>),
-	) -> zbus::Result<Accessible>;
+	fn embed(&self, plug: &(&str, zbus::zvariant::ObjectPath<'_>)) -> zbus::Result<Accessible>;
 
 	/// Unembed method
 	fn unembed(&self, plug: &(&str, zbus::zvariant::ObjectPath<'_>)) -> zbus::Result<()>;

--- a/atspi-proxies/src/table.rs
+++ b/atspi-proxies/src/table.rs
@@ -22,11 +22,7 @@ trait Table {
 	fn add_row_selection(&self, row: i32) -> zbus::Result<bool>;
 
 	/// GetAccessibleAt method
-	fn get_accessible_at(
-		&self,
-		row: i32,
-		column: i32,
-	) -> zbus::Result<Accessible>;
+	fn get_accessible_at(&self, row: i32, column: i32) -> zbus::Result<Accessible>;
 
 	/// GetColumnAtIndex method
 	fn get_column_at_index(&self, index: i32) -> zbus::Result<i32>;
@@ -38,10 +34,7 @@ trait Table {
 	fn get_column_extent_at(&self, row: i32, column: i32) -> zbus::Result<i32>;
 
 	/// GetColumnHeader method
-	fn get_column_header(
-		&self,
-		column: i32,
-	) -> zbus::Result<Accessible>;
+	fn get_column_header(&self, column: i32) -> zbus::Result<Accessible>;
 
 	/// GetIndexAt method
 	fn get_index_at(&self, row: i32, column: i32) -> zbus::Result<i32>;

--- a/atspi-proxies/src/table.rs
+++ b/atspi-proxies/src/table.rs
@@ -11,6 +11,7 @@
 //!
 
 use crate::atspi_proxy;
+use atspi_common::Accessible;
 
 #[atspi_proxy(interface = "org.a11y.atspi.Table", assume_defaults = true)]
 trait Table {
@@ -25,7 +26,7 @@ trait Table {
 		&self,
 		row: i32,
 		column: i32,
-	) -> zbus::Result<(String, zbus::zvariant::OwnedObjectPath)>;
+	) -> zbus::Result<Accessible>;
 
 	/// GetColumnAtIndex method
 	fn get_column_at_index(&self, index: i32) -> zbus::Result<i32>;
@@ -40,7 +41,7 @@ trait Table {
 	fn get_column_header(
 		&self,
 		column: i32,
-	) -> zbus::Result<(String, zbus::zvariant::OwnedObjectPath)>;
+	) -> zbus::Result<Accessible>;
 
 	/// GetIndexAt method
 	fn get_index_at(&self, row: i32, column: i32) -> zbus::Result<i32>;
@@ -61,7 +62,7 @@ trait Table {
 	fn get_row_extent_at(&self, row: i32, column: i32) -> zbus::Result<i32>;
 
 	/// GetRowHeader method
-	fn get_row_header(&self, row: i32) -> zbus::Result<(String, zbus::zvariant::OwnedObjectPath)>;
+	fn get_row_header(&self, row: i32) -> zbus::Result<Accessible>;
 
 	/// GetSelectedColumns method
 	fn get_selected_columns(&self) -> zbus::Result<Vec<i32>>;
@@ -86,7 +87,7 @@ trait Table {
 
 	/// Caption property
 	#[dbus_proxy(property)]
-	fn caption(&self) -> zbus::Result<(String, zbus::zvariant::OwnedObjectPath)>;
+	fn caption(&self) -> zbus::Result<Accessible>;
 
 	/// NColumns property
 	#[dbus_proxy(property)]
@@ -106,5 +107,5 @@ trait Table {
 
 	/// Summary property
 	#[dbus_proxy(property)]
-	fn summary(&self) -> zbus::Result<(String, zbus::zvariant::OwnedObjectPath)>;
+	fn summary(&self) -> zbus::Result<Accessible>;
 }

--- a/atspi-proxies/src/table_cell.rs
+++ b/atspi-proxies/src/table_cell.rs
@@ -38,5 +38,5 @@ trait TableCell {
 
 	/// Table property
 	#[dbus_proxy(property)]
-	fn table(&self) -> zbus::Result<(String, zbus::zvariant::OwnedObjectPath)>;
+	fn table(&self) -> zbus::Result<Accessible>;
 }

--- a/atspi-proxies/src/table_cell.rs
+++ b/atspi-proxies/src/table_cell.rs
@@ -11,18 +11,18 @@
 //!
 
 use crate::atspi_proxy;
-use atspi_common::ObjectPair;
+use atspi_common::Accessible;
 
 #[atspi_proxy(interface = "org.a11y.atspi.TableCell", assume_defaults = true)]
 trait TableCell {
 	/// GetColumnHeaderCells method
-	fn get_column_header_cells(&self) -> zbus::Result<Vec<ObjectPair>>;
+	fn get_column_header_cells(&self) -> zbus::Result<Vec<Accessible>>;
 
 	/// GetRowColumnSpan method
 	fn get_row_column_span(&self) -> zbus::Result<(bool, i32, i32, i32, i32)>;
 
 	/// GetRowHeaderCells method
-	fn get_row_header_cells(&self) -> zbus::Result<Vec<ObjectPair>>;
+	fn get_row_header_cells(&self) -> zbus::Result<Vec<Accessible>>;
 
 	/// ColumnSpan property
 	#[dbus_proxy(property)]


### PR DESCRIPTION
Fixes #107 

* [X] Set type of `Accessible.name` to String, since that is what is sent across the bus.
* [X] Move `Accessible` into its own module within `atspi-common`
* [X] Remove all references to `Objectpair`
* [X] Remove all references to `(String, zvariant::OwnedObjectPath)` 

```shell
$ grep -rne '(String, zvariant::OwnedObjectPath)'
$ 
```

```shell
$ grep -rne 'ObjectPair'
$ 
```