### PR TITLE
Re-export zbus for convenience

### DIFF
--- a/atspi/src/lib.rs
+++ b/atspi/src/lib.rs
@@ -12,5 +12,5 @@ pub use atspi_proxies as proxy;
 #[cfg(feature = "connection")]
 pub use atspi_connection as connection;
 
-#[cfg(feature = "client")]
-pub use atspi_client as client;
+#[cfg(feature = "zbus")]
+pub use zbus;


### PR DESCRIPTION
A bit of  janitorial and quality of life:

Removes export of no longer existing `atspi-client` 
Re-exports `zbus` for convenience.