### PR TITLE
Dependency fixups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,9 @@
 resolver = "2"
 members = [
   "atspi",
-	"atspi-proxies",
 	"atspi-common",
   "atspi-connection",
-]
+	"atspi-proxies"]
 
 [workspace.package]
 description = "AT-SPI2 protocol implementation in Rust"

--- a/atspi-common/Cargo.toml
+++ b/atspi-common/Cargo.toml
@@ -31,7 +31,7 @@ zbus = { workspace = true }
 atspi-connection = { path = "../atspi-connection" }
 atspi-proxies = { path = "../atspi-proxies"  }
 tokio-stream = { version = "0.1", default-features = false, features = ["time"] }
-tokio = { version = "1", default_features = false, features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
 byteorder = "1.4.3"
 rename-item = "0.1.0"
 tokio-test = "0.4.2"

--- a/atspi-common/Cargo.toml
+++ b/atspi-common/Cargo.toml
@@ -22,18 +22,18 @@ tokio = ["zbus/tokio"]
 enumflags2 = "0.7.7"
 serde = "1.0"
 static_assertions = "1.1.0"
+zbus = { workspace = true, optional = true, default-features = false }
 zbus_names = "2.5.0"
 zvariant = { version = "3", default-features = false }
-zbus = { workspace = true, optional = true, default-features = false }
 
 [dev-dependencies]
-zbus = { workspace = true }
 atspi-connection = { path = "../atspi-connection" }
 atspi-proxies = { path = "../atspi-proxies"  }
-tokio-stream = { version = "0.1", default-features = false, features = ["time"] }
-tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
 byteorder = "1.4.3"
 rename-item = "0.1.0"
-tokio-test = "0.4.2"
 serde_plain = "1.0.1"
 static_assertions = "1.1.0"
+tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
+tokio-stream = { version = "0.1", default-features = false, features = ["time"] }
+tokio-test = "0.4.2"
+zbus = { workspace = true }

--- a/atspi-common/src/lib.rs
+++ b/atspi-common/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::all, clippy::pedantic, clippy::cargo, unsafe_code, rustdoc::all)]
 #![allow(clippy::module_name_repetitions)]
+#![allow(clippy::multiple_crate_versions)]
 
 //! # atspi-common
 //!

--- a/atspi-connection/Cargo.toml
+++ b/atspi-connection/Cargo.toml
@@ -22,7 +22,7 @@ tokio = ["zbus/tokio", "atspi-proxies/tokio", "atspi-common/tokio"]
 [dependencies]
 atspi-common = { path = "../atspi-common/", version = "0.3.0", default-features = false }
 atspi-proxies = { path = "../atspi-proxies/", version = "0.3.0", default-features = false }
-futures-lite = "1.13.0"
+futures-lite = { version = "2", default-features = false }
 tracing = { optional = true, workspace = true }
 zbus.workspace = true
 

--- a/atspi-connection/Cargo.toml
+++ b/atspi-connection/Cargo.toml
@@ -20,12 +20,12 @@ async-std = ["zbus/async-io", "atspi-proxies/async-std", "atspi-common/async-std
 tokio = ["zbus/tokio", "atspi-proxies/tokio", "atspi-common/tokio"]
 
 [dependencies]
-atspi-proxies = { path = "../atspi-proxies/", version = "0.3.0", default-features = false }
 atspi-common = { path = "../atspi-common/", version = "0.3.0", default-features = false }
+atspi-proxies = { path = "../atspi-proxies/", version = "0.3.0", default-features = false }
 futures-lite = "1.13.0"
-zbus.workspace = true
 tracing = { optional = true, workspace = true }
+zbus.workspace = true
 
 [dev-dependencies]
-tokio-test = "0.4.2"
 enumflags2.workspace = true
+tokio-test = "0.4.2"

--- a/atspi-connection/src/lib.rs
+++ b/atspi-connection/src/lib.rs
@@ -2,6 +2,7 @@
 //!  connection may receive any [`atspi_common::events::Event`] structures.
 
 #![deny(clippy::all, clippy::pedantic, clippy::cargo, unsafe_code, rustdoc::all)]
+#![allow(clippy::multiple_crate_versions)]
 
 #[cfg(all(not(feature = "async-std"), not(feature = "tokio")))]
 compile_error!("You must specify at least one of the `async-std` or `tokio` features.");

--- a/atspi-proxies/Cargo.toml
+++ b/atspi-proxies/Cargo.toml
@@ -35,7 +35,7 @@ byteorder = "1.4"
 serde_plain = "1.0.1"
 lazy_static = "1.0"
 tokio-stream = "0.1"
-tokio = { version = "1", default_features = false, features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
 async-std = { version = "1", features = ["attributes"] }
 futures-lite = { version = "1.12", default-features = false }
 tokio-test = "0.4.2"

--- a/atspi-proxies/Cargo.toml
+++ b/atspi-proxies/Cargo.toml
@@ -23,24 +23,24 @@ gvariant = ["zbus/gvariant"]
 tokio = ["zbus/tokio", "atspi-common/tokio"]
 
 [dependencies]
+# optional dependencies
+async-trait = { version = "^0.1.59", optional = true }
 atspi-common = { path = "../atspi-common", version = "0.3.0", default-features = false }
 serde = { version = "^1.0", default-features = false, features = ["derive"] }
 zbus = { workspace = true, default-features = false } 
-# optional dependencies
-async-trait = { version = "^0.1.59", optional = true }
 
 [dev-dependencies]
+async-std = { version = "1", features = ["attributes"] }
 atspi-common = { path = "../atspi-common", version = "0.3.0", features = ["async-std"] }
 byteorder = "1.4"
-serde_plain = "1.0.1"
-lazy_static = "1.0"
-tokio-stream = "0.1"
-tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
-async-std = { version = "1", features = ["attributes"] }
-futures-lite = { version = "1.12", default-features = false }
-tokio-test = "0.4.2"
-rename-item = "0.1.0"
 fantoccini = "0.19"
+futures-lite = { version = "1.12", default-features = false }
+lazy_static = "1.0"
+rename-item = "0.1.0"
 serde_json = "1.0.96"
+serde_plain = "1.0.1"
 serial_test = "2.0.0"
+tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
+tokio-stream = "0.1"
+tokio-test = "0.4.2"
 tracing = "0.1.37"

--- a/atspi-proxies/Cargo.toml
+++ b/atspi-proxies/Cargo.toml
@@ -33,7 +33,6 @@ zbus = { workspace = true, default-features = false }
 async-std = { version = "1", features = ["attributes"] }
 atspi-common = { path = "../atspi-common", version = "0.3.0", features = ["async-std"] }
 byteorder = "1.4"
-fantoccini = "0.19"
 futures-lite = { version = "1.12", default-features = false }
 lazy_static = "1.0"
 rename-item = "0.1.0"

--- a/atspi-proxies/Cargo.toml
+++ b/atspi-proxies/Cargo.toml
@@ -33,7 +33,7 @@ zbus = { workspace = true, default-features = false }
 async-std = { version = "1", features = ["attributes"] }
 atspi-common = { path = "../atspi-common", version = "0.3.0", features = ["async-std"] }
 byteorder = "1.4"
-futures-lite = { version = "1.12", default-features = false }
+futures-lite = { version = "2", default-features = false }
 lazy_static = "1.0"
 rename-item = "0.1.0"
 serde_json = "1.0.96"

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -19,7 +19,6 @@ include = ["src/**/*", "LICENSE-*", "README.md"]
 default = ["async-std"]
 async-std = ["proxies-async-std", "connection-async-std"]
 tokio = ["proxies-tokio", "connection-tokio"]
-
 proxies = []
 proxies-async-std = ["atspi-proxies/async-std", "proxies"]
 proxies-tokio = ["atspi-proxies/tokio", "proxies"]
@@ -30,12 +29,12 @@ tracing = ["atspi-connection/tracing"]
 
 [dependencies]
 atspi-common = { path = "../atspi-common", version = "0.3.0", default-features = false }
-atspi-proxies = { path = "../atspi-proxies", version = "0.3.0", default-features = false, optional = true }
 atspi-connection = { path = "../atspi-connection", version = "0.3.0", default-features = false, optional = true }
+atspi-proxies = { path = "../atspi-proxies", version = "0.3.0", default-features = false, optional = true }
 
 [dev-dependencies]
-atspi = { path = "." }
-tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
 async-std = { version = "1", features = ["attributes"] }
+atspi = { path = "." }
 futures-lite = { version = "1.12", default-features = false }
+tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1"

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -35,7 +35,7 @@ atspi-connection = { path = "../atspi-connection", version = "0.3.0", default-fe
 
 [dev-dependencies]
 atspi = { path = "." }
-tokio = { version = "1", default_features = false, features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
 async-std = { version = "1", features = ["attributes"] }
 futures-lite = { version = "1.12", default-features = false }
 tokio-stream = "0.1"

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -35,6 +35,6 @@ atspi-proxies = { path = "../atspi-proxies", version = "0.3.0", default-features
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes"] }
 atspi = { path = "." }
-futures-lite = { version = "1.12", default-features = false }
+futures-lite = { version = "2", default-features = false }
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1"


### PR DESCRIPTION
This commit:

- ["default-features" with dash, not an underscore.](https://github.com/odilia-app/atspi/commit/13b4c5f2d87cccf977aa1cc41950638b3027f0d9)
 - [Sort dependencies in all Cargo.tomls in the workspace](https://github.com/odilia-app/atspi/commit/f5ab38cd530d539a04aff8c16ea3386389a56335)
 - [Try to unify versions of futures-lite](https://github.com/odilia-app/atspi/commit/5ddd5dcfa380fed2aba296c0f0f98d3c4e37833a)
 - [Remove fantoccini](https://github.com/odilia-app/atspi/commit/a515f8e0e2f1bd028a10915008851b7b5369de16)
addresses #151 

 - [Silence Clippy warnings on multiple crate versions](https://github.com/odilia-app/atspi/commit/b74f01a8ce6da592c72b9b7c0185a60648791ba7)

