### PR TITLE
Spelling fixes across the tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 /target
 Cargo.lock
-/atspi-macros/target
-/atspi-matcros/Cargo.lock
-/atspi-codegen/target

--- a/atspi-common/src/cache.rs
+++ b/atspi-common/src/cache.rs
@@ -76,7 +76,7 @@ pub struct LegacyCacheItem {
 	pub parent: Accessible,
 	/// List of references to the accessible's children.  a(so)
 	pub children: Vec<Accessible>,
-	/// The exposed interfece(s) set.  as
+	/// The exposed interface(s) set.  as
 	pub ifaces: InterfaceSet,
 	/// The short localized name.  s
 	pub short_name: String,

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -101,15 +101,15 @@ impl<T> Type for EventBody<'_, T> {
 /// Signature:  "siiv(so)"
 #[derive(Debug, Serialize, Deserialize, Type)]
 pub struct EventBodyQT {
-	/// kind variant, used for specifying an event tripple "object:state-changed:focused",
+	/// kind variant, used for specifying an event triple "object:state-changed:focused",
 	/// the "focus" part of this event is what is contained within the kind.
-	#[serde(rename = "type")]
+	// #[serde(rename = "type")]
 	pub kind: String,
-	/// Generic detail1 value descibed by AT-SPI.
+	/// Generic detail1 value described by AT-SPI.
 	pub detail1: i32,
-	/// Generic detail2 value descibed by AT-SPI.
+	/// Generic detail2 value described by AT-SPI.
 	pub detail2: i32,
-	/// Generic any_data value descibed by AT-SPI.
+	/// Generic any_data value described by AT-SPI.
 	/// This can be any type.
 	pub any_data: OwnedValue,
 	/// A tuple of properties.
@@ -134,15 +134,15 @@ impl Default for EventBodyQT {
 /// Signature `(siiva{sv})`,
 #[derive(Clone, Debug, Serialize, Deserialize, Type, PartialEq)]
 pub struct EventBodyOwned {
-	/// kind variant, used for specifying an event tripple "object:state-changed:focused",
+	/// kind variant, used for specifying an event triple "object:state-changed:focused",
 	/// the "focus" part of this event is what is contained within the kind.
 	#[serde(rename = "type")]
 	pub kind: String,
-	/// Generic detail1 value descibed by AT-SPI.
+	/// Generic detail1 value described by AT-SPI.
 	pub detail1: i32,
-	/// Generic detail2 value descibed by AT-SPI.
+	/// Generic detail2 value described by AT-SPI.
 	pub detail2: i32,
-	/// Generic any_data value descibed by AT-SPI.
+	/// Generic any_data value described by AT-SPI.
 	/// This can be any type.
 	pub any_data: OwnedValue,
 	/// A map of properties.
@@ -810,7 +810,7 @@ mod tests {
 		let with_parentheses = &Signature::from_static_str_unchecked("(ii)(ii)");
 		let without_parentheses = &Signature::from_static_str_unchecked("((ii)(ii)");
 		assert!(!signatures_are_eq(with_parentheses, without_parentheses));
-		// test case with more than oune extra outer parentheses
+		// test case with more than one extra outer parentheses
 		let with_parentheses = &Signature::from_static_str_unchecked("((ii)(ii))");
 		let without_parentheses = &Signature::from_static_str_unchecked("((((ii)(ii))))");
 		assert!(!signatures_are_eq(with_parentheses, without_parentheses));

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -111,7 +111,7 @@ pub struct DesktopCreateEvent {
 	pub item: crate::events::Accessible,
 }
 
-/// A virtual destkop has been deleted.
+/// A virtual desktop has been deleted.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct DesktopDestroyEvent {
 	/// A reference to the destroyed desktop.

--- a/atspi-common/src/interface.rs
+++ b/atspi-common/src/interface.rs
@@ -1,7 +1,7 @@
 //! Conversion functions and types representing a set of [`Interface`]s.
 //!
 //! Each `AccessibleProxy` will implement some set of these interfaces,
-//! represened by a [`InterfaceSet`].
+//! represented by a [`InterfaceSet`].
 
 use enumflags2::{bitflags, BitFlag, BitFlags};
 use serde::{

--- a/atspi-common/src/lib.rs
+++ b/atspi-common/src/lib.rs
@@ -69,7 +69,7 @@ pub enum SortOrder {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Type)]
 #[repr(u32)]
 pub enum TreeTraversalType {
-	/// Restrict children tree traveral
+	/// Restrict children tree traversal
 	RestrictChildren,
 	/// Restrict sibling tree traversal
 	RestrictSibling,
@@ -124,11 +124,11 @@ pub enum ClipType {
 #[repr(u32)]
 /// Level of granularity to get text of, in relation to a cursor position.
 pub enum Granularity {
-	/// Gives the character at the index of the cursor. With a line-style cursor (which is standard) this will get the chracter that appears after the cursor.
+	/// Gives the character at the index of the cursor. With a line-style cursor (which is standard) this will get the character that appears after the cursor.
 	Char,
-	/// Gives the entire word in front of or which contains the cursor. TODO: confirm that it always chooses the word in front of the cursor.
+	/// Gives the entire word in front of, or which contains, the cursor. TODO: confirm that it always chooses the word in front of the cursor.
 	Word,
-	/// Gives to entire sentence in fron of the or which contains the cursor. TODO: confirm that it always chooses the sentence after the cursor.
+	/// Gives entire sentence in front of, or which contains, the cursor. TODO: confirm that it always chooses the sentence after the cursor.
 	Sentence,
 	/// Gives the line, as seen visually of which the cursor is situated within.
 	Line,

--- a/atspi-common/src/role.rs
+++ b/atspi-common/src/role.rs
@@ -125,7 +125,7 @@ pub enum Role {
 	SplitPane,
 	/// Object displays non-quantitative status information (c.f. [`Self::ProgressBar`])
 	StatusBar,
-	/// An object used to repesent information in terms of rows and columns.
+	/// An object used to represent information in terms of rows and columns.
 	Table,
 	/// A 'cell' or discrete child within a Table.
 	/// Note: Table cells need not have [`Self::TableCell`], other [`crate::Role`] values are valid as well.
@@ -147,7 +147,7 @@ pub enum Role {
 	/// For widgets whose purpose is to solicit input from the user, see [`Self::Entry`] and [`Self::PasswordText`].
 	/// For generic objects which display a brief amount of textual information, see [`Self::Static`].
 	Text,
-	/// A specialized push button that can be checked or unchecked, but does not procide a separate indicator for the current state.
+	/// A specialized push button that can be checked or unchecked, but does not provide a separate indicator for the current state.
 	ToggleButton,
 	/// A bar or palette usually composed of push buttons or toggle buttons.
 	ToolBar,
@@ -203,7 +203,7 @@ pub enum Role {
 	DocumentFrame,
 	/// Heading: this is a heading with a level (usually 1-6). This is represented by `<h1>` through `<h6>` in HTML.
 	/// The object serves as a heading for content which follows it in a document.
-	/// The 'heading level' of the heading, if availabe, may be obtained by querying the object's attributes.
+	/// The 'heading level' of the heading, if available, may be obtained by querying the object's attributes.
 	Heading,
 	/// The object is a containing instance which encapsulates a page of information.
 	/// [`Self::Page`] is used in documents and content which support a paginated navigation model.
@@ -221,7 +221,7 @@ pub enum Role {
 	/// Unlike other GUI containers and dialogs which occur inside application instances, [`Self::Form`] containers' components are associated with the current document, rather than the current foreground application or viewer instance.
 	Form,
 	/// The object is a hypertext anchor, i.e. a "link" in a hypertext document.
-	/// Such objects are distinct from 'inline' content which may also use the [`crate::Interface::Hypertext`]/[`crate::Interface::Hyperlink`] interfacesto indicate the range/location within a text object where an inline or embedded object lies.
+	/// Such objects are distinct from 'inline' content which may also use the [`crate::Interface::Hypertext`]/[`crate::Interface::Hyperlink`] interfaces to indicate the range/location within a text object where an inline or embedded object lies.
 	Link,
 	/// The object is a window or similar viewport which is used to allow composition or input of a 'complex character', in other words it is an "input method window".
 	InputMethodWindow,

--- a/atspi-common/tests/tests.rs
+++ b/atspi-common/tests/tests.rs
@@ -124,7 +124,7 @@ async fn test_recv_add_accessible() {
 		.connection()
 		.send_message(msg)
 		.await
-		.expect("Message sending unsuccesful");
+		.expect("Message sending unsuccessful");
 
 	loop {
 		let to = events.try_next().await;

--- a/atspi-proxies/src/convertable.rs
+++ b/atspi-proxies/src/convertable.rs
@@ -211,7 +211,7 @@ async fn convert_to_new_type<
 >(
 	from: &U,
 ) -> zbus::Result<T> {
-	// first thing is first, we need to creat an accessible to query the interfaces.
+	// first thing is first, we need to create an accessible to query the interfaces.
 	let accessible = AccessibleProxy::builder(from.connection())
 		.destination(from.destination())?
 		.cache_properties(CacheProperties::No)
@@ -247,7 +247,7 @@ fn convert_to_new_type_blocking<
 >(
 	from: &U,
 ) -> zbus::Result<T> {
-	// first thing is first, we need to creat an accessible to query the interfaces.
+	// first thing is first, we need to create an accessible to query the interfaces.
 	let accessible = AccessibleProxyBlocking::builder(from.connection())
 		.destination(from.destination())?
 		.cache_properties(CacheProperties::No)

--- a/atspi-proxies/src/text.rs
+++ b/atspi-proxies/src/text.rs
@@ -10,7 +10,7 @@
 //! section of the zbus documentation.
 //!
 #![allow(clippy::too_many_arguments)]
-// this is to silience clippy due to zbus expanding parameter expressions
+// this is to silence clippy due to zbus expanding parameter expressions
 
 use crate::atspi_proxy;
 use crate::common::{ClipType, CoordType, Granularity};


### PR DESCRIPTION
This:

Makes spelling fixes across the tree.
Removes no longer existing remnants from `.gitignore`

