### PR TITLE
[atspi-proxies] Remove alien methods from Application interface

### DIFF
--- a/atspi-proxies/src/application.rs
+++ b/atspi-proxies/src/application.rs
@@ -14,14 +14,8 @@ use crate::atspi_proxy;
 
 #[atspi_proxy(interface = "org.a11y.atspi.Application", assume_defaults = true)]
 trait Application {
-	/// DeregisterEventListener method
-	fn deregister_event_listener(&self, event: &str) -> zbus::Result<()>;
-
 	/// GetLocale method
 	fn get_locale(&self, lctype: u32) -> zbus::Result<String>;
-
-	/// RegisterEventListener method
-	fn register_event_listener(&self, event: &str) -> zbus::Result<()>;
 
 	/// AtspiVersion property
 	#[dbus_proxy(property)]


### PR DESCRIPTION
This removes two methods from `Application` interface that do not belong there. These belong to- and are found in `Registry` interface.

```rust
/// DeregisterEventListener method
fn deregister_event_listener(&self, event: &str) -> zbus::Result<()>;

/// RegisterEventListener method
fn register_event_listener(&self, event: &str) -> zbus::Result<()>;
```