### PR TITLE
Make ObjectRef more explicit in type

### DIFF
--- a/atspi-common/src/cache.rs
+++ b/atspi-common/src/cache.rs
@@ -4,7 +4,8 @@
 use crate::{InterfaceSet, ObjectRef, Role, StateSet};
 use serde::{Deserialize, Serialize};
 use zbus_lockstep_macros::validate;
-use zvariant::Type;
+use zbus_names::BusName;
+use zvariant::{ObjectPath, Type};
 
 /// The item type provided by `Cache:Add` signals
 #[allow(clippy::module_name_repetitions)]
@@ -37,16 +38,22 @@ impl Default for CacheItem {
 	fn default() -> Self {
 		Self {
 			object: ObjectRef {
-				name: ":0.0".try_into().unwrap(),
-				path: "/org/a11y/atspi/accessible/object".try_into().unwrap(),
+				name: BusName::from_static_str(":0.0").unwrap().into(),
+				path: ObjectPath::from_static_str("/org/a11y/atspi/accessible/object")
+					.unwrap()
+					.into(),
 			},
 			app: ObjectRef {
-				name: ":0.0".try_into().unwrap(),
-				path: "/org/a11y/atspi/accessible/application".try_into().unwrap(),
+				name: BusName::from_static_str(":0.0").unwrap().into(),
+				path: ObjectPath::from_static_str("/org/a11y/atspi/accessible/application")
+					.unwrap()
+					.into(),
 			},
 			parent: ObjectRef {
-				name: ":0.0".try_into().unwrap(),
-				path: "/org/a11y/atspi/accessible/parent".try_into().unwrap(),
+				name: BusName::from_static_str(":0.0").unwrap().into(),
+				path: ObjectPath::from_static_str("/org/a11y/atspi/accessible/parent")
+					.unwrap()
+					.into(),
 			},
 			index: 0,
 			children: 0,
@@ -86,16 +93,22 @@ impl Default for LegacyCacheItem {
 	fn default() -> Self {
 		Self {
 			object: ObjectRef {
-				name: ":0.0".try_into().unwrap(),
-				path: "/org/a11y/atspi/accessible/object".try_into().unwrap(),
+				name: BusName::from_static_str(":0.0").unwrap().into(),
+				path: ObjectPath::from_static_str("/org/a11y/atspi/accessible/object")
+					.unwrap()
+					.into(),
 			},
 			app: ObjectRef {
-				name: ":0.0".try_into().unwrap(),
-				path: "/org/a11y/atspi/accessible/application".try_into().unwrap(),
+				name: BusName::from_static_str(":0.0").unwrap().into(),
+				path: ObjectPath::from_static_str("/org/a11y/atspi/accessible/application")
+					.unwrap()
+					.into(),
 			},
 			parent: ObjectRef {
-				name: ":0.0".try_into().unwrap(),
-				path: "/org/a11y/atspi/accessible/parent".try_into().unwrap(),
+				name: BusName::from_static_str(":0.0").unwrap().into(),
+				path: ObjectPath::from_static_str("/org/a11y/atspi/accessible/parent")
+					.unwrap()
+					.into(),
 			},
 			children: Vec::new(),
 			ifaces: InterfaceSet::empty(),

--- a/atspi-common/src/cache.rs
+++ b/atspi-common/src/cache.rs
@@ -37,15 +37,15 @@ impl Default for CacheItem {
 	fn default() -> Self {
 		Self {
 			object: ObjectRef {
-				name: ":0.0".into(),
+				name: ":0.0".try_into().unwrap(),
 				path: "/org/a11y/atspi/accessible/object".try_into().unwrap(),
 			},
 			app: ObjectRef {
-				name: ":0.0".into(),
+				name: ":0.0".try_into().unwrap(),
 				path: "/org/a11y/atspi/accessible/application".try_into().unwrap(),
 			},
 			parent: ObjectRef {
-				name: ":0.0".into(),
+				name: ":0.0".try_into().unwrap(),
 				path: "/org/a11y/atspi/accessible/parent".try_into().unwrap(),
 			},
 			index: 0,
@@ -86,15 +86,15 @@ impl Default for LegacyCacheItem {
 	fn default() -> Self {
 		Self {
 			object: ObjectRef {
-				name: ":0.0".into(),
+				name: ":0.0".try_into().unwrap(),
 				path: "/org/a11y/atspi/accessible/object".try_into().unwrap(),
 			},
 			app: ObjectRef {
-				name: ":0.0".into(),
+				name: ":0.0".try_into().unwrap(),
 				path: "/org/a11y/atspi/accessible/application".try_into().unwrap(),
 			},
 			parent: ObjectRef {
-				name: ":0.0".into(),
+				name: ":0.0".try_into().unwrap(),
 				path: "/org/a11y/atspi/accessible/parent".try_into().unwrap(),
 			},
 			children: Vec::new(),

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -3,6 +3,7 @@ use crate::{
 	events::{EventBodyOwned, GenericEvent, HasMatchRule, HasRegistryEventString, ObjectRef},
 	Event,
 };
+use zbus_names::BusName;
 use zvariant::{ObjectPath, OwnedValue};
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
@@ -84,8 +85,8 @@ impl GenericEvent<'_> for LoadCompleteEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -108,8 +109,8 @@ impl GenericEvent<'_> for ReloadEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -132,8 +133,8 @@ impl GenericEvent<'_> for LoadStoppedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -156,8 +157,8 @@ impl GenericEvent<'_> for ContentChangedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -180,8 +181,8 @@ impl GenericEvent<'_> for AttributesChangedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -204,8 +205,8 @@ impl GenericEvent<'_> for PageChangedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -3,6 +3,7 @@ use crate::{
 	events::{EventBodyOwned, GenericEvent, HasMatchRule, HasRegistryEventString, ObjectRef},
 	Event,
 };
+use zbus_names::BusName;
 use zvariant::{ObjectPath, OwnedValue};
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
@@ -38,8 +39,8 @@ impl GenericEvent<'_> for FocusEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -3,6 +3,7 @@ use crate::{
 	events::{EventBodyOwned, GenericEvent, HasMatchRule, HasRegistryEventString, ObjectRef},
 	Event,
 };
+use zbus_names::BusName;
 use zvariant::{ObjectPath, OwnedValue};
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
@@ -41,8 +42,8 @@ impl GenericEvent<'_> for ModifiersEvent {
 	fn build(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, previous_modifiers: body.detail1, current_modifiers: body.detail2 })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -3,6 +3,7 @@ use crate::{
 	events::{EventBodyOwned, GenericEvent, HasMatchRule, HasRegistryEventString, ObjectRef},
 	Event,
 };
+use zbus_names::BusName;
 use zvariant::ObjectPath;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
@@ -61,8 +62,8 @@ impl GenericEvent<'_> for AbsEvent {
 	fn build(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, x: body.detail1, y: body.detail2 })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -85,8 +86,8 @@ impl GenericEvent<'_> for RelEvent {
 	fn build(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, x: body.detail1, y: body.detail2 })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -109,8 +110,8 @@ impl GenericEvent<'_> for ButtonEvent {
 	fn build(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, detail: body.kind, mouse_x: body.detail1, mouse_y: body.detail2 })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -5,6 +5,7 @@ use crate::{
 	events::{EventBodyOwned, GenericEvent, HasMatchRule, HasRegistryEventString, ObjectRef},
 	Event, State,
 };
+use zbus_names::BusName;
 use zvariant::{ObjectPath, OwnedValue, Value};
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
@@ -429,8 +430,8 @@ impl GenericEvent<'_> for PropertyChangeEvent {
 		let value: Property = body.try_into()?;
 		Ok(Self { item, property, value })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -453,8 +454,8 @@ impl GenericEvent<'_> for BoundsChangedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -477,8 +478,8 @@ impl GenericEvent<'_> for LinkSelectedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -501,8 +502,8 @@ impl GenericEvent<'_> for StateChangedEvent {
 	fn build(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, state: body.kind.into(), enabled: body.detail1 })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -530,8 +531,8 @@ impl GenericEvent<'_> for ChildrenChangedEvent {
 			child: body.any_data.try_into()?,
 		})
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -554,8 +555,8 @@ impl GenericEvent<'_> for VisibleDataChangedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -578,8 +579,8 @@ impl GenericEvent<'_> for SelectionChangedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -602,8 +603,8 @@ impl GenericEvent<'_> for ModelChangedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -626,8 +627,8 @@ impl GenericEvent<'_> for ActiveDescendantChangedEvent {
 	fn build(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, child: body.any_data.try_into()? })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -654,8 +655,8 @@ impl GenericEvent<'_> for AnnouncementEvent {
 			live: body.detail1.try_into()?,
 		})
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -678,8 +679,8 @@ impl GenericEvent<'_> for AttributesChangedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -702,8 +703,8 @@ impl GenericEvent<'_> for RowInsertedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -726,8 +727,8 @@ impl GenericEvent<'_> for RowReorderedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -750,8 +751,8 @@ impl GenericEvent<'_> for RowDeletedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -774,8 +775,8 @@ impl GenericEvent<'_> for ColumnInsertedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -798,8 +799,8 @@ impl GenericEvent<'_> for ColumnReorderedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -822,8 +823,8 @@ impl GenericEvent<'_> for ColumnDeletedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -846,8 +847,8 @@ impl GenericEvent<'_> for TextBoundsChangedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -870,8 +871,8 @@ impl GenericEvent<'_> for TextSelectionChangedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -900,8 +901,8 @@ impl GenericEvent<'_> for TextChangedEvent {
 			text: body.any_data.try_into()?,
 		})
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -924,8 +925,8 @@ impl GenericEvent<'_> for TextAttributesChangedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -948,8 +949,8 @@ impl GenericEvent<'_> for TextCaretMovedEvent {
 	fn build(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, position: body.detail1 })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -3,6 +3,7 @@ use crate::{
 	events::{EventBodyOwned, GenericEvent, HasMatchRule, HasRegistryEventString, ObjectRef},
 	Event,
 };
+use zbus_names::BusName;
 use zvariant::ObjectPath;
 
 /// All events related to the `org.a11y.atspi.Event.Terminal` interface.
@@ -79,8 +80,8 @@ impl GenericEvent<'_> for LineChangedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -103,8 +104,8 @@ impl GenericEvent<'_> for ColumnCountChangedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -127,8 +128,8 @@ impl GenericEvent<'_> for LineCountChangedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -151,8 +152,8 @@ impl GenericEvent<'_> for ApplicationChangedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -175,8 +176,8 @@ impl GenericEvent<'_> for CharWidthChangedEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -3,6 +3,7 @@ use crate::{
 	events::{EventBodyOwned, GenericEvent, HasMatchRule, HasRegistryEventString, ObjectRef},
 	Event,
 };
+use zbus_names::BusName;
 use zvariant::ObjectPath;
 
 /// All events on the `org.a11y.atspi.Event.Window` interface.
@@ -191,8 +192,8 @@ impl GenericEvent<'_> for PropertyChangeEvent {
 	fn build(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, property: body.kind })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -215,8 +216,8 @@ impl GenericEvent<'_> for MinimizeEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -239,8 +240,8 @@ impl GenericEvent<'_> for MaximizeEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -263,8 +264,8 @@ impl GenericEvent<'_> for RestoreEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -287,8 +288,8 @@ impl GenericEvent<'_> for CloseEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -311,8 +312,8 @@ impl GenericEvent<'_> for CreateEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -335,8 +336,8 @@ impl GenericEvent<'_> for ReparentEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -359,8 +360,8 @@ impl GenericEvent<'_> for DesktopCreateEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -383,8 +384,8 @@ impl GenericEvent<'_> for DesktopDestroyEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -407,8 +408,8 @@ impl GenericEvent<'_> for DestroyEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -431,8 +432,8 @@ impl GenericEvent<'_> for ActivateEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -455,8 +456,8 @@ impl GenericEvent<'_> for DeactivateEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -479,8 +480,8 @@ impl GenericEvent<'_> for RaiseEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -503,8 +504,8 @@ impl GenericEvent<'_> for LowerEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -527,8 +528,8 @@ impl GenericEvent<'_> for MoveEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -551,8 +552,8 @@ impl GenericEvent<'_> for ResizeEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -575,8 +576,8 @@ impl GenericEvent<'_> for ShadeEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -599,8 +600,8 @@ impl GenericEvent<'_> for UUshadeEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()
@@ -623,8 +624,8 @@ impl GenericEvent<'_> for RestyleEvent {
 	fn build(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
-	fn sender(&self) -> String {
-		self.item.name.clone()
+	fn sender(&self) -> BusName<'_> {
+		self.item.name.clone().into()
 	}
 	fn path<'a>(&self) -> ObjectPath<'_> {
 		self.item.path.clone().into()

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -184,7 +184,7 @@ macro_rules! impl_to_dbus_message {
 					<$type as GenericEvent>::DBUS_INTERFACE,
 					<$type as GenericEvent>::DBUS_MEMBER,
 				)?
-				.sender(event.sender())?
+				.sender(event.sender().to_string())?
 				.build(&event.body())?)
 			}
 		}

--- a/atspi-common/src/object_ref.rs
+++ b/atspi-common/src/object_ref.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use zbus_lockstep_macros::validate;
-use zbus_names::OwnedBusName;
+use zbus_names::{BusName, OwnedBusName};
 use zvariant::{ObjectPath, OwnedObjectPath, Signature, Type};
 
 pub const OBJECT_REF_SIGNATURE: Signature<'_> = Signature::from_static_str_unchecked("(so)");
@@ -23,7 +23,7 @@ pub struct ObjectRef {
 impl Default for ObjectRef {
 	fn default() -> Self {
 		ObjectRef {
-			name: ":0.0".try_into().unwrap(),
+			name: BusName::from_static_str(":0.0").unwrap().into(),
 			path: ObjectPath::from_static_str("/org/a11y/atspi/accessible/null")
 				.unwrap()
 				.into(),

--- a/atspi-common/tests/tests.rs
+++ b/atspi-common/tests/tests.rs
@@ -5,6 +5,7 @@ use atspi_connection::AccessibilityConnection;
 use std::time::Duration;
 use tokio_stream::StreamExt;
 use zbus::Message;
+use zbus_names::OwnedBusName;
 use zvariant::OwnedObjectPath;
 
 #[tokio::test]
@@ -18,7 +19,7 @@ async fn test_recv_remove_accessible() {
 
 	let msg = {
 		let remove_body = ObjectRef {
-			name: ":69.420".into(),
+			name: OwnedBusName::try_from(":69.420").unwrap(),
 			path: OwnedObjectPath::try_from("/org/a11y/atspi/accessible/remove").unwrap(),
 		};
 

--- a/atspi-proxies/src/accessible.rs
+++ b/atspi-proxies/src/accessible.rs
@@ -233,7 +233,7 @@ impl TryFrom<AccessibleProxy<'_>> for ObjectRef {
 	type Error = AtspiError;
 	fn try_from(proxy: AccessibleProxy<'_>) -> Result<ObjectRef, Self::Error> {
 		Ok(ObjectRef {
-			name: proxy.inner().destination().to_string(),
+			name: proxy.inner().destination().to_owned().into(),
 			path: proxy.inner().path().to_string().try_into()?,
 		})
 	}
@@ -242,7 +242,7 @@ impl TryFrom<&AccessibleProxy<'_>> for ObjectRef {
 	type Error = AtspiError;
 	fn try_from(proxy: &AccessibleProxy<'_>) -> Result<ObjectRef, Self::Error> {
 		Ok(ObjectRef {
-			name: proxy.inner().destination().to_string(),
+			name: proxy.inner().destination().to_owned().into(),
 			path: proxy.inner().path().to_string().try_into()?,
 		})
 	}


### PR DESCRIPTION
Make ObjectRef more explicit in that the "name" refers to a `zbus_names::BusName`, and not just any String.
