### PR TITLE
Move examples to `atspi` crate (fixes #144)

### DIFF
--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -32,3 +32,10 @@ tracing = ["atspi-connection/tracing"]
 atspi-common = { path = "../atspi-common", version = "0.3.0", default-features = false }
 atspi-proxies = { path = "../atspi-proxies", version = "0.3.0", default-features = false, optional = true }
 atspi-connection = { path = "../atspi-connection", version = "0.3.0", default-features = false, optional = true }
+
+[dev-dependencies]
+atspi = { path = "." }
+tokio = { version = "1", default_features = false, features = ["macros", "rt-multi-thread"] }
+async-std = { version = "1", features = ["attributes"] }
+futures-lite = { version = "1.12", default-features = false }
+tokio-stream = "0.1"

--- a/atspi/examples/focused-async-std.rs
+++ b/atspi/examples/focused-async-std.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 	while let Some(Ok(ev)) = events.next().await {
 		let Ok(change) = <StateChangedEvent>::try_from(ev) else { continue };
 
-		if change.state == "focused" && change.enabled == 1 {
+		if change.state == "focused".into() && change.enabled == 1 {
 			let bus_name = change.item.name.clone();
 			println!("Accessible belonging to {bus_name}  focused!");
 		}

--- a/atspi/examples/focused-tokio.rs
+++ b/atspi/examples/focused-tokio.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 	while let Some(Ok(ev)) = events.next().await {
 		let Ok(change) = <StateChangedEvent>::try_from(ev) else { continue };
 
-		if change.state == "focused" && change.enabled == 1 {
+		if change.state == "focused".into() && change.enabled == 1 {
 			let bus_name = change.item.name.clone();
 			println!("Accessible belonging to {bus_name}  focused!");
 		}

--- a/atspi/src/lib.rs
+++ b/atspi/src/lib.rs
@@ -8,6 +8,8 @@ pub use atspi_proxies as proxy;
 
 #[cfg(feature = "connection")]
 pub use atspi_connection as connection;
+#[cfg(feature = "connection")]
+pub use connection::AccessibilityConnection;
 
 #[cfg(feature = "zbus")]
 pub use zbus;


### PR DESCRIPTION
- Move examples to main atspi crate
- Add dev dependencies to main atspi crate
- Re-export AccessibiliyyConnection in atspi::
