### PR TITLE
`v0.22.0`

### DIFF
--- a/atspi-common/Cargo.toml
+++ b/atspi-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atspi-common"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 readme = "README.md"
 categories = ["accessibility", "api-bindings"]

--- a/atspi-connection/Cargo.toml
+++ b/atspi-connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atspi-connection"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "A method of connecting, querying, sending and receiving over AT-SPI."
 license = "Apache-2.0 OR MIT" 
@@ -20,8 +20,8 @@ async-std = ["zbus/async-io", "atspi-proxies/async-std", "atspi-common/async-std
 tokio = ["zbus/tokio", "atspi-proxies/tokio", "atspi-common/tokio"]
 
 [dependencies]
-atspi-common = { path = "../atspi-common/", version = "0.5.0", default-features = false }
-atspi-proxies = { path = "../atspi-proxies/", version = "0.5.0", default-features = false }
+atspi-common = { path = "../atspi-common/", version = "0.6.0", default-features = false }
+atspi-proxies = { path = "../atspi-proxies/", version = "0.6.0", default-features = false }
 futures-lite = { version = "2", default-features = false }
 tracing = { optional = true, workspace = true }
 zbus.workspace = true

--- a/atspi-proxies/Cargo.toml
+++ b/atspi-proxies/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atspi-proxies"
-version = "0.5.0"
+version = "0.6.0"
 description = "AT-SPI2 proxies to query or manipulate UI objects"
 license = "Apache-2.0 OR MIT"
 readme = "README.md"
@@ -23,14 +23,14 @@ gvariant = ["zvariant/gvariant"]
 tokio = ["zbus/tokio", "atspi-common/tokio"]
 
 [dependencies]
-atspi-common = { path = "../atspi-common", version = "0.5.0", default-features = false }
+atspi-common = { path = "../atspi-common", version = "0.6.0", default-features = false }
 serde = { version = "^1.0", default-features = false, features = ["derive"] }
 zbus = { workspace = true }
 zvariant = { version = "4.1", default-features = false }
 
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes"] }
-atspi-common = { path = "../atspi-common", version = "0.5.0", features = ["async-std"] }
+atspi-common = { path = "../atspi-common", version = "0.6.0", features = ["async-std"] }
 byteorder = "1.4"
 futures-lite = { version = "2", default-features = false }
 rename-item = "0.1.0"

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atspi"
-version = "0.21.0"
+version = "0.22.0"
 authors.workspace = true
 edition = "2021"
 description = "Pure-Rust, zbus-based AT-SPI2 protocol implementation."
@@ -29,9 +29,9 @@ connection-tokio = ["atspi-connection/tokio", "connection"]
 tracing = ["atspi-connection/tracing"]
 
 [dependencies]
-atspi-common = { path = "../atspi-common", version = "0.5.0", default-features = false }
-atspi-connection = { path = "../atspi-connection", version = "0.5.0", default-features = false, optional = true }
-atspi-proxies = { path = "../atspi-proxies", version = "0.5.0", default-features = false, optional = true }
+atspi-common = { path = "../atspi-common", version = "0.6.0", default-features = false }
+atspi-connection = { path = "../atspi-connection", version = "0.6.0", default-features = false, optional = true }
+atspi-proxies = { path = "../atspi-proxies", version = "0.6.0", default-features = false, optional = true }
 zbus = { workspace = true, default-features = false, optional = true }
 
 [[bench]]


### PR DESCRIPTION
- `ObjectRef::name` is now a `zbus_names::UniqueName` instead of `zbus_names::BusName`
- `GenericEvent` has been scrapped in favour of three separate traits:
    1. `EventTypeProperties`, which is object safe and can be run on specific event types, or the `Event` enum:
        - `registry()`
        - `interface()`
        - `match_rule()`
        - `registry_string()`
        - This is blanket implemented for any type which implements `BusProperties` (see trait 3)
    2. `EventProperties`, which is object safe and can be run on specific event types, or the `Event` enum:
        - `sender()`
        - `path()`
        - `object_ref()`
    3. `BusProperties`, which is **not** object safe and is implemented only for user facing event types.
        - `DBUS_MEMBER`
        - `DBUS_INTERFACE`
        - `MATCH_RULE_STRING`
        - `REGISTRY_EVENT_STRING`
        - `type Body`
        - `from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self>`
        - `body() -> Self::Body`
- Use [`zbus-lockstep`](https://github.com/luukvanderduim/zbus-lockstep) for DBus XML type validation at compile-time
- Additional test cases and macros
- Move XML to `atspi-common` directory
- Upgrade to `zbus` v4.x

Signed-off-by: Tait Hoyem <tait@tait.tech>
