### PR TITLE
Fix QT problems (again)

### DIFF
--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -428,8 +428,8 @@ impl_try_from_event_for_user_facing_type!(
 	CacheEvents::LegacyAdd,
 	Event::Cache
 );
-event_test_cases!(LegacyAddAccessibleEvent, false);
-impl_from_dbus_message!(LegacyAddAccessibleEvent, false);
+event_test_cases!(LegacyAddAccessibleEvent, Explicit);
+impl_from_dbus_message!(LegacyAddAccessibleEvent, Explicit);
 impl_event_properties!(LegacyAddAccessibleEvent);
 impl_to_dbus_message!(LegacyAddAccessibleEvent);
 
@@ -468,7 +468,7 @@ impl_from_user_facing_event_for_interface_event_enum!(
 );
 impl_from_user_facing_type_for_event_enum!(AddAccessibleEvent, Event::Cache);
 impl_try_from_event_for_user_facing_type!(AddAccessibleEvent, CacheEvents::Add, Event::Cache);
-event_test_cases!(AddAccessibleEvent, false);
+event_test_cases!(AddAccessibleEvent, Explicit);
 
 impl BusProperties for AddAccessibleEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Cache:Add";
@@ -493,7 +493,7 @@ impl<T: BusProperties> HasMatchRule for T {
 impl<T: BusProperties> HasRegistryEventString for T {
 	const REGISTRY_EVENT_STRING: &'static str = <T as BusProperties>::REGISTRY_EVENT_STRING;
 }
-impl_from_dbus_message!(AddAccessibleEvent, false);
+impl_from_dbus_message!(AddAccessibleEvent, Explicit);
 impl_event_properties!(AddAccessibleEvent);
 impl_to_dbus_message!(AddAccessibleEvent);
 
@@ -514,7 +514,7 @@ impl_from_user_facing_event_for_interface_event_enum!(
 );
 impl_from_user_facing_type_for_event_enum!(RemoveAccessibleEvent, Event::Cache);
 impl_try_from_event_for_user_facing_type!(RemoveAccessibleEvent, CacheEvents::Remove, Event::Cache);
-event_test_cases!(RemoveAccessibleEvent, false);
+event_test_cases!(RemoveAccessibleEvent, Explicit);
 impl BusProperties for RemoveAccessibleEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Cache:Remove";
 	const MATCH_RULE_STRING: &'static str =
@@ -532,7 +532,7 @@ impl BusProperties for RemoveAccessibleEvent {
 	}
 }
 
-impl_from_dbus_message!(RemoveAccessibleEvent, false);
+impl_from_dbus_message!(RemoveAccessibleEvent, Explicit);
 impl_event_properties!(RemoveAccessibleEvent);
 impl_to_dbus_message!(RemoveAccessibleEvent);
 
@@ -710,7 +710,7 @@ impl_try_from_event_for_user_facing_type!(
 	EventListenerEvents::Deregistered,
 	Event::Listener
 );
-event_test_cases!(EventListenerDeregisteredEvent, false);
+event_test_cases!(EventListenerDeregisteredEvent, Explicit);
 impl BusProperties for EventListenerDeregisteredEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Registry:EventListenerDeregistered";
 	const MATCH_RULE_STRING: &'static str =
@@ -727,7 +727,7 @@ impl BusProperties for EventListenerDeregisteredEvent {
 		self.deregistered_event.clone()
 	}
 }
-impl_from_dbus_message!(EventListenerDeregisteredEvent, false);
+impl_from_dbus_message!(EventListenerDeregisteredEvent, Explicit);
 impl_event_properties!(EventListenerDeregisteredEvent);
 impl_to_dbus_message!(EventListenerDeregisteredEvent);
 
@@ -752,7 +752,7 @@ impl_try_from_event_for_user_facing_type!(
 	EventListenerEvents::Registered,
 	Event::Listener
 );
-event_test_cases!(EventListenerRegisteredEvent, false);
+event_test_cases!(EventListenerRegisteredEvent, Explicit);
 impl BusProperties for EventListenerRegisteredEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Registry:EventListenerRegistered";
 	const MATCH_RULE_STRING: &'static str =
@@ -769,7 +769,7 @@ impl BusProperties for EventListenerRegisteredEvent {
 		self.registered_event.clone()
 	}
 }
-impl_from_dbus_message!(EventListenerRegisteredEvent, false);
+impl_from_dbus_message!(EventListenerRegisteredEvent, Explicit);
 impl_event_properties!(EventListenerRegisteredEvent);
 impl_to_dbus_message!(EventListenerRegisteredEvent);
 
@@ -795,7 +795,7 @@ impl TryFrom<Event> for AvailableEvent {
 		}
 	}
 }
-event_test_cases!(AvailableEvent, false);
+event_test_cases!(AvailableEvent, Explicit);
 impl BusProperties for AvailableEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Socket:Available";
 	const MATCH_RULE_STRING: &'static str =
@@ -812,7 +812,7 @@ impl BusProperties for AvailableEvent {
 		self.socket.clone()
 	}
 }
-impl_from_dbus_message!(AvailableEvent, false);
+impl_from_dbus_message!(AvailableEvent, Explicit);
 impl_event_properties!(AvailableEvent);
 impl_to_dbus_message!(AvailableEvent);
 

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -71,7 +71,7 @@ impl<T> Type for EventBody<'_, T> {
 
 /// Qt event body, which is not the same as other GUI frameworks.
 /// Signature:  "siiv(so)"
-#[derive(Debug, Serialize, Deserialize, Type)]
+#[derive(Debug, Serialize, Deserialize, Type, PartialEq)]
 pub struct EventBodyQT {
 	/// kind variant, used for specifying an event triple "object:state-changed:focused",
 	/// the "focus" part of this event is what is contained within the kind.
@@ -87,6 +87,17 @@ pub struct EventBodyQT {
 	/// A tuple of properties.
 	/// Not in use.
 	pub properties: ObjectRef,
+}
+impl From<EventBodyOwned> for EventBodyQT {
+	fn from(ev: EventBodyOwned) -> Self {
+		EventBodyQT {
+			kind: ev.kind,
+			detail1: ev.detail1,
+			detail2: ev.detail2,
+			any_data: ev.any_data,
+			properties: ObjectRef::default(),
+		}
+	}
 }
 
 impl Default for EventBodyQT {
@@ -417,8 +428,8 @@ impl_try_from_event_for_user_facing_type!(
 	CacheEvents::LegacyAdd,
 	Event::Cache
 );
-event_test_cases!(LegacyAddAccessibleEvent);
-impl_from_dbus_message!(LegacyAddAccessibleEvent);
+event_test_cases!(LegacyAddAccessibleEvent, false);
+impl_from_dbus_message!(LegacyAddAccessibleEvent, false);
 impl_event_properties!(LegacyAddAccessibleEvent);
 impl_to_dbus_message!(LegacyAddAccessibleEvent);
 
@@ -457,7 +468,7 @@ impl_from_user_facing_event_for_interface_event_enum!(
 );
 impl_from_user_facing_type_for_event_enum!(AddAccessibleEvent, Event::Cache);
 impl_try_from_event_for_user_facing_type!(AddAccessibleEvent, CacheEvents::Add, Event::Cache);
-event_test_cases!(AddAccessibleEvent);
+event_test_cases!(AddAccessibleEvent, false);
 
 impl BusProperties for AddAccessibleEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Cache:Add";
@@ -482,7 +493,7 @@ impl<T: BusProperties> HasMatchRule for T {
 impl<T: BusProperties> HasRegistryEventString for T {
 	const REGISTRY_EVENT_STRING: &'static str = <T as BusProperties>::REGISTRY_EVENT_STRING;
 }
-impl_from_dbus_message!(AddAccessibleEvent);
+impl_from_dbus_message!(AddAccessibleEvent, false);
 impl_event_properties!(AddAccessibleEvent);
 impl_to_dbus_message!(AddAccessibleEvent);
 
@@ -503,7 +514,7 @@ impl_from_user_facing_event_for_interface_event_enum!(
 );
 impl_from_user_facing_type_for_event_enum!(RemoveAccessibleEvent, Event::Cache);
 impl_try_from_event_for_user_facing_type!(RemoveAccessibleEvent, CacheEvents::Remove, Event::Cache);
-event_test_cases!(RemoveAccessibleEvent);
+event_test_cases!(RemoveAccessibleEvent, false);
 impl BusProperties for RemoveAccessibleEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Cache:Remove";
 	const MATCH_RULE_STRING: &'static str =
@@ -521,7 +532,7 @@ impl BusProperties for RemoveAccessibleEvent {
 	}
 }
 
-impl_from_dbus_message!(RemoveAccessibleEvent);
+impl_from_dbus_message!(RemoveAccessibleEvent, false);
 impl_event_properties!(RemoveAccessibleEvent);
 impl_to_dbus_message!(RemoveAccessibleEvent);
 
@@ -699,7 +710,7 @@ impl_try_from_event_for_user_facing_type!(
 	EventListenerEvents::Deregistered,
 	Event::Listener
 );
-event_test_cases!(EventListenerDeregisteredEvent);
+event_test_cases!(EventListenerDeregisteredEvent, false);
 impl BusProperties for EventListenerDeregisteredEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Registry:EventListenerDeregistered";
 	const MATCH_RULE_STRING: &'static str =
@@ -716,7 +727,7 @@ impl BusProperties for EventListenerDeregisteredEvent {
 		self.deregistered_event.clone()
 	}
 }
-impl_from_dbus_message!(EventListenerDeregisteredEvent);
+impl_from_dbus_message!(EventListenerDeregisteredEvent, false);
 impl_event_properties!(EventListenerDeregisteredEvent);
 impl_to_dbus_message!(EventListenerDeregisteredEvent);
 
@@ -741,7 +752,7 @@ impl_try_from_event_for_user_facing_type!(
 	EventListenerEvents::Registered,
 	Event::Listener
 );
-event_test_cases!(EventListenerRegisteredEvent);
+event_test_cases!(EventListenerRegisteredEvent, false);
 impl BusProperties for EventListenerRegisteredEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Registry:EventListenerRegistered";
 	const MATCH_RULE_STRING: &'static str =
@@ -758,7 +769,7 @@ impl BusProperties for EventListenerRegisteredEvent {
 		self.registered_event.clone()
 	}
 }
-impl_from_dbus_message!(EventListenerRegisteredEvent);
+impl_from_dbus_message!(EventListenerRegisteredEvent, false);
 impl_event_properties!(EventListenerRegisteredEvent);
 impl_to_dbus_message!(EventListenerRegisteredEvent);
 
@@ -784,7 +795,7 @@ impl TryFrom<Event> for AvailableEvent {
 		}
 	}
 }
-event_test_cases!(AvailableEvent);
+event_test_cases!(AvailableEvent, false);
 impl BusProperties for AvailableEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Socket:Available";
 	const MATCH_RULE_STRING: &'static str =
@@ -801,7 +812,7 @@ impl BusProperties for AvailableEvent {
 		self.socket.clone()
 	}
 }
-impl_from_dbus_message!(AvailableEvent);
+impl_from_dbus_message!(AvailableEvent, false);
 impl_event_properties!(AvailableEvent);
 impl_to_dbus_message!(AvailableEvent);
 

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -418,7 +418,7 @@ macro_rules! event_enum_transparency_test_case {
 
 #[cfg(test)]
 macro_rules! zbus_message_qtspi_test_case {
-    ($type:ty, true) => {
+    ($type:ty, Auto) => {
       #[cfg(feature = "zbus")]
      #[test]
     fn zbus_message_conversion_qtspi() {
@@ -439,7 +439,7 @@ macro_rules! zbus_message_qtspi_test_case {
           <$type>::try_from(&msg).expect("Should be able to use an EventBodyQT for any type whose BusProperties::Body = EventBodyOwned");
         }
     };
-    ($type:ty, false) => {};
+    ($type:ty, Explicit) => {};
 }
 
 // We decorate the macro with a `#[cfg(test)]` attribute.
@@ -450,10 +450,10 @@ macro_rules! zbus_message_qtspi_test_case {
 #[cfg(test)]
 macro_rules! zbus_message_test_case {
   ($type:ty) => {
-      zbus_message_test_case!($type, true);
+      zbus_message_test_case!($type, Auto);
     };
-	($type:ty, $val:tt) => {
-    zbus_message_qtspi_test_case!($type, $val);
+	($type:ty, $extra:tt) => {
+    zbus_message_qtspi_test_case!($type, $extra);
 		#[cfg(feature = "zbus")]
 		#[test]
 		fn zbus_msg_conversion_to_specific_event_type() {
@@ -696,7 +696,7 @@ macro_rules! event_wrapper_test_cases {
 
 macro_rules! event_test_cases {
   ($type:ty) => {
-      event_test_cases!($type, true);
+      event_test_cases!($type, Auto);
   };
 	($type:ty, $qt:tt) => {
 		#[cfg(test)]

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -252,12 +252,12 @@ macro_rules! impl_to_dbus_message {
 /// ```
 ///
 /// There is also a variant that can be used for events whose [`crate::events::BusProperties::Body`] is not
-/// [`crate::events::EventBodyOwned`]. You can call this by setting the second parameter to `false`.
+/// [`crate::events::EventBodyOwned`]. You can call this by setting the second parameter to `Explicit`.
 macro_rules! impl_from_dbus_message {
 	($type:ty) => {
-		impl_from_dbus_message!($type, true);
+		impl_from_dbus_message!($type, Auto);
 	};
-	($type:ty, true) => {
+	($type:ty, Auto) => {
 		#[cfg(feature = "zbus")]
 		impl TryFrom<&zbus::Message> for $type {
 			type Error = AtspiError;
@@ -284,7 +284,7 @@ macro_rules! impl_from_dbus_message {
 			}
 		}
 	};
-	($type:ty, false) => {
+	($type:ty, Explicit) => {
 		#[cfg(feature = "zbus")]
 		impl TryFrom<&zbus::Message> for $type {
 			type Error = AtspiError;


### PR DESCRIPTION
- Add new `From<EventBodyOwned> for EventBodyQT`
- Use booleans in call to macros:
	- `event_test_case!($ty) -> event_test_case!($ty, true)`
	- `impl_from_dbus_message!($ty) -> impl_from_dbus_message!($ty,
	  true)`
	- `false` should be used as the second argument if the `<$ty as
	  BusProperties>::Body` is not `EventBodyOwned`.
- This only marginally changes the macro expansion of
  `impl_from_dbus_message`, and so we should consider only changing the
  one line instead of having two entirely separate impl blocks.

cc @luukvanderduim
