### PR TITLE
`from_message_parts` into `from_message`

### DIFF
--- a/atspi-common/src/error.rs
+++ b/atspi-common/src/error.rs
@@ -30,6 +30,9 @@ pub enum AtspiError {
 	/// No Signature.
 	MissingSignature,
 
+	/// When matching on a signal with an event, but the event does not match the signal.
+	EventMismatch,
+
 	/// When matching on an unknown role
 	UnknownRole(u32),
 
@@ -86,6 +89,7 @@ impl std::fmt::Display for AtspiError {
 			Self::MissingInterface => f.write_str("Missing interface."),
 			Self::MissingMember => f.write_str("Missing member."),
 			Self::MissingSignature => f.write_str("Missing signature."),
+			Self::EventMismatch => f.write_str("Event <--> Message mismatch"),
 			Self::UnknownRole(e) => f.write_str(&format!("atspi: Unknown role: {e}")),
 			Self::UnknownSignal => f.write_str("atspi: Unknown signal"),
 			Self::CacheVariantMismatch => f.write_str("atspi: Cache variant mismatch"),

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -149,9 +149,10 @@ impl BusProperties for LoadCompleteEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: ObjectRef::try_from(msg)? })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -167,9 +168,10 @@ impl BusProperties for ReloadEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: ObjectRef::try_from(msg)? })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -185,9 +187,10 @@ impl BusProperties for LoadStoppedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: ObjectRef::try_from(msg)? })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -203,9 +206,10 @@ impl BusProperties for ContentChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: ObjectRef::try_from(msg)? })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -221,9 +225,10 @@ impl BusProperties for AttributesChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: ObjectRef::try_from(msg)? })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -239,9 +244,10 @@ impl BusProperties for PageChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: ObjectRef::try_from(msg)? })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -149,6 +149,7 @@ impl BusProperties for LoadCompleteEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -168,6 +169,7 @@ impl BusProperties for ReloadEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -177,7 +179,6 @@ impl BusProperties for ReloadEvent {
 		copy.into()
 	}
 }
-
 impl BusProperties for LoadStoppedEvent {
 	const DBUS_MEMBER: &'static str = "LoadStopped";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Document";
@@ -187,6 +188,7 @@ impl BusProperties for LoadStoppedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -206,6 +208,7 @@ impl BusProperties for ContentChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -225,6 +228,7 @@ impl BusProperties for AttributesChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -244,6 +248,7 @@ impl BusProperties for PageChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -102,7 +102,7 @@ impl HasMatchRule for DocumentEvents {
 /// `LibreOffice` has loaded a document from disk.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct LoadCompleteEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`ObjectRef`][crate::object_ref::ObjectRef] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
@@ -110,7 +110,7 @@ pub struct LoadCompleteEvent {
 /// For example: pressing F5, or `Control + r` will reload a page in a web browser.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct ReloadEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`ObjectRef`][crate::events::ObjectRef] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
@@ -118,25 +118,25 @@ pub struct ReloadEvent {
 /// For example: during the loading of a large web page, a user may press `Escape` to stop loading the page.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct LoadStoppedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`ObjectRef`][crate::events::ObjectRef] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct ContentChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`ObjectRef`][crate::events::ObjectRef] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct AttributesChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`ObjectRef`][crate::events::ObjectRef] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct PageChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`ObjectRef`][crate::events::ObjectRef] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -1,6 +1,6 @@
 use crate::{
 	error::AtspiError,
-	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, ObjectRef},
+	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::BusName;
@@ -150,7 +150,7 @@ impl BusProperties for LoadCompleteEvent {
 	type Body = EventBodyOwned;
 
 	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		Ok(Self { item: ObjectRef::try_from(msg)? })
+		Ok(Self { item: msg.try_into()? })
 	}
 
 	fn body(&self) -> Self::Body {
@@ -169,7 +169,7 @@ impl BusProperties for ReloadEvent {
 	type Body = EventBodyOwned;
 
 	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		Ok(Self { item: ObjectRef::try_from(msg)? })
+		Ok(Self { item: msg.try_into()? })
 	}
 
 	fn body(&self) -> Self::Body {
@@ -188,7 +188,7 @@ impl BusProperties for LoadStoppedEvent {
 	type Body = EventBodyOwned;
 
 	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		Ok(Self { item: ObjectRef::try_from(msg)? })
+		Ok(Self { item: msg.try_into()? })
 	}
 
 	fn body(&self) -> Self::Body {
@@ -207,7 +207,7 @@ impl BusProperties for ContentChangedEvent {
 	type Body = EventBodyOwned;
 
 	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		Ok(Self { item: ObjectRef::try_from(msg)? })
+		Ok(Self { item: msg.try_into()? })
 	}
 
 	fn body(&self) -> Self::Body {
@@ -226,7 +226,7 @@ impl BusProperties for AttributesChangedEvent {
 	type Body = EventBodyOwned;
 
 	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		Ok(Self { item: ObjectRef::try_from(msg)? })
+		Ok(Self { item: msg.try_into()? })
 	}
 
 	fn body(&self) -> Self::Body {
@@ -245,7 +245,7 @@ impl BusProperties for PageChangedEvent {
 	type Body = EventBodyOwned;
 
 	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		Ok(Self { item: ObjectRef::try_from(msg)? })
+		Ok(Self { item: msg.try_into()? })
 	}
 
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -149,7 +149,7 @@ impl BusProperties for LoadCompleteEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 
@@ -168,7 +168,7 @@ impl BusProperties for ReloadEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 
@@ -187,7 +187,7 @@ impl BusProperties for LoadStoppedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 
@@ -206,7 +206,7 @@ impl BusProperties for ContentChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 
@@ -225,7 +225,7 @@ impl BusProperties for AttributesChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 
@@ -244,7 +244,7 @@ impl BusProperties for PageChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -59,7 +59,7 @@ impl HasMatchRule for FocusEvents {
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct FocusEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`ObjectRef`][crate::events::ObjectRef] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -72,6 +72,7 @@ impl BusProperties for FocusEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -72,9 +72,10 @@ impl BusProperties for FocusEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: ObjectRef::try_from(msg)? })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -1,6 +1,6 @@
 use crate::{
 	error::AtspiError,
-	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, ObjectRef},
+	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::BusName;
@@ -72,8 +72,8 @@ impl BusProperties for FocusEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		Ok(Self { item: ObjectRef::try_from(msg)? })
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -75,9 +75,12 @@ impl BusProperties for ModifiersEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = ObjectRef::try_from(msg)?;
+		let body: EventBodyOwned = msg.try_into()?;
 		Ok(Self { item, previous_modifiers: body.detail1, current_modifiers: body.detail2 })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -1,7 +1,10 @@
 use crate::{
 	error::AtspiError,
-	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, ObjectRef},
-	Event, EventProperties, EventTypeProperties,
+	events::{
+		BusProperties, EventBodyOwned, EventProperties, HasMatchRule, HasRegistryEventString,
+		ObjectRef,
+	},
+	Event, EventTypeProperties,
 };
 use zbus_names::BusName;
 use zvariant::{ObjectPath, OwnedValue};
@@ -75,6 +78,7 @@ impl BusProperties for ModifiersEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body: EventBodyOwned = msg.try_into()?;

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -75,7 +75,7 @@ impl BusProperties for ModifiersEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body: EventBodyOwned = msg.try_into()?;
 		Ok(Self { item, previous_modifiers: body.detail1, current_modifiers: body.detail2 })

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -431,6 +431,7 @@ impl BusProperties for LegacyAddAccessibleEvent {
 
 	type Body = LegacyCacheItem;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let body = msg.body();
 		let node_added: Self::Body = body.deserialize::<Self::Body>()?;
@@ -472,6 +473,7 @@ impl BusProperties for AddAccessibleEvent {
 
 	type Body = CacheItem;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let body = msg.body();
 		let node_added: Self::Body = body.deserialize::<Self::Body>()?;
@@ -512,6 +514,7 @@ impl_from_user_facing_event_for_interface_event_enum!(
 impl_from_user_facing_type_for_event_enum!(RemoveAccessibleEvent, Event::Cache);
 impl_try_from_event_for_user_facing_type!(RemoveAccessibleEvent, CacheEvents::Remove, Event::Cache);
 event_test_cases!(RemoveAccessibleEvent);
+
 impl BusProperties for RemoveAccessibleEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Cache:Remove";
 	const MATCH_RULE_STRING: &'static str =
@@ -521,6 +524,7 @@ impl BusProperties for RemoveAccessibleEvent {
 
 	type Body = ObjectRef;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let body = msg.body();
 		let node_removed: Self::Body = body.deserialize::<Self::Body>()?;
@@ -723,6 +727,7 @@ impl BusProperties for EventListenerDeregisteredEvent {
 
 	type Body = EventListeners;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body: Self::Body = msg.body().deserialize::<Self::Body>()?;
@@ -759,6 +764,7 @@ impl_try_from_event_for_user_facing_type!(
 	Event::Listener
 );
 event_test_cases!(EventListenerRegisteredEvent);
+
 impl BusProperties for EventListenerRegisteredEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Registry:EventListenerRegistered";
 	const MATCH_RULE_STRING: &'static str =
@@ -768,6 +774,7 @@ impl BusProperties for EventListenerRegisteredEvent {
 
 	type Body = EventListeners;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body: Self::Body = msg.body().deserialize::<Self::Body>()?;
@@ -805,6 +812,7 @@ impl TryFrom<Event> for AvailableEvent {
 	}
 }
 event_test_cases!(AvailableEvent);
+
 impl BusProperties for AvailableEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Socket:Available";
 	const MATCH_RULE_STRING: &'static str =
@@ -814,6 +822,7 @@ impl BusProperties for AvailableEvent {
 
 	type Body = ObjectRef;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
@@ -997,6 +1006,7 @@ pub trait BusProperties {
 	///
 	/// When the body type, which is what the raw message looks like over `DBus`, does not match the type that is expected for the given event.
 	/// It is not possible for this to error on most events, but on events whose raw message [`Self::Body`] type contains a [`enum@zvariant::Value`], you may get errors when constructing the structure.
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> std::result::Result<Self, AtspiError>
 	where
 		Self: Sized;

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -431,7 +431,7 @@ impl BusProperties for LegacyAddAccessibleEvent {
 
 	type Body = LegacyCacheItem;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let body = msg.body();
 		let node_added: Self::Body = body.deserialize::<Self::Body>()?;
 		let item = msg.try_into()?;
@@ -472,7 +472,7 @@ impl BusProperties for AddAccessibleEvent {
 
 	type Body = CacheItem;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let body = msg.body();
 		let node_added: Self::Body = body.deserialize::<Self::Body>()?;
 		let item = msg.try_into()?;
@@ -521,7 +521,7 @@ impl BusProperties for RemoveAccessibleEvent {
 
 	type Body = ObjectRef;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let body = msg.body();
 		let node_removed: Self::Body = body.deserialize::<Self::Body>()?;
 		let item = msg.try_into()?;
@@ -723,7 +723,7 @@ impl BusProperties for EventListenerDeregisteredEvent {
 
 	type Body = EventListeners;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body: Self::Body = msg.body().deserialize::<Self::Body>()?;
 		Ok(Self { item, deregistered_event: body })
@@ -768,7 +768,7 @@ impl BusProperties for EventListenerRegisteredEvent {
 
 	type Body = EventListeners;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body: Self::Body = msg.body().deserialize::<Self::Body>()?;
 		Ok(Self { item, registered_event: body })
@@ -814,7 +814,7 @@ impl BusProperties for AvailableEvent {
 
 	type Body = ObjectRef;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		let socket: Self::Body = body.deserialize::<Self::Body>()?;
@@ -988,7 +988,7 @@ pub trait BusProperties {
 	///    if !msg.matches_event::<EventType>()? {
 	///        return Err(AtspiError::EventMismatch);
 	///    }
-	///    let event = EventType::from_message(msg)?;
+	///    let event = EventType::try_from_message(msg)?;
 	/// ```
 	///
 	/// These checks are already performed in the `Event::try_from` implementation, therefore the check is omited in the implementations of `BusProperties`.
@@ -997,7 +997,7 @@ pub trait BusProperties {
 	///
 	/// When the body type, which is what the raw message looks like over `DBus`, does not match the type that is expected for the given event.
 	/// It is not possible for this to error on most events, but on events whose raw message [`Self::Body`] type contains a [`enum@zvariant::Value`], you may get errors when constructing the structure.
-	fn from_message(msg: &zbus::Message) -> std::result::Result<Self, AtspiError>
+	fn try_from_message(msg: &zbus::Message) -> std::result::Result<Self, AtspiError>
 	where
 		Self: Sized;
 

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -107,6 +107,7 @@ impl BusProperties for AbsEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
@@ -128,6 +129,7 @@ impl BusProperties for RelEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
@@ -149,6 +151,7 @@ impl BusProperties for ButtonEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -107,7 +107,7 @@ impl BusProperties for AbsEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
 		Ok(Self { item, x: body.detail1, y: body.detail2 })
@@ -128,7 +128,7 @@ impl BusProperties for RelEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
 		Ok(Self { item, x: body.detail1, y: body.detail2 })
@@ -149,7 +149,7 @@ impl BusProperties for ButtonEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
 		Ok(Self { item, detail: body.kind, mouse_x: body.detail1, mouse_y: body.detail2 })

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -107,9 +107,12 @@ impl BusProperties for AbsEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = ObjectRef::try_from(msg)?;
+		let body = EventBodyOwned::try_from(msg)?;
 		Ok(Self { item, x: body.detail1, y: body.detail2 })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -125,9 +128,12 @@ impl BusProperties for RelEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = ObjectRef::try_from(msg)?;
+		let body = EventBodyOwned::try_from(msg)?;
 		Ok(Self { item, x: body.detail1, y: body.detail2 })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -143,7 +149,9 @@ impl BusProperties for ButtonEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = ObjectRef::try_from(msg)?;
+		let body = EventBodyOwned::try_from(msg)?;
 		Ok(Self { item, detail: body.kind, mouse_x: body.detail1, mouse_y: body.detail2 })
 	}
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -587,7 +587,7 @@ impl BusProperties for PropertyChangeEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
 		let property = body.kind.clone();
@@ -609,7 +609,7 @@ impl BusProperties for BoundsChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 
@@ -628,7 +628,7 @@ impl BusProperties for LinkSelectedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 
@@ -647,7 +647,7 @@ impl BusProperties for StateChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
 		Ok(Self { item, state: body.kind.into(), enabled: body.detail1 })
@@ -668,7 +668,7 @@ impl BusProperties for ChildrenChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
 
@@ -695,7 +695,7 @@ impl BusProperties for VisibleDataChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 
@@ -714,7 +714,7 @@ impl BusProperties for SelectionChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 
@@ -733,7 +733,7 @@ impl BusProperties for ModelChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 
@@ -752,7 +752,7 @@ impl BusProperties for ActiveDescendantChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
 		Ok(Self { item, child: body.any_data.try_into()? })
@@ -773,7 +773,7 @@ impl BusProperties for AnnouncementEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
 
@@ -798,7 +798,7 @@ impl BusProperties for AttributesChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -816,7 +816,7 @@ impl BusProperties for RowInsertedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -834,7 +834,7 @@ impl BusProperties for RowReorderedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -852,7 +852,7 @@ impl BusProperties for RowDeletedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -870,7 +870,7 @@ impl BusProperties for ColumnInsertedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -888,7 +888,7 @@ impl BusProperties for ColumnReorderedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -906,7 +906,7 @@ impl BusProperties for ColumnDeletedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 
@@ -925,7 +925,7 @@ impl BusProperties for TextBoundsChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 
@@ -944,7 +944,7 @@ impl BusProperties for TextSelectionChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 
@@ -963,7 +963,7 @@ impl BusProperties for TextChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
 
@@ -990,7 +990,7 @@ impl BusProperties for TextAttributesChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 
@@ -1009,7 +1009,7 @@ impl BusProperties for TextCaretMovedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
 

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -587,7 +587,9 @@ impl BusProperties for PropertyChangeEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = ObjectRef::try_from(msg)?;
+		let body = EventBodyOwned::try_from(msg)?;
 		let property = body.kind.clone();
 		let value: Property = body.try_into()?;
 		Ok(Self { item, property, value })
@@ -607,9 +609,10 @@ impl BusProperties for BoundsChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -625,9 +628,10 @@ impl BusProperties for LinkSelectedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -643,9 +647,12 @@ impl BusProperties for StateChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = ObjectRef::try_from(msg)?;
+		let body = EventBodyOwned::try_from(msg)?;
 		Ok(Self { item, state: body.kind.into(), enabled: body.detail1 })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -661,7 +668,10 @@ impl BusProperties for ChildrenChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = ObjectRef::try_from(msg)?;
+		let body = EventBodyOwned::try_from(msg)?;
+
 		Ok(Self {
 			item,
 			operation: body.kind,
@@ -669,6 +679,7 @@ impl BusProperties for ChildrenChangedEvent {
 			child: body.any_data.try_into()?,
 		})
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -684,9 +695,10 @@ impl BusProperties for VisibleDataChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -702,9 +714,10 @@ impl BusProperties for SelectionChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -720,9 +733,10 @@ impl BusProperties for ModelChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -738,9 +752,12 @@ impl BusProperties for ActiveDescendantChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = ObjectRef::try_from(msg)?;
+		let body = EventBodyOwned::try_from(msg)?;
 		Ok(Self { item, child: body.any_data.try_into()? })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -756,7 +773,10 @@ impl BusProperties for AnnouncementEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = ObjectRef::try_from(msg)?;
+		let body = EventBodyOwned::try_from(msg)?;
+
 		Ok(Self {
 			item,
 			text: body.any_data.try_into().map_err(|_| AtspiError::Conversion("text"))?,
@@ -778,8 +798,8 @@ impl BusProperties for AttributesChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -796,8 +816,8 @@ impl BusProperties for RowInsertedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -814,8 +834,8 @@ impl BusProperties for RowReorderedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -832,8 +852,8 @@ impl BusProperties for RowDeletedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -850,8 +870,8 @@ impl BusProperties for ColumnInsertedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -868,8 +888,8 @@ impl BusProperties for ColumnReorderedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -886,9 +906,10 @@ impl BusProperties for ColumnDeletedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -904,9 +925,10 @@ impl BusProperties for TextBoundsChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -922,9 +944,10 @@ impl BusProperties for TextSelectionChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -940,7 +963,10 @@ impl BusProperties for TextChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = ObjectRef::try_from(msg)?;
+		let body = EventBodyOwned::try_from(msg)?;
+
 		Ok(Self {
 			item,
 			operation: body.kind,
@@ -964,9 +990,10 @@ impl BusProperties for TextAttributesChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -982,9 +1009,13 @@ impl BusProperties for TextCaretMovedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = ObjectRef::try_from(msg)?;
+		let body = EventBodyOwned::try_from(msg)?;
+
 		Ok(Self { item, position: body.detail1 })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -587,6 +587,7 @@ impl BusProperties for PropertyChangeEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
@@ -609,6 +610,7 @@ impl BusProperties for BoundsChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -628,6 +630,7 @@ impl BusProperties for LinkSelectedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -647,6 +650,7 @@ impl BusProperties for StateChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
@@ -668,6 +672,7 @@ impl BusProperties for ChildrenChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
@@ -695,6 +700,7 @@ impl BusProperties for VisibleDataChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -714,6 +720,7 @@ impl BusProperties for SelectionChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -733,6 +740,7 @@ impl BusProperties for ModelChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -752,6 +760,7 @@ impl BusProperties for ActiveDescendantChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
@@ -773,6 +782,7 @@ impl BusProperties for AnnouncementEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
@@ -798,6 +808,7 @@ impl BusProperties for AttributesChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -816,6 +827,7 @@ impl BusProperties for RowInsertedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -834,6 +846,7 @@ impl BusProperties for RowReorderedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -852,6 +865,7 @@ impl BusProperties for RowDeletedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -870,6 +884,7 @@ impl BusProperties for ColumnInsertedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -888,6 +903,7 @@ impl BusProperties for ColumnReorderedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -906,6 +922,7 @@ impl BusProperties for ColumnDeletedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -925,6 +942,7 @@ impl BusProperties for TextBoundsChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -944,6 +962,7 @@ impl BusProperties for TextSelectionChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -963,6 +982,7 @@ impl BusProperties for TextChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
@@ -990,6 +1010,7 @@ impl BusProperties for TextAttributesChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -1009,6 +1030,7 @@ impl BusProperties for TextCaretMovedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -137,7 +137,7 @@ impl BusProperties for LineChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -155,7 +155,7 @@ impl BusProperties for ColumnCountChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -173,7 +173,7 @@ impl BusProperties for LineCountChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -191,7 +191,7 @@ impl BusProperties for ApplicationChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -209,7 +209,7 @@ impl BusProperties for CharWidthChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -94,7 +94,7 @@ impl HasMatchRule for TerminalEvents {
 /// A line of text has been changed.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct LineChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`ObjectRef`][crate::events::ObjectRef] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
@@ -102,7 +102,7 @@ pub struct LineChangedEvent {
 /// able to fit on one *visual* line has changed.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct ColumnCountChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`ObjectRef`][crate::events::ObjectRef] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
@@ -110,13 +110,13 @@ pub struct ColumnCountChangedEvent {
 /// able to fit within the terminal has changed.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct LineCountChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`ObjectRef`][crate::events::ObjectRef] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct ApplicationChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`ObjectRef`][crate::events::ObjectRef] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
@@ -124,7 +124,7 @@ pub struct ApplicationChangedEvent {
 /// able to fit on one *visual* line has changed.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct CharWidthChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`ObjectRef`][crate::events::ObjectRef] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -1,6 +1,6 @@
 use crate::{
 	error::AtspiError,
-	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, ObjectRef},
+	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::BusName;
@@ -137,8 +137,8 @@ impl BusProperties for LineChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -155,8 +155,8 @@ impl BusProperties for ColumnCountChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -173,8 +173,8 @@ impl BusProperties for LineCountChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -191,8 +191,8 @@ impl BusProperties for ApplicationChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -209,8 +209,8 @@ impl BusProperties for CharWidthChangedEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -137,6 +137,7 @@ impl BusProperties for LineChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -155,6 +156,7 @@ impl BusProperties for ColumnCountChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -173,6 +175,7 @@ impl BusProperties for LineCountChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -191,6 +194,7 @@ impl BusProperties for ApplicationChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -209,6 +213,7 @@ impl BusProperties for CharWidthChangedEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -333,9 +333,12 @@ impl BusProperties for PropertyChangeEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = ObjectRef::try_from(msg)?;
+		let body = EventBodyOwned::try_from(msg)?;
 		Ok(Self { item, property: body.kind })
 	}
+
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
 		copy.into()
@@ -351,8 +354,8 @@ impl BusProperties for MinimizeEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -369,8 +372,8 @@ impl BusProperties for MaximizeEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -387,8 +390,8 @@ impl BusProperties for RestoreEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -405,8 +408,8 @@ impl BusProperties for CloseEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -423,8 +426,8 @@ impl BusProperties for CreateEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -441,8 +444,8 @@ impl BusProperties for ReparentEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -459,8 +462,8 @@ impl BusProperties for DesktopCreateEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -477,8 +480,8 @@ impl BusProperties for DesktopDestroyEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -495,8 +498,8 @@ impl BusProperties for DestroyEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -513,8 +516,8 @@ impl BusProperties for ActivateEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -531,8 +534,8 @@ impl BusProperties for DeactivateEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -549,8 +552,8 @@ impl BusProperties for RaiseEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -567,8 +570,8 @@ impl BusProperties for LowerEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -585,8 +588,8 @@ impl BusProperties for MoveEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -603,8 +606,8 @@ impl BusProperties for ResizeEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -621,8 +624,8 @@ impl BusProperties for ShadeEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -639,8 +642,8 @@ impl BusProperties for UUshadeEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -657,8 +660,8 @@ impl BusProperties for RestyleEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item })
+	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -333,6 +333,7 @@ impl BusProperties for PropertyChangeEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
@@ -354,6 +355,7 @@ impl BusProperties for MinimizeEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -372,6 +374,7 @@ impl BusProperties for MaximizeEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -390,6 +393,7 @@ impl BusProperties for RestoreEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -408,6 +412,7 @@ impl BusProperties for CloseEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -426,6 +431,7 @@ impl BusProperties for CreateEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -444,6 +450,7 @@ impl BusProperties for ReparentEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -462,6 +469,7 @@ impl BusProperties for DesktopCreateEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -480,6 +488,7 @@ impl BusProperties for DesktopDestroyEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -498,6 +507,7 @@ impl BusProperties for DestroyEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -516,6 +526,7 @@ impl BusProperties for ActivateEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -534,6 +545,7 @@ impl BusProperties for DeactivateEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -552,6 +564,7 @@ impl BusProperties for RaiseEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -570,6 +583,7 @@ impl BusProperties for LowerEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -588,6 +602,7 @@ impl BusProperties for MoveEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -606,6 +621,7 @@ impl BusProperties for ResizeEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -624,6 +640,7 @@ impl BusProperties for ShadeEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -642,6 +659,7 @@ impl BusProperties for UUshadeEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
@@ -660,6 +678,7 @@ impl BusProperties for RestyleEvent {
 
 	type Body = EventBodyOwned;
 
+	#[cfg(feature = "zbus")]
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -333,7 +333,7 @@ impl BusProperties for PropertyChangeEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = ObjectRef::try_from(msg)?;
 		let body = EventBodyOwned::try_from(msg)?;
 		Ok(Self { item, property: body.kind })
@@ -354,7 +354,7 @@ impl BusProperties for MinimizeEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -372,7 +372,7 @@ impl BusProperties for MaximizeEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -390,7 +390,7 @@ impl BusProperties for RestoreEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -408,7 +408,7 @@ impl BusProperties for CloseEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -426,7 +426,7 @@ impl BusProperties for CreateEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -444,7 +444,7 @@ impl BusProperties for ReparentEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -462,7 +462,7 @@ impl BusProperties for DesktopCreateEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -480,7 +480,7 @@ impl BusProperties for DesktopDestroyEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -498,7 +498,7 @@ impl BusProperties for DestroyEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -516,7 +516,7 @@ impl BusProperties for ActivateEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -534,7 +534,7 @@ impl BusProperties for DeactivateEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -552,7 +552,7 @@ impl BusProperties for RaiseEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -570,7 +570,7 @@ impl BusProperties for LowerEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -588,7 +588,7 @@ impl BusProperties for MoveEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -606,7 +606,7 @@ impl BusProperties for ResizeEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -624,7 +624,7 @@ impl BusProperties for ShadeEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -642,7 +642,7 @@ impl BusProperties for UUshadeEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -660,7 +660,7 @@ impl BusProperties for RestyleEvent {
 
 	type Body = EventBodyOwned;
 
-	fn from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		Ok(Self { item: msg.try_into()? })
 	}
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/lib.rs
+++ b/atspi-common/src/lib.rs
@@ -232,6 +232,7 @@ impl TryFrom<i32> for Live {
 	}
 }
 
+#[cfg(feature = "zbus")]
 pub trait MessageExt {
 	/// Check if the message matches the event.
 	///
@@ -242,6 +243,7 @@ pub trait MessageExt {
 	fn matches_event<EV: BusProperties>(&self) -> crate::Result<bool>;
 }
 
+#[cfg(feature = "zbus")]
 impl MessageExt for zbus::Message {
 	fn matches_event<EV: BusProperties>(&self) -> crate::Result<bool> {
 		let event_signature = <EV as BusProperties>::Body::signature();

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -296,6 +296,7 @@ macro_rules! impl_from_dbus_message {
 #[cfg(test)]
 macro_rules! generic_event_test_case {
 	($type:ty) => {
+		#[cfg(feature = "zbus")]
 		#[test]
 		fn generic_event_uses() {
 			let struct_event = <$type>::default();
@@ -542,6 +543,7 @@ macro_rules! event_wrapper_test_cases {
 		#[rename_item::rename(name($type), prefix = "events_tests_", case = "snake")]
 		mod foo {
 			use super::{$any_subtype, $type, Event, BusProperties};
+			#[cfg(feature = "zbus")]
 			#[test]
 			fn into_and_try_from_event() {
 				// Create a default event struct from its type's `Default::default()` impl.

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -237,7 +237,7 @@ macro_rules! impl_to_dbus_message {
 ///   type Error = AtspiError;
 ///   fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
 ///    if msg.header().interface().ok_or(AtspiError::MissingInterface)? != StateChangedEvent::DBUS_INTERFACE {
-///     StateChangedEvent::from_message(msg)
+///     StateChangedEvent::try_from_message(msg)
 ///  }
 /// }
 /// ```
@@ -250,7 +250,7 @@ macro_rules! impl_from_dbus_message {
 				use crate::MessageExt;
 
 				if msg.matches_event::<$type>()? {
-					<$type>::from_message(msg)
+					<$type>::try_from_message(msg)
 				} else {
 					Err(AtspiError::EventMismatch)
 				}
@@ -263,13 +263,13 @@ macro_rules! impl_from_dbus_message {
 // This prevents Clippy from complaining about the macro not being used.
 // It is being used, but only in test mode.
 //
-/// Tests `Default` and `BusProperties::from_message` for a given event struct.
+/// Tests `Default` and `BusProperties::try_from_message` for a given event struct.
 ///
 /// Obtains a default for the given event struct.
 /// Asserts that the path and sender are the default.
 ///
 /// Retreives a body from the event type, creates a message from the event type and body.
-/// Then tests `BusProperties::from_message` with the message.
+/// Then tests `BusProperties::try_from_message` with the message.
 #[cfg(test)]
 macro_rules! generic_event_test_case {
 	($type:ty) => {
@@ -293,7 +293,7 @@ macro_rules! generic_event_test_case {
 				.build(&body)
 				.expect("Should build a message from the default event struct.");
 
-			let build_struct = <$type>::from_message(&msg)
+			let build_struct = <$type>::try_from_message(&msg)
 				.expect("<$type as Default>'s parts should build a valid ObjectRef");
 			assert_eq!(struct_event, build_struct);
 		}

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -118,9 +118,9 @@ macro_rules! impl_from_user_facing_event_for_interface_event_enum {
 
 /// Expands to a conversion given two arguments,
 /// 1. the user facing event type `(inner_type)`
-/// which relies on a conversion to its interface variant enum type variant.
+///    which relies on a conversion to its interface variant enum type variant.
 /// 2. the outer `Event::<Interface(<InterfaceEnum>)>` wrapper.,
-/// the enum type and outtermost variant.
+///    the enum type and outtermost variant.
 ///
 /// ```ignore                                   user facing type, outer event variant
 /// impl_from_user_facing_type_for_event_enum!(StateChangedEvent, Event::Object);
@@ -238,6 +238,7 @@ macro_rules! impl_to_dbus_message {
 ///   fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
 ///    if msg.header().interface().ok_or(AtspiError::MissingInterface)? != StateChangedEvent::DBUS_INTERFACE {
 ///     StateChangedEvent::try_from_message(msg)
+///   }
 ///  }
 /// }
 /// ```

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -32,8 +32,7 @@ tracing = ["atspi-connection/tracing"]
 atspi-common = { path = "../atspi-common", version = "0.5.0", default-features = false }
 atspi-connection = { path = "../atspi-connection", version = "0.5.0", default-features = false, optional = true }
 atspi-proxies = { path = "../atspi-proxies", version = "0.5.0", default-features = false, optional = true }
-zbus = { workspace = true, optional = true }
-
+zbus = { workspace = true, optional = true, default-features = false }
 
 [[bench]]
 name = "event_parsing"

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -28,6 +28,7 @@ connection-async-std = ["atspi-connection/async-std", "connection"]
 connection-tokio = ["atspi-connection/tokio", "connection"]
 tracing = ["atspi-connection/tracing"]
 
+
 [dependencies]
 atspi-common = { path = "../atspi-common", version = "0.5.0", default-features = false }
 atspi-connection = { path = "../atspi-connection", version = "0.5.0", default-features = false, optional = true }


### PR DESCRIPTION
Builds on 'new-generic-event-trait'

`from_message` takes just one argument, `&zbus::Message` and converts into the `BusProperties` implementing type.

This avoids crreating a body in the cases we do not need one.

This also introduces a `MessageExt` trait that provides `matches_event` This allows users who have / prefer a `MessageStream` over the `event_stream` to do something like this:

```Rust
	if msg.matches_event::<AbsEvent>()? {
		AbsEvent::from_message()?
	} else {
		Err(AtspiError::EventMisMatch)
	};
```

or simply use:

```Rust
	AbsEvent::try_from(msg)?
```

Which now uses `matches_event`.

Lastly, this has a few little optimizations that avoid clones in a conversion.