### PR TITLE
[atspi-proxies] Document Registry's `Application::get_children`

### DIFF
--- a/atspi-common/src/role.rs
+++ b/atspi-common/src/role.rs
@@ -377,14 +377,14 @@ pub mod tests {
 	#[test]
 	fn test_serialization_matches_from_impl() {
 		let ctxt = EncodingContext::<byteorder::LE>::new_dbus(0);
-		for role_num in 1..HIGHEST_ROLE_VALUE + 1 {
-			let from_role =
-				Role::try_from(role_num).expect(&format!("Unable to convert {role_num} into Role"));
+		for role_num in 1..=HIGHEST_ROLE_VALUE {
+			let from_role = Role::try_from(role_num)
+				.unwrap_or_else(|_| panic!("Unable to convert {role_num} into Role"));
 			let encoded = to_bytes(ctxt, &from_role).expect("Unable to encode {from_role}");
-			println!("ENCODED: {:?}", encoded);
+			println!("ENCODED: {encoded:?}");
 			let zbus_role: Role =
 				from_slice(&encoded, ctxt).expect("Unable to convert {encoded} into Role");
-			assert_eq!(from_role, zbus_role, "The serde zvariant::from_slice(...) and From<u32> implementations have produced different results. The number used was {}, it produced a Role of {}, but the from_slice(...) implementation produced {}", role_num, from_role, zbus_role);
+			assert_eq!(from_role, zbus_role, "The serde zvariant::from_slice(...) and From<u32> implementations have produced different results. The number used was {role_num}, it produced a Role of {from_role}, but the from_slice(...) implementation produced {zbus_role}");
 			assert_eq!(
 				from_role as u32, role_num,
 				"The role number {role_num} does not match the representation of the role {}",

--- a/atspi-proxies/src/accessible.rs
+++ b/atspi-proxies/src/accessible.rs
@@ -55,7 +55,12 @@ trait Accessible {
 
 	/// Retrieves a list of the object's accessible children.
 	///
-	/// Each array element is an [`Accessible`] representing the accessible child.
+	/// Each array element is an [`Accessible`] representing the accessible child object.
+	///
+	/// ## Registry
+	///
+	/// On the `Accessible` interface of `org.a11y.atspi.Registry`, the registry daemon, this method retrieves a list
+	/// of all accessible applications' root objects on the bus.
 	///
 	/// [`Accessible`]: ../atspi_common::events::Accessible
 	fn get_children(&self) -> zbus::Result<Vec<Accessible>>;


### PR DESCRIPTION
Document how to obtain list of accessible bus applications.
    
The implementation of `Accessible::get_children` on `org.a11y.atspi.Registry`
returns a list of root objects corresponding to all accessible applications
on the bus.
