### PR TITLE
Add 'bus-tree' example

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "rust-analyzer.cargo.features": [
-        "zbus",
-        "proxies-tokio",
-        "tokio"
-    ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "rust-analyzer.cargo.features": [
+        "zbus",
+        "proxies-tokio",
+        "tokio"
+    ]
+}

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -44,6 +44,21 @@ name = "event_parsing_100k"
 path = "./benches/event_parsing_100k.rs"
 harness = false
 
+[[example]]
+name = "tree"
+path = "./examples/bus-tree.rs"
+required-features = ["proxies-tokio", "zbus"]
+
+[[example]]
+name = "focused-tokio"
+path = "./examples/focused-tokio.rs"
+required-features = ["connection-tokio"]
+
+[[example]]
+name = "focused-async-std"
+path = "./examples/focused-async-std.rs"
+required-features = ["connection-async-std"]
+
 [dev-dependencies]
 async-std = { version = "1.12", default-features = false }
 atspi = { path = "." }
@@ -52,7 +67,6 @@ display_tree = "1.1"
 fastrand = "2.0"
 futures = { version = "0.3", default-features = false }
 futures-lite = { version = "2", default-features = false }
-static_assertions = "1.1"
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1"
 zbus.workspace = true

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -45,11 +45,14 @@ path = "./benches/event_parsing_100k.rs"
 harness = false
 
 [dev-dependencies]
-atspi = { path = "." }
-zbus.workspace = true
-criterion = "0.5"
-futures-lite = { version = "2", default-features = false }
-fastrand = "2.0"
 async-std = { version = "1.12", default-features = false }
+atspi = { path = "." }
+criterion = "0.5"
+display_tree = "1.1"
+fastrand = "2.0"
+futures = { version = "0.3", default-features = false }
+futures-lite = { version = "2", default-features = false }
+static_assertions = "1.1"
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1"
+zbus.workspace = true

--- a/atspi/examples/bus-tree.rs
+++ b/atspi/examples/bus-tree.rs
@@ -1,0 +1,145 @@
+//! This example demonstrates how to construct a tree of accessible objects on the accessibility-bus.
+//!
+//! "This example requires the  `proxies-tokio`, `tokio` and `zbus` features to be enabled:
+//!
+//! ```sh
+//! cargo run --example bus-tree --features zbus,proxies-tokio,tokio
+//! ```
+//! Authors:
+//!    Luuk van der Duim,
+//!    Tait Hoyem
+use static_assertions as sa;
+
+sa::assert_cfg!(all(all(feature = "zbus", feature = "tokio", feature = "proxies-tokio")), "This example requires the `zbus`, `tokio` and `proxies-tokio` features to be enabled.\n\n Run with: `cargo run --example bus-tree --features zbus,proxies-tokio,tokio`.\n\n");
+
+use atspi::{
+	connection::set_session_accessibility,
+	proxy::accessible::{AccessibleProxy, ObjectRefExt},
+	zbus::{proxy::CacheProperties, Connection},
+	AccessibilityConnection, Role,
+};
+use display_tree::{AsTree, DisplayTree, Style};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+const REGISTRY_DEST: &str = "org.a11y.atspi.Registry";
+const REGISTRY_PATH: &str = "/org/a11y/atspi/accessible/root";
+const ACCCESSIBLE_INTERFACE: &str = "org.a11y.atspi.Accessible";
+
+#[derive(Debug)]
+struct A11yNode {
+	role: Role,
+	children: Vec<A11yNode>,
+}
+
+impl DisplayTree for A11yNode {
+	fn fmt(&self, f: &mut std::fmt::Formatter, style: Style) -> std::fmt::Result {
+		self.fmt_with(f, style, &mut vec![])
+	}
+}
+
+impl A11yNode {
+	fn fmt_with(
+		&self,
+		f: &mut std::fmt::Formatter<'_>,
+		style: Style,
+		prefix: &mut Vec<bool>,
+	) -> std::fmt::Result {
+		for (i, is_last_at_i) in prefix.iter().enumerate() {
+			// if it is the last portion of the line
+			let is_last = i == prefix.len() - 1;
+			match (is_last, *is_last_at_i) {
+				(true, true) => write!(f, "{}", style.char_set.end_connector)?,
+				(true, false) => write!(f, "{}", style.char_set.connector)?,
+				// four spaces to emulate `tree`
+				(false, true) => write!(f, "    ")?,
+				// three spaces and vertical char
+				(false, false) => write!(f, "{}   ", style.char_set.vertical)?,
+			}
+		}
+
+		// two horizontal chars to mimic `tree`
+		writeln!(f, "{}{} {}", style.char_set.horizontal, style.char_set.horizontal, self.role)?;
+
+		for (i, child) in self.children.iter().enumerate() {
+			prefix.push(i == self.children.len() - 1);
+			child.fmt_with(f, style, prefix)?;
+			prefix.pop();
+		}
+
+		Ok(())
+	}
+}
+
+impl A11yNode {
+	async fn from_accessible_proxy(ap: AccessibleProxy<'_>) -> Result<Self> {
+		let role = ap.get_role().await?;
+		let child_objs = ap.get_children().await?;
+		let connection = ap.inner().connection();
+
+		// Convert `Vec<ObjectRef>` to a `Vec<Future<Output = AccessibleProxy>`.
+		let children = child_objs
+			.iter()
+			.map(|child| child.as_accessible_proxy(connection))
+			.collect::<Vec<_>>();
+
+		// Resolve the futures and filter out the errors.
+		let children = futures::future::join_all(children)
+			.await
+			.into_iter()
+			.filter_map(|child| child.ok())
+			.collect::<Vec<_>>();
+
+		// Convert to a `Vec<Future<Output = Result<A11yNode>>`.
+		let children = children
+			.into_iter()
+			.map(|child| Box::pin(Self::from_accessible_proxy(child)))
+			.collect::<Vec<_>>();
+
+		// Resolve the futures and filter out the errors.
+		let children = futures::future::join_all(children)
+			.await
+			.into_iter()
+			.filter_map(|child| child.ok())
+			.collect::<Vec<_>>();
+
+		Ok(A11yNode { role, children })
+	}
+}
+
+async fn get_registry_accessible<'a>(conn: &Connection) -> Result<AccessibleProxy<'a>> {
+	let registry = AccessibleProxy::builder(conn)
+		.destination(REGISTRY_DEST)?
+		.path(REGISTRY_PATH)?
+		.interface(ACCCESSIBLE_INTERFACE)?
+		.cache_properties(CacheProperties::No)
+		.build()
+		.await?;
+
+	Ok(registry)
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+	set_session_accessibility(true).await?;
+	let a11y = AccessibilityConnection::new().await?;
+
+	let conn = a11y.connection();
+	let registry = get_registry_accessible(conn).await?;
+
+	let no_children = registry.child_count().await?;
+	println!("Number of accessible applications on the a11y-bus: {no_children}");
+	println!("Construct a tree of accessible objects on the a11y-bus\n");
+
+	let now = std::time::Instant::now();
+	let tree = A11yNode::from_accessible_proxy(registry).await?;
+	let elapsed = now.elapsed();
+	println!("Elapsed time: {:?}", elapsed);
+
+	println!("\nPress 'Enter' to print the tree...");
+	let _ = std::io::stdin().read_line(&mut String::new());
+
+	println!("{}", AsTree::new(&tree));
+
+	Ok(())
+}

--- a/atspi/examples/bus-tree.rs
+++ b/atspi/examples/bus-tree.rs
@@ -10,7 +10,7 @@
 //!    Tait Hoyem
 use static_assertions as sa;
 
-sa::assert_cfg!(all(all(feature = "zbus", feature = "tokio", feature = "proxies-tokio")), "This example requires the `zbus`, `tokio` and `proxies-tokio` features to be enabled.\n\n Run with: `cargo run --example bus-tree --features zbus,proxies-tokio,tokio`.\n\n");
+sa::assert_cfg!(all(feature = "zbus", feature = "tokio", feature = "proxies-tokio"), "This example requires the `zbus`, `tokio` and `proxies-tokio` features to be enabled.\n\n Run with: `cargo run --example bus-tree --features zbus,proxies-tokio,tokio`.\n\n");
 
 use atspi::{
 	connection::set_session_accessibility,

--- a/atspi/examples/bus-tree.rs
+++ b/atspi/examples/bus-tree.rs
@@ -80,6 +80,11 @@ impl A11yNode {
 
 		// If the stack has an `AccessibleProxy`, we take the last.
 		while let Some(ap) = stack.pop() {
+			// Prevent obects with huge child counts from stalling the program.
+			if ap.child_count().await? > 65536 {
+				continue;
+			}
+
 			let child_objects = ap.get_children().await?;
 			let mut children_proxies = try_join_all(
 				child_objects

--- a/atspi/examples/bus-tree.rs
+++ b/atspi/examples/bus-tree.rs
@@ -8,9 +8,6 @@
 //! Authors:
 //!    Luuk van der Duim,
 //!    Tait Hoyem
-use static_assertions as sa;
-
-sa::assert_cfg!(all(feature = "zbus", feature = "tokio", feature = "proxies-tokio"), "This example requires the `zbus`, `tokio` and `proxies-tokio` features to be enabled.\n\n Run with: `cargo run --example bus-tree --features zbus,proxies-tokio,tokio`.\n\n");
 
 use atspi::{
 	connection::set_session_accessibility,

--- a/atspi/examples/focused-async-std.rs
+++ b/atspi/examples/focused-async-std.rs
@@ -1,11 +1,7 @@
-#[cfg(feature = "connection")]
 use atspi::events::object::{ObjectEvents, StateChangedEvent};
-#[cfg(feature = "connection")]
 use futures_lite::stream::StreamExt;
-#[cfg(feature = "connection")]
 use std::error::Error;
 
-#[cfg(feature = "connection")]
 #[async_std::main]
 async fn main() -> Result<(), Box<dyn Error>> {
 	let atspi = atspi::AccessibilityConnection::new().await?;
@@ -23,8 +19,4 @@ async fn main() -> Result<(), Box<dyn Error>> {
 		}
 	}
 	Ok(())
-}
-#[cfg(not(feature = "connection"))]
-fn main() {
-	println!("This test can not be run without the \"connection\" feature.");
 }

--- a/atspi/examples/focused-tokio.rs
+++ b/atspi/examples/focused-tokio.rs
@@ -1,11 +1,7 @@
-#[cfg(feature = "connection")]
 use atspi::events::object::{ObjectEvents, StateChangedEvent};
-#[cfg(feature = "connection")]
 use std::error::Error;
-#[cfg(feature = "connection")]
 use tokio_stream::StreamExt;
 
-#[cfg(feature = "connection")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
 	let atspi = atspi::AccessibilityConnection::new().await?;
@@ -23,8 +19,4 @@ async fn main() -> Result<(), Box<dyn Error>> {
 		}
 	}
 	Ok(())
-}
-#[cfg(not(feature = "connection"))]
-fn main() {
-	println!("This test can not be run without the \"connection\" feature.");
 }


### PR DESCRIPTION
Addresses issue #173 

- Adds the 'bus-tree' example 

~~Also try out `static_assertions::assert_cfg!` to inform users of the appropriate features to use.
This will make rust-analyzer noisy if you don't have these set in your editor.~~

- Add `[[example]]` section in Cargo.toml, which allows us to point out, using the `required-features` list which features a user needs.
 
~~This tries to add `.vscode/settings.json` to mitigate that but if this is deemed too opinionated, just remove it.~~ 
removed, no longer needed.

