### PR TITLE
CI: Run nightly Clippy instead of stable and beta.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     needs: [rustfmt,no-unused-dependencies,wasm-compatible-common-crate]
-    name: ${{ matrix.toolchain }} / clippy
-    strategy:
-        fail-fast: false
-        matrix:
-            toolchain: [stable, beta]
+    name: nightly Clippy
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -63,12 +59,12 @@ jobs:
             ~/.cargo/git/db
           key: ${{ runner.os }}-x86_64-unknown-linux-gnu-build-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-x86_64-unknown-linux-gnu-build-${{ env.cache-name }}-
-      - name: Install ${{ matrix.toolchain }}
+               ${{ runner.os }}-x86_64-unknown-linux-gnu-build-${{ env.cache-name }}-
+      - name: Install nightly
         uses: dtolnay/rust-toolchain@master
         with:
           components: clippy
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: nightly
       - name: Clippy
         run: cargo clippy --tests --workspace --no-deps -- -D warnings 
   tests:


### PR DESCRIPTION
Run less, cover more, more up-to-date `main`.

Newer clippy versions have the previous' versions lints plus some more. No matter which toolchain you run, `main` will be up to date with all lints until new lintes are added.

Downside:
The added nightly lints may contain bugs.
This is true but so do stable.

Either the:
 - errors are not found by the lint in which case we will only learn of the error when the bug gets fixed.
 - errors are false positives. These patterns are usually quickly found and fixed overnight.

If we are bothered by a particular crate we can always `#[allow(clippy::bothersome-lint-in-our-context)]`
