### PR TITLE
Type validation with zbus_lockstep!

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
           toolchain: stable
       - name: Install Cargo Machete
         uses: taiki-e/install-action@cargo-machete
-      - name: Check For Unused Depdencies
+      - name: Check For Unused Dependencies
         run: cargo machete
   semver-compliance:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
         with:
           tool: cargo-semver-checks
       - name: Check Semver Compliance
-        run: cargo semver-checks check-release -p atspi --default-features
+        run: LOCKSTEP_XML_PATH="../xml" cargo semver-checks check-release -p atspi --default-features
   msrv-compliance:
     runs-on: ubuntu-latest
     needs: [clippy,no-unused-dependencies,find-msrv]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Part of the [Odilia screen reader project](https://odilia.app).
 ## Design
 
 * Fully documented, with `#[deny(missing_docs)]`
-	* Or at least, it will be by 1.0
+* Or at least, it will be by 1.0
 * Fully safe, with `#[deny(unsafe_code)]`
 * Fantastic code style with `#[deny(clippy:all, clippy::pedantic, clippy::cargo)]`
 
@@ -24,6 +24,17 @@ We use the asynchronous zbus API, so to use atspi, you will need to run an async
 [tokio](https://crates.io/crates/tokio) or
 [async-std](https://crates.io/crates/async-std).
 The `async-io` and `tokio` features are exposed and will be passed through to zbus.
+
+## D-Bus type validation
+
+Atspi is used to send and receive data to and from applications. Sender and recipient need to agree on the shape of the data type for fruitful communication. Our best bet is to keep our types in sync with the protocol descriptions.
+
+We employ [zbus-lockstep](https://github.com/luukvanderduim/zbus-lockstep/) to match types against those defined in the AT-SPI2 protocol descriptions.
+
+Not all types can be validated (easily) with zbus_lockstep because types may not exist
+in the protocol descriptions, for example because they are deprecated (but still in use) or we have chosen a different representation.
+
+[A (partial) review of type validation may be found here](type_validation.md)
 
 ## License
 

--- a/atspi-common/Cargo.toml
+++ b/atspi-common/Cargo.toml
@@ -27,6 +27,7 @@ zvariant = { version = "4.0", default-features = false }
 zbus = { workspace = true, optional = true, default-features = false }
 zbus-lockstep = "0.4.1"
 zbus-lockstep-macros = "0.4.1"
+zbus_xml = "4.0.0"
 
 [dev-dependencies]
 zbus = { workspace = true }

--- a/atspi-common/Cargo.toml
+++ b/atspi-common/Cargo.toml
@@ -25,6 +25,8 @@ static_assertions = "1.1.0"
 zbus_names = "3.0"
 zvariant = { version = "4.0", default-features = false }
 zbus = { workspace = true, optional = true, default-features = false }
+zbus-lockstep = "0.4.1"
+zbus-lockstep-macros = "0.4.1"
 
 [dev-dependencies]
 zbus = { workspace = true }

--- a/atspi-common/Cargo.toml
+++ b/atspi-common/Cargo.toml
@@ -25,9 +25,8 @@ static_assertions = "1.1.0"
 zbus_names = "3.0"
 zvariant = { version = "4.0", default-features = false }
 zbus = { workspace = true, optional = true, default-features = false }
-zbus-lockstep = "0.4.1"
-zbus-lockstep-macros = "0.4.1"
-zbus_xml = "4.0.0"
+zbus-lockstep = "0.4.2"
+zbus-lockstep-macros = "0.4.2"
 
 [dev-dependencies]
 zbus = { workspace = true }

--- a/atspi-common/src/cache.rs
+++ b/atspi-common/src/cache.rs
@@ -3,11 +3,13 @@
 
 use crate::{InterfaceSet, ObjectRef, Role, StateSet};
 use serde::{Deserialize, Serialize};
+use zbus_lockstep_macros::validate;
 use zvariant::Type;
 
 /// The item type provided by `Cache:Add` signals
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Debug, Serialize, Deserialize, Type, PartialEq, Eq, Hash)]
+#[validate(signal: "AddAccessible")]
 pub struct CacheItem {
 	/// The accessible object (within the application)   (so)
 	pub object: ObjectRef,
@@ -30,6 +32,7 @@ pub struct CacheItem {
 	/// The states applicable to the accessible.  au
 	pub states: StateSet,
 }
+
 impl Default for CacheItem {
 	fn default() -> Self {
 		Self {
@@ -54,14 +57,6 @@ impl Default for CacheItem {
 			states: StateSet::empty(),
 		}
 	}
-}
-
-#[test]
-fn zvariant_type_signature_of_cache_item() {
-	assert_eq!(
-		CacheItem::signature(),
-		zbus::zvariant::Signature::from_static_str("((so)(so)(so)iiassusau)").unwrap()
-	);
 }
 
 /// The item type provided by `Cache:Add` signals
@@ -112,6 +107,7 @@ impl Default for LegacyCacheItem {
 	}
 }
 
+#[cfg(test)]
 #[test]
 fn zvariant_type_signature_of_legacy_cache_item() {
 	assert_eq!(

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -23,7 +23,6 @@ pub const QSPI_EVENT_SIGNATURE: Signature<'_> = Signature::from_static_str_unche
 pub const EVENT_LISTENER_SIGNATURE: Signature<'_> = Signature::from_static_str_unchecked("(ss)");
 pub const CACHE_ADD_SIGNATURE: Signature<'_> =
 	Signature::from_static_str_unchecked("((so)(so)(so)iiassusau)");
-pub const ACCESSIBLE_PAIR_SIGNATURE: Signature<'_> = Signature::from_static_str_unchecked("(so)");
 
 use std::collections::HashMap;
 

--- a/atspi-common/src/lib.rs
+++ b/atspi-common/src/lib.rs
@@ -222,7 +222,7 @@ pub enum Live {
 impl TryFrom<i32> for Live {
 	type Error = AtspiError;
 
-	fn try_from(value: i32) -> Result<Self, Self::Error> {
+	fn try_from(value: i32) -> std::result::Result<Self, Self::Error> {
 		match value {
 			0 => Ok(Live::None),
 			1 => Ok(Live::Polite),
@@ -235,6 +235,9 @@ impl TryFrom<i32> for Live {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use zbus_lockstep::{
+		method_args_signature, method_return_signature, signal_body_type_signature,
+	};
 
 	#[test]
 	fn convert_i32_to_live() {
@@ -243,5 +246,67 @@ mod tests {
 		assert_eq!(Live::Assertive, Live::try_from(2).unwrap());
 		assert!(Live::try_from(3).is_err());
 		assert!(Live::try_from(-1).is_err());
+	}
+
+	#[test]
+	fn set_env_for_signature_validations() {
+		std::env::set_var("LOCKSTEP_XML_PATH", "../xml");
+		assert_eq!(std::env::var("LOCKSTEP_XML_PATH").unwrap(), "../xml");
+	}
+
+	#[test]
+	fn validate_live_signature() {
+		let signature = signal_body_type_signature!("Announcement");
+		let politeness_signature = signature.slice(1..2);
+		assert_eq!(Live::signature(), politeness_signature);
+	}
+
+	#[test]
+	fn validate_scroll_type_signature() {
+		let signature = method_args_signature!(member: "ScrollTo", interface: "org.a11y.atspi.Component", argument: "type");
+		assert_eq!(ScrollType::signature(), signature);
+	}
+
+	#[test]
+	fn validate_layer_signature() {
+		let signature = method_return_signature!("GetLayer");
+		assert_eq!(Layer::signature(), signature);
+	}
+
+	#[test]
+	fn validate_granularity_signature() {
+		let signature = method_args_signature!(member: "GetStringAtOffset", interface: "org.a11y.atspi.Text", argument: "granularity");
+		assert_eq!(Granularity::signature(), signature);
+	}
+
+	#[test]
+	fn validate_clip_type_signature() {
+		let signature = method_args_signature!(member: "GetTextAtOffset", interface: "org.a11y.atspi.Text", argument: "type");
+		assert_eq!(ClipType::signature(), signature);
+	}
+
+	#[test]
+	fn validate_coord_type_signature() {
+		let signature = method_args_signature!(member: "GetImagePosition", interface: "org.a11y.atspi.Image", argument: "coordType");
+		assert_eq!(CoordType::signature(), signature);
+	}
+
+	#[test]
+	fn validate_match_type_signature() {
+		let rule_signature = method_args_signature!(member: "GetMatchesTo", interface: "org.a11y.atspi.Collection", argument: "rule");
+		let match_type_signature = rule_signature.slice(3..4);
+		assert_eq!(MatchType::signature(), match_type_signature);
+	}
+
+	#[test]
+	fn validate_tree_traversal_type_signature() {
+		let signature = method_args_signature!(member: "GetMatchesTo", interface: "org.a11y.atspi.Collection", argument: "tree");
+		assert_eq!(TreeTraversalType::signature(), signature);
+	}
+
+	#[test]
+	fn validate_sort_order_signature() {
+		let signature = method_args_signature!(member: "GetMatches", interface: "org.a11y.atspi.Collection", argument: "sortby");
+		assert_eq!(SortOrder::signature(), signature);
 	}
 }

--- a/atspi-common/src/lib.rs
+++ b/atspi-common/src/lib.rs
@@ -34,6 +34,8 @@ pub use relation_type::RelationType;
 use serde::{Deserialize, Serialize};
 use zvariant::Type;
 
+pub type Result<T> = std::result::Result<T, AtspiError>;
+
 pub type MatchArgs<'a> = (
 	&'a [i32],
 	MatchType,

--- a/atspi-common/src/lib.rs
+++ b/atspi-common/src/lib.rs
@@ -204,23 +204,19 @@ pub enum ScrollType {
 
 /// Enumeration used to indicate a type of live region and how assertive it
 /// should be in terms of speaking notifications. Currently, this is only used
-/// for "announcement" events, but it may be used for additional purposes
+/// for `Announcement` events, but it may be used for additional purposes
 /// in the future.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Type)]
-#[repr(u32)]
+/// The argument in the `Announcement` event is named `politeness`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize, Type)]
+#[repr(i32)]
 pub enum Live {
 	/// No live region.
+	#[default]
 	None,
 	/// This live region should be considered polite.
 	Polite,
 	/// This live region should be considered assertive.
 	Assertive,
-}
-
-impl Default for Live {
-	fn default() -> Self {
-		Self::None
-	}
 }
 
 impl TryFrom<i32> for Live {

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -465,7 +465,7 @@ macro_rules! event_wrapper_test_cases {
 				.build(&<$any_subtype>::default().body())
 				.unwrap();
 
-				// It is hard to see what eventually is tested here. Let's unravels it:
+				// It is hard to see what eventually is tested here. Let's unravel it:
 				//
 				// Below we call `TryFrom<&zbus::Message> for $type` where `$type` the interface enum name. (eg. `MouseEvents`, `ObjectEvents`, etc.) and
 				// `mod_type` is an 'interface enum' variant (eg. `MouseEvents::Abs(AbsEvent)`).

--- a/atspi-common/tests/tests.rs
+++ b/atspi-common/tests/tests.rs
@@ -8,7 +8,7 @@ use tokio_stream::StreamExt;
 use zbus::Message;
 use zvariant::OwnedObjectPath;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn test_recv_remove_accessible() {
 	let atspi = atspi_connection::AccessibilityConnection::new().await.unwrap();
 	atspi.register_event::<RemoveAccessibleEvent>().await.unwrap();
@@ -61,7 +61,7 @@ async fn test_recv_remove_accessible() {
 	}
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn test_recv_add_accessible() {
 	let atspi = AccessibilityConnection::new().await.unwrap();
 	atspi.register_event::<AddAccessibleEvent>().await.unwrap();

--- a/atspi-common/tests/tests.rs
+++ b/atspi-common/tests/tests.rs
@@ -1,6 +1,7 @@
 use atspi_common::events::{AddAccessibleEvent, Event, RemoveAccessibleEvent};
 use atspi_common::events::{CacheEvents, CACHE_ADD_SIGNATURE};
-use atspi_common::{object_ref::ACCESSIBLE_PAIR_SIGNATURE, CacheItem, ObjectRef};
+use atspi_common::object_ref::OBJECT_REF_SIGNATURE;
+use atspi_common::{CacheItem, ObjectRef};
 use atspi_connection::AccessibilityConnection;
 use std::time::Duration;
 use tokio_stream::StreamExt;
@@ -34,7 +35,7 @@ async fn test_recv_remove_accessible() {
 			.unwrap()
 	};
 
-	assert_eq!(&msg.body().signature().unwrap(), &ACCESSIBLE_PAIR_SIGNATURE);
+	assert_eq!(&msg.body().signature().unwrap(), &OBJECT_REF_SIGNATURE);
 	atspi.connection().send(&msg).await.unwrap();
 
 	loop {

--- a/atspi-common/tests/tests.rs
+++ b/atspi-common/tests/tests.rs
@@ -1,6 +1,5 @@
+use atspi_common::events::CacheEvents;
 use atspi_common::events::{AddAccessibleEvent, Event, RemoveAccessibleEvent};
-use atspi_common::events::{CacheEvents, CACHE_ADD_SIGNATURE};
-use atspi_common::object_ref::OBJECT_REF_SIGNATURE;
 use atspi_common::{CacheItem, ObjectRef};
 use atspi_connection::AccessibilityConnection;
 use std::time::Duration;
@@ -10,6 +9,8 @@ use zvariant::OwnedObjectPath;
 
 #[tokio::test]
 async fn test_recv_remove_accessible() {
+	std::env::set_var("LOCKSTEP_XML_PATH", "../xml");
+
 	let atspi = atspi_connection::AccessibilityConnection::new().await.unwrap();
 	atspi.register_event::<RemoveAccessibleEvent>().await.unwrap();
 	let unique_bus_name = atspi.connection().unique_name().unwrap();
@@ -35,7 +36,13 @@ async fn test_recv_remove_accessible() {
 			.unwrap()
 	};
 
-	assert_eq!(&msg.body().signature().unwrap(), &OBJECT_REF_SIGNATURE);
+	// Retrieve the signature of the body of 'RemoveAccessible' signal from XML
+	// and compare it to the signature of the body of the message
+	assert_eq!(
+		msg.body().signature().unwrap(),
+		zbus_lockstep::signal_body_type_signature!("RemoveAccessible")
+	);
+
 	atspi.connection().send(&msg).await.unwrap();
 
 	loop {
@@ -46,7 +53,7 @@ async fn test_recv_remove_accessible() {
 			.expect("conversion to `Event` failed");
 
 		if let Event::Cache(CacheEvents::Remove(event)) = event {
-			// If we did not send the signal, continue listening.
+			// If we were not sender of the signal, continue listening.
 			if event.item.name.as_str() != unique_bus_name.as_str() {
 				continue;
 			}
@@ -55,7 +62,7 @@ async fn test_recv_remove_accessible() {
 			assert_eq!(name.as_str(), ":69.420");
 			assert_eq!(path.as_str(), "/org/a11y/atspi/accessible/remove");
 
-			// If we did, break the loop.
+			// If we were sender, break the loop.
 			break;
 		}
 	}
@@ -63,6 +70,9 @@ async fn test_recv_remove_accessible() {
 
 #[tokio::test]
 async fn test_recv_add_accessible() {
+	// Set env variable `LOCKSTEP_XML_PATH` to the path of the XML files. See above.
+	std::env::set_var("LOCKSTEP_XML_PATH", "../xml");
+
 	let atspi = AccessibilityConnection::new().await.unwrap();
 	atspi.register_event::<AddAccessibleEvent>().await.unwrap();
 	let unique_bus_name = atspi.connection().unique_name().unwrap();
@@ -85,7 +95,11 @@ async fn test_recv_add_accessible() {
 			.unwrap()
 	};
 
-	assert_eq!(msg.body().signature().unwrap(), CACHE_ADD_SIGNATURE);
+	assert_eq!(
+		msg.body().signature().unwrap(),
+		zbus_lockstep::signal_body_type_signature!("AddAccessible")
+	);
+
 	atspi
 		.connection()
 		.send(&msg)
@@ -119,6 +133,8 @@ async fn test_recv_add_accessible() {
 // that we can handle that case.
 #[tokio::test]
 async fn test_recv_add_accessible_unmarshalled_body() {
+	std::env::set_var("LOCKSTEP_XML_PATH", "../xml");
+
 	let atspi = AccessibilityConnection::new().await.unwrap();
 	atspi.register_event::<AddAccessibleEvent>().await.unwrap();
 	let unique_bus_name = atspi.connection().unique_name().unwrap();
@@ -141,7 +157,10 @@ async fn test_recv_add_accessible_unmarshalled_body() {
 			.unwrap()
 	};
 
-	assert_eq!(&msg.body().signature().unwrap(), &CACHE_ADD_SIGNATURE);
+	assert_eq!(
+		msg.body().signature().unwrap(),
+		zbus_lockstep::signal_body_type_signature!("AddAccessible")
+	);
 
 	atspi
 		.connection()

--- a/type_validation.md
+++ b/type_validation.md
@@ -1,0 +1,33 @@
+# Type validation
+
+For successful communication it is important that data are
+understood equally on both ends.
+
+We make a deliberate effort to validate our types in `atspi`.
+We leverage [zbus-lockstep](https://github.com/luukvanderduim/zbus-lockstep/) to match types in our crate against those defined in the AT-SPI2 protocol descriptions.
+
+`zbus-lockstep` is used to check if a type's (D-Bus type-system) signature corresponds to its counterpart in the protocol's XML.
+
+## Validation table
+
+| `atspi` type| XML validation | Notes |
+|:--|---|---|
+| `ObjectRef`| ✓ | Formerly: `Accessible`, used in `Available` and `RemoveAccessible`|
+| `CacheItem`| ✓ | See: `AddAccessible` signal of the `Cache` interface.|
+| `LegacyCacheItem` | ⚠ | The signature does not appear in current protocol: test hard coded.|
+| `Interface` | ⚠ | Unlike the protocol, which uses strings, we store `Interface` as bitflags.|
+| `InterfaceSet` | ⚠ | We store `InterfaceSet` as a single `u64`, not as 'array of strings'.|
+| `State` | ⚠ | XML: "au", a list of enum variants. Whereas `atspi` stores a `u64` bitflag.|
+| `StateSet` | ⚠ | See `State`.|
+| `EventBodyOwned` | ✓ | Covers many other events.|
+| `EventBodyQt` | ⚠ | Signature does not appear in XML.|
+| `EventListeners` | ✓ | Represents signals of `EventListenerRegistered` and `EventListenerDeregistered`|
+| `SortOrder` | ✓ | 'sortby' argument pf member `GetMatches`|
+| `TreeTraversalType` | ✓ | 'tree' argument of member `GetMatchesTo`|
+| `MatchType` | ✓ | Found at index 3, in the 'rule' argument in `GetMatches`|
+| `CoordType` | ✓ | Argument of `GetImagePosition` of `org.a11y.atspi.Image`|
+| `ClipType` | ✓ | `Text::GetTextAtOffset` argument `type`|
+| `Granularity` | ✓ | `Text::GetStringAtOffset` argument `granularity`|
+| `Layer` | ✓ | `Component::GetLayer` return type.|
+| `ScrollType` | ✓ | `Component::ScrollTo` argument `type`|
+| `Live` | ✓ | `Event.Object::Announcement` argument `politeness`|


### PR DESCRIPTION
This adds [zbus-lockstep](https://github.com/luukvanderduim/zbus-lockstep/) type validation to _atspi_.

Addresses:  #125

This replaces, in many cases, comparing signatures against a hard-coded const.
Also this adds a markdown page with an overview of types which have and have received lockstep validation.
(Some types simply can't because we have chosen a more efficient data-type.)

This is a good start, there are more validations to be added but the existing types with such tests have been converted:

`atspi` type| XML validation | Notes
|:--|---|---|
| `ObjectRef`| ✓ | Formerly: `Accessible`, used in `Available` and `RemoveAccessible`
| `CacheItem`| ✓ | See: `AddAccessible` signal of the `Cache` interface.
| `LegacyCacheItem` | ⚠ | The signature does not appear in current protocol: test hard coded.
| `Interface` | ⚠ | Unlike the protocol, which uses strings, we store `Interface` as bitflags.
| `InterfaceSet` | ⚠ | We store `InterfaceSet` as a single `u64`, not as 'array of strings'.
| `State` | ⚠ | XML: "au", a list of enum variants. Whereas `atspi` stores a `u64` bitflag.
| `StateSet` | ⚠ | See `State`.
| `EventBodyOwned` | ✓ | Covers many other events.
| `EventBodyQt` | ⚠ | Signature does not appear in XML.
| `EventListeners` | ✓ | Represents signals of `EventListenerRegistered` and `EventListenerDeregistered`
| `SortOrder` | ✓ | 'sortby' argument pf member `GetMatches`
| `TreeTraversalType` | ✓ | 'tree' argument of member `GetMatchesTo`
| `MatchType` | ✓ | Found at index 3, in the 'rule' argument in `GetMatches`
| `CoordType` | ✓ | Argument of `GetImagePosition` of `org.a11y.atspi.Image`
| `ClipType` | ✓ | `Text::GetTextAtOffset` argument `type`
| `Granularity` | ✓ | `Text::GetStringAtOffset` argument `granularity`
| `Layer` | ✓ | `Component::GetLayer` return type.
| `ScrollType` | ✓ | `Component::ScrollTo` argument `type`
| `Live` | ✓ | `Event.Object::Announcement` argument `politeness`

Note: 
 that the `const` signatures still have a purpose in run-time code because the lockstep functions are not `const` themselves. When those can be converted to `const fn` we may be able to leverage const  evaluation on those `const`s too.

## Caveat

This will probably add to test duration because the tests now regularly visit XML files to lookup signatures.

## Future 

It might be an improvement to add a function to `zbus_lockstep` to, if updates are available, retrieve the protocol descriptions.
This function could then be added to a `build.rs`, needs a bit more thinking.

 