### PR TITLE
[atspi-connection] Use a channel to communicate.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,11 +192,14 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-      - name: Install WASM target
-        run: rustup target add wasm32-wasi
+      - name: Install WASM targets
+        run: rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknwon
       - name: Test Common Compilation (wasm32-wasi)
         working-directory: atspi-common
-        run: cargo build --target wasm32-wasi
+        run: cargo build --target wasm32-wasi --no-default-features
+      - name: Test Common Compilation (wasm32-unknown-unknown)
+        working-directory: atspi-common
+        run: cargo build --target wasm32-unknwon-unknown --no-default-features
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,11 +192,8 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-      - name: Install WASM target(s)
-        run: rustup target add wasm32-unknown-unknown && rustup target add wasm32-wasi
-      - name: Test Common Compilation (wasm32-unknown-unknown)
-        working-directory: atspi-common
-        run: cargo build --target wasm32-unknown-unknown
+      - name: Install WASM target
+        run: rustup target add wasm32-wasi
       - name: Test Common Compilation (wasm32-wasi)
         working-directory: atspi-common
         run: cargo build --target wasm32-wasi

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -28,6 +28,7 @@ pub const CACHE_ADD_SIGNATURE: Signature<'_> =
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "zbus")]
 use zbus::{MessageField, MessageFieldCode};
 use zbus_names::{OwnedUniqueName, UniqueName};
 use zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Signature, Type, Value};

--- a/atspi-connection/Cargo.toml
+++ b/atspi-connection/Cargo.toml
@@ -14,8 +14,8 @@ readme = "README.md"
 [features]
 default = ["async-std"]
 tracing = ["dep:tracing"]
-async-std = ["zbus/async-io", "atspi-proxies/async-std", "atspi-common/async-std"]
-tokio = ["zbus/tokio", "atspi-proxies/tokio", "atspi-common/tokio"]
+async-std = ["zbus/async-io", "atspi-proxies/async-std", "atspi-common/async-std", "dep:async-std"]
+tokio = ["zbus/tokio", "atspi-proxies/tokio", "atspi-common/tokio", "dep:tokio"]
 
 [dependencies]
 atspi-proxies = { path = "../atspi-proxies/", version = "0.1.0", default-features = false }
@@ -23,6 +23,8 @@ atspi-common = { path = "../atspi-common/", version = "0.1.0", default-features 
 futures-lite = "1.13.0"
 zbus.workspace = true
 tracing = { optional = true, workspace = true }
+tokio = { optional = true, version = "1.0" }
+async-std = { optional = true, version = "1.12.0" }
 
 [dev-dependencies]
 tokio-test = "0.4.2"

--- a/atspi-connection/Cargo.toml
+++ b/atspi-connection/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 default = ["async-std"]
 tracing = ["dep:tracing"]
 async-std = ["zbus/async-io", "atspi-proxies/async-std", "atspi-common/async-std", "dep:async-std"]
-tokio = ["zbus/tokio", "atspi-proxies/tokio", "atspi-common/tokio", "dep:tokio"]
+tokio = ["zbus/tokio", "atspi-proxies/tokio", "atspi-common/tokio", "dep:tokio", "dep:tokio-stream"]
 
 [dependencies]
 atspi-proxies = { path = "../atspi-proxies/", version = "0.1.0", default-features = false }
@@ -24,6 +24,7 @@ futures-lite = "1.13.0"
 zbus.workspace = true
 tracing = { optional = true, workspace = true }
 tokio = { optional = true, version = "1.0" }
+tokio-stream = { version = "0.1.4", optional = true }
 async-std = { optional = true, version = "1.12.0" }
 
 [dev-dependencies]

--- a/atspi-connection/src/lib.rs
+++ b/atspi-connection/src/lib.rs
@@ -6,13 +6,13 @@ compile_error!("You must specify either the async-std or tokio feature.");
 
 #[cfg(feature = "async-std")]
 use async_std::{
-	channel::{bounded as channel, Receiver, Sender, TrySendError},
+	channel::{bounded as channel, TrySendError},
 	task::spawn,
 };
 
 #[cfg(feature = "tokio")]
 use tokio::{
-	sync::mpsc::{channel, error::TrySendError, Receiver, Sender},
+	sync::mpsc::{channel, error::TrySendError},
 	task::spawn,
 };
 #[cfg(feature = "tokio")]
@@ -156,10 +156,7 @@ impl AccessibilityConnection {
 	/// # }
 	/// ```
 	pub fn event_stream(&self) -> impl Stream<Item = Result<Event, AtspiError>> {
-		let (tx_out, rx_out): (
-			Sender<Result<Event, AtspiError>>,
-			Receiver<Result<Event, AtspiError>>,
-		) = channel(10_000);
+		let (tx_out, rx_out) = channel(10_000);
 		let mut msg_stream = MessageStream::from(self.registry.connection()).filter_map(|res| {
 			let msg = match res {
 				Ok(m) => m,

--- a/atspi-connection/src/lib.rs
+++ b/atspi-connection/src/lib.rs
@@ -15,6 +15,8 @@ use tokio::{
 	sync::mpsc::{Sender, Receiver, channel, error::TrySendError},
 	task::spawn,
 };
+#[cfg(feature = "tokio")]
+use tokio_stream::wrappers::ReceiverStream;
 
 use atspi_common::error::AtspiError;
 use atspi_common::events::{Event, GenericEvent, HasMatchRule, HasRegistryEventString};
@@ -193,7 +195,10 @@ impl AccessibilityConnection {
 				}
 			}
 		});
-		rx_out
+		#[cfg(feature = "tokio")]
+		return ReceiverStream::new(rx_out);
+		#[cfg(feature = "async-std")]
+		return rx_out;
 	}
 
 	/// Registers an events as defined in [`atspi-types::events`]. This function registers a single event, like so:


### PR DESCRIPTION
* Some issues faced by @luukvanderduim when opening Thunderbird caused event storms to overwhelm the bus.
* Since the MessageStream was not being polled fast enough, `zbus` was getting clogged up, which can cause issues like hanging.
	* This is even mentioned in the documentation for `zbus`.
* This commit takes a different approach, adding a channel, where the receiving end is send out to the user (luckily for us, the return type hasn't changed at all thanks to `impl Stream<_>`)
* Now, a separate task will poll the MessageStream, and add it to the channel.
* If the channel gets backed up, we having tracing/debug information avaiable as to why this happened.
* Now, at least if `zbus` is getting backed up, we should be able to find out what is slowing down to polling of the channel, and then blocking up `zbus` indirectly.
* It is possible that we want to spawn a second *thread* to deal with these events storms, but I suspect this will not be necessary unless the "30,000" events reported by Luuk simply overwhelm even `tokio`'s executor.
* Odilia *should* in theory be unaffected by this, since each even handler is spawned on its own task, and Odilia shouldn't back up unless a very large quanitiy of events are mutating the same items in the cache (worst case scenario with locking).
	* The other option is that we simply can't launch tasks fast enough. Based on [these benchmarks](http://gravitext.com/2020/01/13/blocking-permit.html) it seems spawning may be in the hundreds of microseconds, which may not be able to keep up with 30,000 spawns a second (it would need to be at least less than 333us, but ideally we'd want to some headroom).

If possible, I'd like [Luuk's statspi](https://github.com/luukvanderduim/statspi) to be tested with this branch and see if it can stave off the event storms backing up `zbus`s very small queue.