### PR TITLE
0.19.0 release

### DIFF
--- a/atspi-common/Cargo.toml
+++ b/atspi-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atspi-common"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 readme = "README.md"
 categories = ["accessibility", "api-bindings"]

--- a/atspi-common/Cargo.toml
+++ b/atspi-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atspi-common"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 readme = "README.md"
 categories = ["accessibility", "api-bindings"]

--- a/atspi-connection/Cargo.toml
+++ b/atspi-connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atspi-connection"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "A method of connecting, querying, sending and receiving over AT-SPI."
 license = "Apache-2.0 OR MIT" 
@@ -20,8 +20,8 @@ async-std = ["zbus/async-io", "atspi-proxies/async-std", "atspi-common/async-std
 tokio = ["zbus/tokio", "atspi-proxies/tokio", "atspi-common/tokio"]
 
 [dependencies]
-atspi-proxies = { path = "../atspi-proxies/", version = "0.2.0", default-features = false }
-atspi-common = { path = "../atspi-common/", version = "0.2.0", default-features = false }
+atspi-proxies = { path = "../atspi-proxies/", version = "0.2.1", default-features = false }
+atspi-common = { path = "../atspi-common/", version = "0.2.1", default-features = false }
 futures-lite = "1.13.0"
 zbus.workspace = true
 tracing = { optional = true, workspace = true }

--- a/atspi-connection/Cargo.toml
+++ b/atspi-connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atspi-connection"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "A method of connecting, querying, sending and receiving over AT-SPI."
 license = "Apache-2.0 OR MIT" 
@@ -20,8 +20,8 @@ async-std = ["zbus/async-io", "atspi-proxies/async-std", "atspi-common/async-std
 tokio = ["zbus/tokio", "atspi-proxies/tokio", "atspi-common/tokio"]
 
 [dependencies]
-atspi-proxies = { path = "../atspi-proxies/", version = "0.2.1", default-features = false }
-atspi-common = { path = "../atspi-common/", version = "0.2.1", default-features = false }
+atspi-proxies = { path = "../atspi-proxies/", version = "0.3.0", default-features = false }
+atspi-common = { path = "../atspi-common/", version = "0.3.0", default-features = false }
 futures-lite = "1.13.0"
 zbus.workspace = true
 tracing = { optional = true, workspace = true }

--- a/atspi-proxies/Cargo.toml
+++ b/atspi-proxies/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atspi-proxies"
-version = "0.2.1"
+version = "0.3.0"
 description = "AT-SPI2 proxies to query or manipulate UI objects"
 license = "Apache-2.0 OR MIT"
 readme = "README.md"
@@ -23,7 +23,7 @@ gvariant = ["zbus/gvariant"]
 tokio = ["zbus/tokio", "atspi-common/tokio"]
 
 [dependencies]
-atspi-common = { path = "../atspi-common", version = "0.2.1", default-features = false }
+atspi-common = { path = "../atspi-common", version = "0.3.0", default-features = false }
 serde = { version = "^1.0", default-features = false, features = ["derive"] }
 zbus = { workspace = true, default-features = false } 
 # optional dependencies
@@ -31,7 +31,7 @@ async-trait = { version = "^0.1.59", optional = true }
 futures-lite = { version = "1.12", default-features = false, optional = true }
 
 [dev-dependencies]
-atspi-common = { path = "../atspi-common", version = "0.2.0", features = ["async-std"] }
+atspi-common = { path = "../atspi-common", version = "0.3.0", features = ["async-std"] }
 byteorder = "1.4"
 serde_plain = "1.0.1"
 lazy_static = "1.0"

--- a/atspi-proxies/Cargo.toml
+++ b/atspi-proxies/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atspi-proxies"
-version = "0.2.0"
+version = "0.2.1"
 description = "AT-SPI2 proxies to query or manipulate UI objects"
 license = "Apache-2.0 OR MIT"
 readme = "README.md"
@@ -23,7 +23,7 @@ gvariant = ["zbus/gvariant"]
 tokio = ["zbus/tokio", "atspi-common/tokio"]
 
 [dependencies]
-atspi-common = { path = "../atspi-common", version = "0.2.0", default-features = false }
+atspi-common = { path = "../atspi-common", version = "0.2.1", default-features = false }
 serde = { version = "^1.0", default-features = false, features = ["derive"] }
 zbus = { workspace = true, default-features = false } 
 # optional dependencies

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atspi"
-version = "0.18.1"
+version = "0.19.0"
 authors.workspace = true
 edition = "2021"
 description = "Pure-Rust, zbus-based AT-SPI2 protocol implementation."
@@ -29,6 +29,6 @@ connection-tokio = ["atspi-connection/tokio", "connection"]
 tracing = ["atspi-connection/tracing"]
 
 [dependencies]
-atspi-common = { path = "../atspi-common", version = "0.2.1", default-features = false }
-atspi-proxies = { path = "../atspi-proxies", version = "0.2.1", default-features = false, optional = true }
-atspi-connection = { path = "../atspi-connection", version = "0.2.1", default-features = false, optional = true }
+atspi-common = { path = "../atspi-common", version = "0.3.0", default-features = false }
+atspi-proxies = { path = "../atspi-proxies", version = "0.3.0", default-features = false, optional = true }
+atspi-connection = { path = "../atspi-connection", version = "0.3.0", default-features = false, optional = true }

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atspi"
-version = "0.18.0"
+version = "0.18.1"
 authors.workspace = true
 edition = "2021"
 description = "Pure-Rust, zbus-based AT-SPI2 protocol implementation."
@@ -29,6 +29,6 @@ connection-tokio = ["atspi-connection/tokio", "connection"]
 tracing = ["atspi-connection/tracing"]
 
 [dependencies]
-atspi-common = { path = "../atspi-common", version = "0.2.0", default-features = false }
-atspi-proxies = { path = "../atspi-proxies", version = "0.2.0", default-features = false, optional = true }
-atspi-connection = { path = "../atspi-connection", version = "0.2.0", default-features = false, optional = true }
+atspi-common = { path = "../atspi-common", version = "0.2.1", default-features = false }
+atspi-proxies = { path = "../atspi-proxies", version = "0.2.1", default-features = false, optional = true }
+atspi-connection = { path = "../atspi-connection", version = "0.2.1", default-features = false, optional = true }


### PR DESCRIPTION
- Bump minor versions across crates
- realize there are unreleased breaking changes, and add major version bump
