### PR TITLE
Big Trait Changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,13 +245,11 @@ jobs:
         with:
           toolchain: stable
       - name: Install WASM target(s)
-        run: rustup target add  wasm32-wasi && rustup target add wasm32-unknown-unknown
+        run: rustup target add  wasm32-wasip1 && rustup target add wasm32-unknown-unknown
       - name: Test Common Compilation (wasm32-unknown-unknown)
-        working-directory: atspi-common
-        run: cargo build --no-default-features --target wasm32-unknown-unknown
-      - name: Test Common Compilation (wasm32-wasi)
-        working-directory: atspi-common
-        run: cargo build --no-default-features --target wasm32-wasi
+        run: cargo build -p atspi-common --no-default-features --target wasm32-unknown-unknown
+      - name: Test Common Compilation (wasm32-wasip1)
+        run: cargo build -p atspi-common --no-default-features --target wasm32-wasip1
   coverage:
     runs-on: ubuntu-latest
     needs: [clippy,no-unused-dependencies]

--- a/atspi-common/Cargo.toml
+++ b/atspi-common/Cargo.toml
@@ -38,3 +38,4 @@ tokio-stream = { version = "0.1", default-features = false, features = ["time"] 
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
 tokio-test = "0.4.2"
 zbus = { workspace = true }
+assert_matches = "1.5.0"

--- a/atspi-common/src/error.rs
+++ b/atspi-common/src/error.rs
@@ -89,6 +89,7 @@ impl std::fmt::Display for AtspiError {
 			}
 			Self::SignatureMatch(e) => {
 				f.write_str(format!("atspi: body signature mismatch in conversion: {e:?}").as_str())
+			}
 			Self::UnknownBusSignature(e) => {
 				f.write_str("atspi: Unknown bus body signature: ")?;
 				e.fmt(f)

--- a/atspi-common/src/error.rs
+++ b/atspi-common/src/error.rs
@@ -19,7 +19,7 @@ pub enum AtspiError {
 	KindMatch(String),
 
 	/// To indicate a match or equality test on a signal body signature failed.
-	UnknownBusSignature(String),
+	SignatureMatch(String),
 
 	/// When matching on an unknown interface
 	UnknownInterface,
@@ -85,8 +85,8 @@ impl std::fmt::Display for AtspiError {
 			Self::KindMatch(e) => {
 				f.write_str(format!("atspi: kind mismatch in conversion: {e}").as_str())
 			}
-			Self::UnknownBusSignature(e) => {
-				f.write_str(format!("atspi: Unknown bus body signature: {e:?}").as_str())
+			Self::SignatureMatch(e) => {
+				f.write_str(format!("atspi: body signature mismatch in conversion: {e:?}").as_str())
 			}
 			Self::UnknownInterface => f.write_str("Unknown interface."),
 			Self::MissingInterface => f.write_str("Missing interface."),

--- a/atspi-common/src/error.rs
+++ b/atspi-common/src/error.rs
@@ -90,10 +90,6 @@ impl std::fmt::Display for AtspiError {
 			Self::SignatureMatch(e) => {
 				f.write_str(format!("atspi: body signature mismatch in conversion: {e:?}").as_str())
 			}
-			Self::UnknownBusSignature(e) => {
-				f.write_str("atspi: Unknown bus body signature: ")?;
-				e.fmt(f)
-			}
 			Self::UnknownInterface => f.write_str("Unknown interface."),
 			Self::MissingInterface => f.write_str("Missing interface."),
 			Self::MissingMember => f.write_str("Missing member."),

--- a/atspi-common/src/events/cache.rs
+++ b/atspi-common/src/events/cache.rs
@@ -1,0 +1,280 @@
+#[cfg(feature = "zbus")]
+use crate::events::MessageConversion;
+use crate::{
+	cache::{CacheItem, LegacyCacheItem},
+	error::AtspiError,
+	events::{
+		BusProperties, EventWrapperMessageConversion, HasInterfaceName, HasMatchRule,
+		HasRegistryEventString, ObjectRef,
+	},
+	Event, EventProperties, EventTypeProperties,
+};
+use serde::{Deserialize, Serialize};
+use zbus_names::UniqueName;
+use zvariant::ObjectPath;
+
+/// All events related to the `org.a11y.atspi.Cache` interface.
+/// Note that these are not telling the client that an item *has been added* to a cache.
+/// It is telling the client "here is a bunch of information to store it in your cache".
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, Hash)]
+#[allow(clippy::module_name_repetitions)]
+pub enum CacheEvents {
+	/// See: [`AddAccessibleEvent`].
+	Add(AddAccessibleEvent),
+	/// See: [`LegacyAddAccessibleEvent`].
+	LegacyAdd(LegacyAddAccessibleEvent),
+	/// See: [`RemoveAccessibleEvent`].
+	Remove(RemoveAccessibleEvent),
+}
+
+impl HasMatchRule for CacheEvents {
+	const MATCH_RULE_STRING: &'static str = "type='signal',interface='org.a11y.atspi.Cache'";
+}
+
+impl HasRegistryEventString for CacheEvents {
+	const REGISTRY_EVENT_STRING: &'static str = "Cache";
+}
+
+impl HasInterfaceName for CacheEvents {
+	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Cache";
+}
+
+impl EventTypeProperties for CacheEvents {
+	fn member(&self) -> &'static str {
+		match self {
+			Self::Add(inner) => inner.member(),
+			Self::LegacyAdd(inner) => inner.member(),
+			Self::Remove(inner) => inner.member(),
+		}
+	}
+	fn interface(&self) -> &'static str {
+		match self {
+			Self::Add(inner) => inner.interface(),
+			Self::LegacyAdd(inner) => inner.interface(),
+			Self::Remove(inner) => inner.interface(),
+		}
+	}
+	fn match_rule(&self) -> &'static str {
+		match self {
+			Self::Add(inner) => inner.match_rule(),
+			Self::LegacyAdd(inner) => inner.match_rule(),
+			Self::Remove(inner) => inner.match_rule(),
+		}
+	}
+	fn registry_string(&self) -> &'static str {
+		match self {
+			Self::Add(inner) => inner.registry_string(),
+			Self::LegacyAdd(inner) => inner.registry_string(),
+			Self::Remove(inner) => inner.registry_string(),
+		}
+	}
+}
+
+impl EventProperties for CacheEvents {
+	fn path(&self) -> ObjectPath<'_> {
+		match self {
+			Self::Add(inner) => inner.path(),
+			Self::LegacyAdd(inner) => inner.path(),
+			Self::Remove(inner) => inner.path(),
+		}
+	}
+	fn sender(&self) -> UniqueName<'_> {
+		match self {
+			Self::Add(inner) => inner.sender(),
+			Self::LegacyAdd(inner) => inner.sender(),
+			Self::Remove(inner) => inner.sender(),
+		}
+	}
+}
+
+#[cfg(feature = "zbus")]
+impl EventWrapperMessageConversion for CacheEvents {
+	fn try_from_message_interface_checked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let header = msg.header();
+		let member = header.member().ok_or(AtspiError::MissingMember)?;
+		match member.as_str() {
+			"AddAccessible" => {
+				let body = msg.body();
+				let sig = body.signature().ok_or(AtspiError::MissingSignature)?;
+				match sig.as_str() {
+					"(so)(so)(so)iiassusau" => {
+						Ok(CacheEvents::Add(AddAccessibleEvent::try_from_message_unchecked(msg)?))
+					}
+					"(so)(so)(so)a(so)assusau" => Ok(CacheEvents::LegacyAdd(
+						LegacyAddAccessibleEvent::try_from_message_unchecked(msg)?,
+					)),
+					_ => Err(AtspiError::SignatureMatch(format!(
+						"No matching event for signature {} in interface {}",
+						sig.as_str(),
+						Self::DBUS_INTERFACE
+					))),
+				}
+			}
+			"RemoveAccessible" => {
+				Ok(CacheEvents::Remove(RemoveAccessibleEvent::try_from_message_unchecked(msg)?))
+			}
+			_ => Err(AtspiError::MemberMatch(format!(
+				"No member {} in {}",
+				member.as_str(),
+				Self::DBUS_INTERFACE
+			))),
+		}
+	}
+}
+
+#[cfg(feature = "zbus")]
+impl TryFrom<&zbus::Message> for CacheEvents {
+	type Error = AtspiError;
+	fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
+		let header = msg.header();
+		let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
+		if interface != CacheEvents::DBUS_INTERFACE {
+			return Err(AtspiError::InterfaceMatch(format!(
+				"Interface {} does not match require interface for event: {}",
+				interface,
+				CacheEvents::DBUS_INTERFACE
+			)));
+		}
+		CacheEvents::try_from_message_interface_checked(msg)
+	}
+}
+
+/// Type that contains the `zbus::Message` for meta information and
+/// the [`crate::cache::LegacyCacheItem`]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, Eq, Hash)]
+pub struct LegacyAddAccessibleEvent {
+	/// The [`ObjectRef`] the event applies to.
+	pub item: ObjectRef,
+	/// A cache item to add to the internal cache.
+	pub node_added: LegacyCacheItem,
+}
+
+impl_from_user_facing_event_for_interface_event_enum!(
+	LegacyAddAccessibleEvent,
+	CacheEvents,
+	CacheEvents::LegacyAdd
+);
+impl_from_user_facing_type_for_event_enum!(LegacyAddAccessibleEvent, Event::Cache);
+impl_try_from_event_for_user_facing_type!(
+	LegacyAddAccessibleEvent,
+	CacheEvents::LegacyAdd,
+	Event::Cache
+);
+event_test_cases!(LegacyAddAccessibleEvent);
+impl_from_dbus_message!(LegacyAddAccessibleEvent);
+impl_event_properties!(LegacyAddAccessibleEvent);
+impl_to_dbus_message!(LegacyAddAccessibleEvent);
+
+impl BusProperties for LegacyAddAccessibleEvent {
+	const REGISTRY_EVENT_STRING: &'static str = "Cache:Add";
+	const MATCH_RULE_STRING: &'static str =
+		"type='signal',interface='org.a11y.atspi.Cache',member='AddAccessible'";
+	const DBUS_MEMBER: &'static str = "AddAccessible";
+	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Cache";
+}
+
+#[cfg(feature = "zbus")]
+impl MessageConversion for LegacyAddAccessibleEvent {
+	type Body = LegacyCacheItem;
+
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
+		Ok(Self { item, node_added: body.deserialize_unchecked()? })
+	}
+
+	fn body(&self) -> Self::Body {
+		self.node_added.clone()
+	}
+}
+
+/// Type that contains the `zbus::Message` for meta information and
+/// the [`crate::cache::CacheItem`]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, Eq, Hash)]
+pub struct AddAccessibleEvent {
+	/// The [`ObjectRef`] the event applies to.
+	pub item: ObjectRef,
+	/// A cache item to add to the internal cache.
+	pub node_added: CacheItem,
+}
+
+impl_from_user_facing_event_for_interface_event_enum!(
+	AddAccessibleEvent,
+	CacheEvents,
+	CacheEvents::Add
+);
+impl_from_user_facing_type_for_event_enum!(AddAccessibleEvent, Event::Cache);
+impl_try_from_event_for_user_facing_type!(AddAccessibleEvent, CacheEvents::Add, Event::Cache);
+event_test_cases!(AddAccessibleEvent);
+
+impl BusProperties for AddAccessibleEvent {
+	const REGISTRY_EVENT_STRING: &'static str = "Cache:Add";
+	const MATCH_RULE_STRING: &'static str =
+		"type='signal',interface='org.a11y.atspi.Cache',member='AddAccessible'";
+	const DBUS_MEMBER: &'static str = "AddAccessible";
+	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Cache";
+}
+
+#[cfg(feature = "zbus")]
+impl MessageConversion for AddAccessibleEvent {
+	type Body = CacheItem;
+
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
+		Ok(Self { item, node_added: body.deserialize_unchecked()? })
+	}
+
+	fn body(&self) -> Self::Body {
+		self.node_added.clone()
+	}
+}
+
+impl_from_dbus_message!(AddAccessibleEvent);
+impl_event_properties!(AddAccessibleEvent);
+impl_to_dbus_message!(AddAccessibleEvent);
+
+/// `Cache::RemoveAccessible` signal event type.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, Eq, Hash)]
+pub struct RemoveAccessibleEvent {
+	/// The application that emitted the signal TODO Check Me
+	/// The [`ObjectRef`] the event applies to.
+	pub item: ObjectRef,
+	/// The node that was removed from the application tree  TODO Check Me
+	pub node_removed: ObjectRef,
+}
+
+impl_from_user_facing_event_for_interface_event_enum!(
+	RemoveAccessibleEvent,
+	CacheEvents,
+	CacheEvents::Remove
+);
+impl_from_user_facing_type_for_event_enum!(RemoveAccessibleEvent, Event::Cache);
+impl_try_from_event_for_user_facing_type!(RemoveAccessibleEvent, CacheEvents::Remove, Event::Cache);
+event_test_cases!(RemoveAccessibleEvent);
+
+impl BusProperties for RemoveAccessibleEvent {
+	const REGISTRY_EVENT_STRING: &'static str = "Cache:Remove";
+	const MATCH_RULE_STRING: &'static str =
+		"type='signal',interface='org.a11y.atspi.Cache',member='RemoveAccessible'";
+	const DBUS_MEMBER: &'static str = "RemoveAccessible";
+	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Cache";
+}
+
+#[cfg(feature = "zbus")]
+impl MessageConversion for RemoveAccessibleEvent {
+	type Body = ObjectRef;
+
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
+		Ok(Self { item, node_removed: body.deserialize_unchecked()? })
+	}
+	fn body(&self) -> Self::Body {
+		self.node_removed.clone()
+	}
+}
+
+impl_from_dbus_message!(RemoveAccessibleEvent);
+impl_event_properties!(RemoveAccessibleEvent);
+impl_to_dbus_message!(RemoveAccessibleEvent);

--- a/atspi-common/src/events/cache.rs
+++ b/atspi-common/src/events/cache.rs
@@ -149,7 +149,7 @@ impl_try_from_event_for_user_facing_type!(
 	Event::Cache
 );
 event_test_cases!(LegacyAddAccessibleEvent, Explicit);
-impl_from_dbus_message!(LegacyAddAccessibleEvent);
+impl_from_dbus_message!(LegacyAddAccessibleEvent, Explicit);
 impl_event_properties!(LegacyAddAccessibleEvent);
 impl_to_dbus_message!(LegacyAddAccessibleEvent);
 
@@ -165,10 +165,16 @@ impl BusProperties for LegacyAddAccessibleEvent {
 impl MessageConversion for LegacyAddAccessibleEvent {
 	type Body = LegacyCacheItem;
 
+	fn try_from_validated_message_parts(
+		item: ObjectRef,
+		body: Self::Body,
+	) -> Result<Self, AtspiError> {
+		Ok(Self { item, node_added: body })
+	}
 	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
-		let body = msg.body();
-		Ok(Self { item, node_added: body.deserialize_unchecked()? })
+		let body = msg.body().deserialize()?;
+		Self::try_from_validated_message_parts(item, body)
 	}
 
 	fn body(&self) -> Self::Body {
@@ -207,10 +213,16 @@ impl BusProperties for AddAccessibleEvent {
 impl MessageConversion for AddAccessibleEvent {
 	type Body = CacheItem;
 
+	fn try_from_validated_message_parts(
+		item: ObjectRef,
+		body: Self::Body,
+	) -> Result<Self, AtspiError> {
+		Ok(Self { item, node_added: body })
+	}
 	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
-		let body = msg.body();
-		Ok(Self { item, node_added: body.deserialize_unchecked()? })
+		let body = msg.body().deserialize()?;
+		Self::try_from_validated_message_parts(item, body)
 	}
 
 	fn body(&self) -> Self::Body {
@@ -218,7 +230,7 @@ impl MessageConversion for AddAccessibleEvent {
 	}
 }
 
-impl_from_dbus_message!(AddAccessibleEvent);
+impl_from_dbus_message!(AddAccessibleEvent, Explicit);
 impl_event_properties!(AddAccessibleEvent);
 impl_to_dbus_message!(AddAccessibleEvent);
 
@@ -253,16 +265,22 @@ impl BusProperties for RemoveAccessibleEvent {
 impl MessageConversion for RemoveAccessibleEvent {
 	type Body = ObjectRef;
 
+	fn try_from_validated_message_parts(
+		item: ObjectRef,
+		body: Self::Body,
+	) -> Result<Self, AtspiError> {
+		Ok(Self { item, node_removed: body })
+	}
 	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
-		let body = msg.body();
-		Ok(Self { item, node_removed: body.deserialize_unchecked()? })
+		let body = msg.body().deserialize()?;
+		Self::try_from_validated_message_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		self.node_removed.clone()
 	}
 }
 
-impl_from_dbus_message!(RemoveAccessibleEvent);
+impl_from_dbus_message!(RemoveAccessibleEvent, Explicit);
 impl_event_properties!(RemoveAccessibleEvent);
 impl_to_dbus_message!(RemoveAccessibleEvent);

--- a/atspi-common/src/events/cache.rs
+++ b/atspi-common/src/events/cache.rs
@@ -167,10 +167,7 @@ impl BusProperties for LegacyAddAccessibleEvent {
 impl MessageConversion for LegacyAddAccessibleEvent {
 	type Body = LegacyCacheItem;
 
-	fn from_message_unchecked_parts(
-		item: ObjectRef,
-		body: Self::Body,
-	) -> Result<Self, AtspiError> {
+	fn from_message_unchecked_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, node_added: body })
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
@@ -215,10 +212,7 @@ impl BusProperties for AddAccessibleEvent {
 impl MessageConversion for AddAccessibleEvent {
 	type Body = CacheItem;
 
-	fn from_message_unchecked_parts(
-		item: ObjectRef,
-		body: Self::Body,
-	) -> Result<Self, AtspiError> {
+	fn from_message_unchecked_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, node_added: body })
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
@@ -267,10 +261,7 @@ impl BusProperties for RemoveAccessibleEvent {
 impl MessageConversion for RemoveAccessibleEvent {
 	type Body = ObjectRef;
 
-	fn from_message_unchecked_parts(
-		item: ObjectRef,
-		body: Self::Body,
-	) -> Result<Self, AtspiError> {
+	fn from_message_unchecked_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, node_removed: body })
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {

--- a/atspi-common/src/events/cache.rs
+++ b/atspi-common/src/events/cache.rs
@@ -97,10 +97,10 @@ impl EventWrapperMessageConversion for CacheEvents {
 				let sig = body.signature().ok_or(AtspiError::MissingSignature)?;
 				match sig.as_str() {
 					"(so)(so)(so)iiassusau" => {
-						Ok(CacheEvents::Add(AddAccessibleEvent::try_from_validated_message(msg)?))
+						Ok(CacheEvents::Add(AddAccessibleEvent::from_message_unchecked(msg)?))
 					}
 					"(so)(so)(so)a(so)assusau" => Ok(CacheEvents::LegacyAdd(
-						LegacyAddAccessibleEvent::try_from_validated_message(msg)?,
+						LegacyAddAccessibleEvent::from_message_unchecked(msg)?,
 					)),
 					_ => Err(AtspiError::SignatureMatch(format!(
 						"No matching event for signature {} in interface {}",
@@ -110,7 +110,7 @@ impl EventWrapperMessageConversion for CacheEvents {
 				}
 			}
 			RemoveAccessibleEvent::DBUS_MEMBER => {
-				Ok(CacheEvents::Remove(RemoveAccessibleEvent::try_from_validated_message(msg)?))
+				Ok(CacheEvents::Remove(RemoveAccessibleEvent::from_message_unchecked(msg)?))
 			}
 			_ => Err(AtspiError::MemberMatch(format!(
 				"No member {} in {}",
@@ -167,16 +167,16 @@ impl BusProperties for LegacyAddAccessibleEvent {
 impl MessageConversion for LegacyAddAccessibleEvent {
 	type Body = LegacyCacheItem;
 
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		item: ObjectRef,
 		body: Self::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item, node_added: body })
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body().deserialize()?;
-		Self::try_from_validated_message_parts(item, body)
+		Self::from_message_unchecked_parts(item, body)
 	}
 
 	fn body(&self) -> Self::Body {
@@ -215,16 +215,16 @@ impl BusProperties for AddAccessibleEvent {
 impl MessageConversion for AddAccessibleEvent {
 	type Body = CacheItem;
 
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		item: ObjectRef,
 		body: Self::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item, node_added: body })
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body().deserialize()?;
-		Self::try_from_validated_message_parts(item, body)
+		Self::from_message_unchecked_parts(item, body)
 	}
 
 	fn body(&self) -> Self::Body {
@@ -267,16 +267,16 @@ impl BusProperties for RemoveAccessibleEvent {
 impl MessageConversion for RemoveAccessibleEvent {
 	type Body = ObjectRef;
 
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		item: ObjectRef,
 		body: Self::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item, node_removed: body })
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body().deserialize()?;
-		Self::try_from_validated_message_parts(item, body)
+		Self::from_message_unchecked_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		self.node_removed.clone()

--- a/atspi-common/src/events/cache.rs
+++ b/atspi-common/src/events/cache.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "zbus")]
-use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage, MessageConversionExt};
+use crate::events::{
+	EventWrapperMessageConversion, MessageConversion, MessageConversionExt, TryFromMessage,
+};
 use crate::{
 	cache::{CacheItem, LegacyCacheItem},
 	error::AtspiError,

--- a/atspi-common/src/events/cache.rs
+++ b/atspi-common/src/events/cache.rs
@@ -148,7 +148,7 @@ impl_try_from_event_for_user_facing_type!(
 	CacheEvents::LegacyAdd,
 	Event::Cache
 );
-event_test_cases!(LegacyAddAccessibleEvent);
+event_test_cases!(LegacyAddAccessibleEvent, Explicit);
 impl_from_dbus_message!(LegacyAddAccessibleEvent);
 impl_event_properties!(LegacyAddAccessibleEvent);
 impl_to_dbus_message!(LegacyAddAccessibleEvent);
@@ -193,7 +193,7 @@ impl_from_user_facing_event_for_interface_event_enum!(
 );
 impl_from_user_facing_type_for_event_enum!(AddAccessibleEvent, Event::Cache);
 impl_try_from_event_for_user_facing_type!(AddAccessibleEvent, CacheEvents::Add, Event::Cache);
-event_test_cases!(AddAccessibleEvent);
+event_test_cases!(AddAccessibleEvent, Explicit);
 
 impl BusProperties for AddAccessibleEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Cache:Add";
@@ -239,7 +239,7 @@ impl_from_user_facing_event_for_interface_event_enum!(
 );
 impl_from_user_facing_type_for_event_enum!(RemoveAccessibleEvent, Event::Cache);
 impl_try_from_event_for_user_facing_type!(RemoveAccessibleEvent, CacheEvents::Remove, Event::Cache);
-event_test_cases!(RemoveAccessibleEvent);
+event_test_cases!(RemoveAccessibleEvent, Explicit);
 
 impl BusProperties for RemoveAccessibleEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Cache:Remove";

--- a/atspi-common/src/events/cache.rs
+++ b/atspi-common/src/events/cache.rs
@@ -5,7 +5,7 @@ use crate::{
 	error::AtspiError,
 	events::{
 		BusProperties, EventWrapperMessageConversion, HasInterfaceName, HasMatchRule,
-		HasRegistryEventString, ObjectRef,
+		HasRegistryEventString, ObjectRef, TryFromMessage,
 	},
 	Event, EventProperties, EventTypeProperties,
 };
@@ -126,16 +126,7 @@ impl EventWrapperMessageConversion for CacheEvents {
 impl TryFrom<&zbus::Message> for CacheEvents {
 	type Error = AtspiError;
 	fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
-		let header = msg.header();
-		let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
-		if interface != CacheEvents::DBUS_INTERFACE {
-			return Err(AtspiError::InterfaceMatch(format!(
-				"Interface {} does not match require interface for event: {}",
-				interface,
-				CacheEvents::DBUS_INTERFACE
-			)));
-		}
-		CacheEvents::try_from_message_interface_checked(msg)
+		Self::try_from_message(msg)
 	}
 }
 

--- a/atspi-common/src/events/cache.rs
+++ b/atspi-common/src/events/cache.rs
@@ -90,7 +90,7 @@ impl EventWrapperMessageConversion for CacheEvents {
 		let header = msg.header();
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
-			"AddAccessible" => {
+			AddAccessibleEvent::DBUS_MEMBER => {
 				let body = msg.body();
 				let sig = body.signature().ok_or(AtspiError::MissingSignature)?;
 				match sig.as_str() {
@@ -107,7 +107,7 @@ impl EventWrapperMessageConversion for CacheEvents {
 					))),
 				}
 			}
-			"RemoveAccessible" => {
+			RemoveAccessibleEvent::DBUS_MEMBER => {
 				Ok(CacheEvents::Remove(RemoveAccessibleEvent::try_from_message_unchecked(msg)?))
 			}
 			_ => Err(AtspiError::MemberMatch(format!(

--- a/atspi-common/src/events/cache.rs
+++ b/atspi-common/src/events/cache.rs
@@ -1,12 +1,9 @@
 #[cfg(feature = "zbus")]
-use crate::events::MessageConversion;
+use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage};
 use crate::{
 	cache::{CacheItem, LegacyCacheItem},
 	error::AtspiError,
-	events::{
-		BusProperties, EventWrapperMessageConversion, HasInterfaceName, HasMatchRule,
-		HasRegistryEventString, ObjectRef, TryFromMessage,
-	},
+	events::{BusProperties, HasInterfaceName, HasMatchRule, HasRegistryEventString, ObjectRef},
 	Event, EventProperties, EventTypeProperties,
 };
 use serde::{Deserialize, Serialize};

--- a/atspi-common/src/events/cache.rs
+++ b/atspi-common/src/events/cache.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "zbus")]
-use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage};
+use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage, MessageConversionExt};
 use crate::{
 	cache::{CacheItem, LegacyCacheItem},
 	error::AtspiError,

--- a/atspi-common/src/events/cache.rs
+++ b/atspi-common/src/events/cache.rs
@@ -95,10 +95,10 @@ impl EventWrapperMessageConversion for CacheEvents {
 				let sig = body.signature().ok_or(AtspiError::MissingSignature)?;
 				match sig.as_str() {
 					"(so)(so)(so)iiassusau" => {
-						Ok(CacheEvents::Add(AddAccessibleEvent::try_from_message_unchecked(msg)?))
+						Ok(CacheEvents::Add(AddAccessibleEvent::try_from_validated_message(msg)?))
 					}
 					"(so)(so)(so)a(so)assusau" => Ok(CacheEvents::LegacyAdd(
-						LegacyAddAccessibleEvent::try_from_message_unchecked(msg)?,
+						LegacyAddAccessibleEvent::try_from_validated_message(msg)?,
 					)),
 					_ => Err(AtspiError::SignatureMatch(format!(
 						"No matching event for signature {} in interface {}",
@@ -108,7 +108,7 @@ impl EventWrapperMessageConversion for CacheEvents {
 				}
 			}
 			RemoveAccessibleEvent::DBUS_MEMBER => {
-				Ok(CacheEvents::Remove(RemoveAccessibleEvent::try_from_message_unchecked(msg)?))
+				Ok(CacheEvents::Remove(RemoveAccessibleEvent::try_from_validated_message(msg)?))
 			}
 			_ => Err(AtspiError::MemberMatch(format!(
 				"No member {} in {}",
@@ -165,7 +165,7 @@ impl BusProperties for LegacyAddAccessibleEvent {
 impl MessageConversion for LegacyAddAccessibleEvent {
 	type Body = LegacyCacheItem;
 
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		Ok(Self { item, node_added: body.deserialize_unchecked()? })
@@ -207,7 +207,7 @@ impl BusProperties for AddAccessibleEvent {
 impl MessageConversion for AddAccessibleEvent {
 	type Body = CacheItem;
 
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		Ok(Self { item, node_added: body.deserialize_unchecked()? })
@@ -253,7 +253,7 @@ impl BusProperties for RemoveAccessibleEvent {
 impl MessageConversion for RemoveAccessibleEvent {
 	type Body = ObjectRef;
 
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		Ok(Self { item, node_removed: body.deserialize_unchecked()? })

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -161,7 +161,7 @@ impl BusProperties for LoadCompleteEvent {
 impl MessageConversion for LoadCompleteEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -185,7 +185,7 @@ impl BusProperties for ReloadEvent {
 impl MessageConversion for ReloadEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -209,7 +209,7 @@ impl BusProperties for LoadStoppedEvent {
 impl MessageConversion for LoadStoppedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -233,7 +233,7 @@ impl BusProperties for ContentChangedEvent {
 impl MessageConversion for ContentChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -257,7 +257,7 @@ impl BusProperties for AttributesChangedEvent {
 impl MessageConversion for AttributesChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -281,7 +281,7 @@ impl BusProperties for PageChangedEvent {
 impl MessageConversion for PageChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -4,7 +4,7 @@ use crate::{
 	error::AtspiError,
 	events::{
 		BusProperties, EventWrapperMessageConversion, HasInterfaceName, HasMatchRule,
-		HasRegistryEventString,
+		HasRegistryEventString, TryFromMessage,
 	},
 	Event, EventProperties, EventTypeProperties,
 };
@@ -235,16 +235,7 @@ impl EventWrapperMessageConversion for DocumentEvents {
 impl TryFrom<&zbus::Message> for DocumentEvents {
 	type Error = AtspiError;
 	fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
-		let header = msg.header();
-		let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
-		if interface != DocumentEvents::DBUS_INTERFACE {
-			return Err(AtspiError::InterfaceMatch(format!(
-				"Interface {} does not match interface {}",
-				interface,
-				DocumentEvents::DBUS_INTERFACE
-			)));
-		}
-		Self::try_from_message_interface_checked(msg)
+		Self::try_from_message(msg)
 	}
 }
 

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -1,9 +1,8 @@
+#[cfg(feature = "zbus")]
+use crate::events::{MessageConversion, ObjectRef};
 use crate::{
 	error::AtspiError,
-	events::{
-		BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, MessageConversion,
-		ObjectRef,
-	},
+	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;
@@ -158,6 +157,7 @@ impl BusProperties for LoadCompleteEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for LoadCompleteEvent {
 	type Body = EventBodyOwned;
 
@@ -181,6 +181,7 @@ impl BusProperties for ReloadEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for ReloadEvent {
 	type Body = EventBodyOwned;
 
@@ -204,6 +205,7 @@ impl BusProperties for LoadStoppedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for LoadStoppedEvent {
 	type Body = EventBodyOwned;
 
@@ -227,6 +229,7 @@ impl BusProperties for ContentChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for ContentChangedEvent {
 	type Body = EventBodyOwned;
 
@@ -250,6 +253,7 @@ impl BusProperties for AttributesChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for AttributesChangedEvent {
 	type Body = EventBodyOwned;
 
@@ -273,6 +277,7 @@ impl BusProperties for PageChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for PageChangedEvent {
 	type Body = EventBodyOwned;
 

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -161,10 +161,8 @@ impl BusProperties for LoadCompleteEvent {
 impl MessageConversion for LoadCompleteEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -185,10 +183,8 @@ impl BusProperties for ReloadEvent {
 impl MessageConversion for ReloadEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -209,10 +205,8 @@ impl BusProperties for LoadStoppedEvent {
 impl MessageConversion for LoadStoppedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -233,10 +227,8 @@ impl BusProperties for ContentChangedEvent {
 impl MessageConversion for ContentChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -257,10 +249,8 @@ impl BusProperties for AttributesChangedEvent {
 impl MessageConversion for AttributesChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -281,10 +271,8 @@ impl BusProperties for PageChangedEvent {
 impl MessageConversion for PageChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "zbus")]
-use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage};
+use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage, MessageConversionExt};
 use crate::{
 	error::AtspiError,
 	events::{BusProperties, HasInterfaceName, HasMatchRule, HasRegistryEventString},

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -209,9 +209,9 @@ impl EventWrapperMessageConversion for DocumentEvents {
 		let header = msg.header();
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
-			LoadCompleteEvent::DBUS_MEMBER => Ok(DocumentEvents::LoadComplete(
-				LoadCompleteEvent::from_message_unchecked(msg)?,
-			)),
+			LoadCompleteEvent::DBUS_MEMBER => {
+				Ok(DocumentEvents::LoadComplete(LoadCompleteEvent::from_message_unchecked(msg)?))
+			}
 			ReloadEvent::DBUS_MEMBER => {
 				Ok(DocumentEvents::Reload(ReloadEvent::from_message_unchecked(msg)?))
 			}

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -157,40 +157,12 @@ impl BusProperties for LoadCompleteEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for LoadCompleteEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for ReloadEvent {
 	const DBUS_MEMBER: &'static str = "Reload";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Document";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Document',member='Reload'";
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for ReloadEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 impl BusProperties for LoadStoppedEvent {
@@ -201,40 +173,12 @@ impl BusProperties for LoadStoppedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for LoadStoppedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for ContentChangedEvent {
 	const DBUS_MEMBER: &'static str = "ContentChanged";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Document";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Document',member='ContentChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for ContentChangedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 impl BusProperties for AttributesChangedEvent {
@@ -245,40 +189,12 @@ impl BusProperties for AttributesChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for AttributesChangedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for PageChangedEvent {
 	const DBUS_MEMBER: &'static str = "PageChanged";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Document";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Document',member='PageChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for PageChangedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 #[cfg(feature = "zbus")]
@@ -317,6 +233,7 @@ event_test_cases!(LoadCompleteEvent);
 impl_to_dbus_message!(LoadCompleteEvent);
 impl_from_dbus_message!(LoadCompleteEvent);
 impl_event_properties!(LoadCompleteEvent);
+impl_from_object_ref!(LoadCompleteEvent);
 impl From<LoadCompleteEvent> for EventBodyOwned {
 	fn from(_event: LoadCompleteEvent) -> Self {
 		EventBodyOwned {
@@ -341,6 +258,7 @@ event_test_cases!(ReloadEvent);
 impl_to_dbus_message!(ReloadEvent);
 impl_from_dbus_message!(ReloadEvent);
 impl_event_properties!(ReloadEvent);
+impl_from_object_ref!(ReloadEvent);
 impl From<ReloadEvent> for EventBodyOwned {
 	fn from(_event: ReloadEvent) -> Self {
 		EventBodyOwned {
@@ -369,6 +287,7 @@ event_test_cases!(LoadStoppedEvent);
 impl_to_dbus_message!(LoadStoppedEvent);
 impl_from_dbus_message!(LoadStoppedEvent);
 impl_event_properties!(LoadStoppedEvent);
+impl_from_object_ref!(LoadStoppedEvent);
 impl From<LoadStoppedEvent> for EventBodyOwned {
 	fn from(_event: LoadStoppedEvent) -> Self {
 		EventBodyOwned {
@@ -397,6 +316,7 @@ event_test_cases!(ContentChangedEvent);
 impl_to_dbus_message!(ContentChangedEvent);
 impl_from_dbus_message!(ContentChangedEvent);
 impl_event_properties!(ContentChangedEvent);
+impl_from_object_ref!(ContentChangedEvent);
 impl From<ContentChangedEvent> for EventBodyOwned {
 	fn from(_event: ContentChangedEvent) -> Self {
 		EventBodyOwned {
@@ -425,6 +345,7 @@ event_test_cases!(AttributesChangedEvent);
 impl_to_dbus_message!(AttributesChangedEvent);
 impl_from_dbus_message!(AttributesChangedEvent);
 impl_event_properties!(AttributesChangedEvent);
+impl_from_object_ref!(AttributesChangedEvent);
 impl From<AttributesChangedEvent> for EventBodyOwned {
 	fn from(_event: AttributesChangedEvent) -> Self {
 		EventBodyOwned {
@@ -453,6 +374,7 @@ event_test_cases!(PageChangedEvent);
 impl_to_dbus_message!(PageChangedEvent);
 impl_from_dbus_message!(PageChangedEvent);
 impl_event_properties!(PageChangedEvent);
+impl_from_object_ref!(PageChangedEvent);
 impl From<PageChangedEvent> for EventBodyOwned {
 	fn from(_event: PageChangedEvent) -> Self {
 		EventBodyOwned {

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "zbus")]
-use crate::events::{MessageConversion, ObjectRef};
+use crate::events::MessageConversion;
 use crate::{
 	error::AtspiError,
 	events::{BusProperties, HasMatchRule, HasRegistryEventString},

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -2,11 +2,11 @@
 use crate::events::{MessageConversion, ObjectRef};
 use crate::{
 	error::AtspiError,
-	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString},
+	events::{BusProperties, HasMatchRule, HasRegistryEventString},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;
-use zvariant::{ObjectPath, OwnedValue};
+use zvariant::ObjectPath;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
 pub enum DocumentEvents {
@@ -234,17 +234,6 @@ impl_to_dbus_message!(LoadCompleteEvent);
 impl_from_dbus_message!(LoadCompleteEvent);
 impl_event_properties!(LoadCompleteEvent);
 impl_from_object_ref!(LoadCompleteEvent);
-impl From<LoadCompleteEvent> for EventBodyOwned {
-	fn from(_event: LoadCompleteEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: OwnedValue::from(0u8),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	ReloadEvent,
@@ -259,17 +248,6 @@ impl_to_dbus_message!(ReloadEvent);
 impl_from_dbus_message!(ReloadEvent);
 impl_event_properties!(ReloadEvent);
 impl_from_object_ref!(ReloadEvent);
-impl From<ReloadEvent> for EventBodyOwned {
-	fn from(_event: ReloadEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: OwnedValue::from(0u8),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	LoadStoppedEvent,
@@ -288,17 +266,6 @@ impl_to_dbus_message!(LoadStoppedEvent);
 impl_from_dbus_message!(LoadStoppedEvent);
 impl_event_properties!(LoadStoppedEvent);
 impl_from_object_ref!(LoadStoppedEvent);
-impl From<LoadStoppedEvent> for EventBodyOwned {
-	fn from(_event: LoadStoppedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: OwnedValue::from(0u8),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	ContentChangedEvent,
@@ -317,17 +284,6 @@ impl_to_dbus_message!(ContentChangedEvent);
 impl_from_dbus_message!(ContentChangedEvent);
 impl_event_properties!(ContentChangedEvent);
 impl_from_object_ref!(ContentChangedEvent);
-impl From<ContentChangedEvent> for EventBodyOwned {
-	fn from(_event: ContentChangedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: OwnedValue::from(0u8),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	AttributesChangedEvent,
@@ -346,17 +302,6 @@ impl_to_dbus_message!(AttributesChangedEvent);
 impl_from_dbus_message!(AttributesChangedEvent);
 impl_event_properties!(AttributesChangedEvent);
 impl_from_object_ref!(AttributesChangedEvent);
-impl From<AttributesChangedEvent> for EventBodyOwned {
-	fn from(_event: AttributesChangedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: OwnedValue::from(0u8),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	PageChangedEvent,
@@ -375,17 +320,6 @@ impl_to_dbus_message!(PageChangedEvent);
 impl_from_dbus_message!(PageChangedEvent);
 impl_event_properties!(PageChangedEvent);
 impl_from_object_ref!(PageChangedEvent);
-impl From<PageChangedEvent> for EventBodyOwned {
-	fn from(_event: PageChangedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: OwnedValue::from(0u8),
-		}
-	}
-}
 
 impl HasRegistryEventString for DocumentEvents {
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -104,7 +104,7 @@ impl HasMatchRule for DocumentEvents {
 /// `LibreOffice` has loaded a document from disk.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct LoadCompleteEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
@@ -112,7 +112,7 @@ pub struct LoadCompleteEvent {
 /// For example: pressing F5, or `Control + r` will reload a page in a web browser.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct ReloadEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
@@ -120,19 +120,19 @@ pub struct ReloadEvent {
 /// For example: during the loading of a large web page, a user may press `Escape` to stop loading the page.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct LoadStoppedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct ContentChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct AttributesChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
@@ -145,7 +145,7 @@ pub struct AttributesChangedEvent {
 /// page number.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct PageChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -207,20 +207,22 @@ impl EventWrapperMessageConversion for DocumentEvents {
 		let header = msg.header();
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
-			"LoadComplete" => Ok(DocumentEvents::LoadComplete(
+			LoadCompleteEvent::DBUS_MEMBER => Ok(DocumentEvents::LoadComplete(
 				LoadCompleteEvent::try_from_message_unchecked(msg)?,
 			)),
-			"Reload" => Ok(DocumentEvents::Reload(ReloadEvent::try_from_message_unchecked(msg)?)),
-			"LoadStopped" => {
+			ReloadEvent::DBUS_MEMBER => {
+				Ok(DocumentEvents::Reload(ReloadEvent::try_from_message_unchecked(msg)?))
+			}
+			LoadStoppedEvent::DBUS_MEMBER => {
 				Ok(DocumentEvents::LoadStopped(LoadStoppedEvent::try_from_message_unchecked(msg)?))
 			}
-			"ContentChanged" => Ok(DocumentEvents::ContentChanged(
+			ContentChangedEvent::DBUS_MEMBER => Ok(DocumentEvents::ContentChanged(
 				ContentChangedEvent::try_from_message_unchecked(msg)?,
 			)),
-			"AttributesChanged" => Ok(DocumentEvents::AttributesChanged(
+			AttributesChangedEvent::DBUS_MEMBER => Ok(DocumentEvents::AttributesChanged(
 				AttributesChangedEvent::try_from_message_unchecked(msg)?,
 			)),
-			"PageChanged" => {
+			PageChangedEvent::DBUS_MEMBER => {
 				Ok(DocumentEvents::PageChanged(PageChangedEvent::try_from_message_unchecked(msg)?))
 			}
 			_ => Err(AtspiError::MemberMatch("No matching member for Document".into())),

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -163,7 +163,7 @@ impl MessageConversion for LoadCompleteEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -187,7 +187,7 @@ impl MessageConversion for ReloadEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -211,7 +211,7 @@ impl MessageConversion for LoadStoppedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -235,7 +235,7 @@ impl MessageConversion for ContentChangedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -259,7 +259,7 @@ impl MessageConversion for AttributesChangedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -283,7 +283,7 @@ impl MessageConversion for PageChangedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -1,11 +1,8 @@
 #[cfg(feature = "zbus")]
-use crate::events::MessageConversion;
+use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage};
 use crate::{
 	error::AtspiError,
-	events::{
-		BusProperties, EventWrapperMessageConversion, HasInterfaceName, HasMatchRule,
-		HasRegistryEventString, TryFromMessage,
-	},
+	events::{BusProperties, HasInterfaceName, HasMatchRule, HasRegistryEventString},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -210,22 +210,22 @@ impl EventWrapperMessageConversion for DocumentEvents {
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
 			LoadCompleteEvent::DBUS_MEMBER => Ok(DocumentEvents::LoadComplete(
-				LoadCompleteEvent::try_from_validated_message(msg)?,
+				LoadCompleteEvent::from_message_unchecked(msg)?,
 			)),
 			ReloadEvent::DBUS_MEMBER => {
-				Ok(DocumentEvents::Reload(ReloadEvent::try_from_validated_message(msg)?))
+				Ok(DocumentEvents::Reload(ReloadEvent::from_message_unchecked(msg)?))
 			}
 			LoadStoppedEvent::DBUS_MEMBER => {
-				Ok(DocumentEvents::LoadStopped(LoadStoppedEvent::try_from_validated_message(msg)?))
+				Ok(DocumentEvents::LoadStopped(LoadStoppedEvent::from_message_unchecked(msg)?))
 			}
 			ContentChangedEvent::DBUS_MEMBER => Ok(DocumentEvents::ContentChanged(
-				ContentChangedEvent::try_from_validated_message(msg)?,
+				ContentChangedEvent::from_message_unchecked(msg)?,
 			)),
 			AttributesChangedEvent::DBUS_MEMBER => Ok(DocumentEvents::AttributesChanged(
-				AttributesChangedEvent::try_from_validated_message(msg)?,
+				AttributesChangedEvent::from_message_unchecked(msg)?,
 			)),
 			PageChangedEvent::DBUS_MEMBER => {
-				Ok(DocumentEvents::PageChanged(PageChangedEvent::try_from_validated_message(msg)?))
+				Ok(DocumentEvents::PageChanged(PageChangedEvent::from_message_unchecked(msg)?))
 			}
 			_ => Err(AtspiError::MemberMatch("No matching member for Document".into())),
 		}

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "zbus")]
-use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage, MessageConversionExt};
+use crate::events::{
+	EventWrapperMessageConversion, MessageConversion, MessageConversionExt, TryFromMessage,
+};
 use crate::{
 	error::AtspiError,
 	events::{BusProperties, HasInterfaceName, HasMatchRule, HasRegistryEventString},

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -1,6 +1,9 @@
 use crate::{
 	error::AtspiError,
-	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, ObjectRef},
+	events::{
+		BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, MessageConversion,
+		ObjectRef,
+	},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;
@@ -153,10 +156,15 @@ impl BusProperties for LoadCompleteEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Document',member='LoadComplete'";
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";
+}
 
+impl MessageConversion for LoadCompleteEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -171,10 +179,15 @@ impl BusProperties for ReloadEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Document',member='Reload'";
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";
+}
 
+impl MessageConversion for ReloadEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -189,10 +202,15 @@ impl BusProperties for LoadStoppedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Document',member='LoadStopped'";
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";
+}
 
+impl MessageConversion for LoadStoppedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -207,10 +225,15 @@ impl BusProperties for ContentChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Document',member='ContentChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";
+}
 
+impl MessageConversion for ContentChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -225,10 +248,15 @@ impl BusProperties for AttributesChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Document',member='AttributesChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";
+}
 
+impl MessageConversion for AttributesChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -243,10 +271,15 @@ impl BusProperties for PageChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Document',member='PageChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Document:";
+}
 
+impl MessageConversion for PageChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/events/document.rs
+++ b/atspi-common/src/events/document.rs
@@ -208,22 +208,22 @@ impl EventWrapperMessageConversion for DocumentEvents {
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
 			LoadCompleteEvent::DBUS_MEMBER => Ok(DocumentEvents::LoadComplete(
-				LoadCompleteEvent::try_from_message_unchecked(msg)?,
+				LoadCompleteEvent::try_from_validated_message(msg)?,
 			)),
 			ReloadEvent::DBUS_MEMBER => {
-				Ok(DocumentEvents::Reload(ReloadEvent::try_from_message_unchecked(msg)?))
+				Ok(DocumentEvents::Reload(ReloadEvent::try_from_validated_message(msg)?))
 			}
 			LoadStoppedEvent::DBUS_MEMBER => {
-				Ok(DocumentEvents::LoadStopped(LoadStoppedEvent::try_from_message_unchecked(msg)?))
+				Ok(DocumentEvents::LoadStopped(LoadStoppedEvent::try_from_validated_message(msg)?))
 			}
 			ContentChangedEvent::DBUS_MEMBER => Ok(DocumentEvents::ContentChanged(
-				ContentChangedEvent::try_from_message_unchecked(msg)?,
+				ContentChangedEvent::try_from_validated_message(msg)?,
 			)),
 			AttributesChangedEvent::DBUS_MEMBER => Ok(DocumentEvents::AttributesChanged(
-				AttributesChangedEvent::try_from_message_unchecked(msg)?,
+				AttributesChangedEvent::try_from_validated_message(msg)?,
 			)),
 			PageChangedEvent::DBUS_MEMBER => {
-				Ok(DocumentEvents::PageChanged(PageChangedEvent::try_from_message_unchecked(msg)?))
+				Ok(DocumentEvents::PageChanged(PageChangedEvent::try_from_validated_message(msg)?))
 			}
 			_ => Err(AtspiError::MemberMatch("No matching member for Document".into())),
 		}

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -1,9 +1,8 @@
+#[cfg(feature = "zbus")]
+use crate::events::{MessageConversion, ObjectRef};
 use crate::{
 	error::AtspiError,
-	events::{
-		BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, MessageConversion,
-		ObjectRef,
-	},
+	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;
@@ -74,6 +73,7 @@ impl BusProperties for FocusEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Focus:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for FocusEvent {
 	type Body = EventBodyOwned;
 

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -4,7 +4,7 @@ use crate::{
 	error::AtspiError,
 	events::{
 		BusProperties, EventWrapperMessageConversion, HasInterfaceName, HasMatchRule,
-		HasRegistryEventString,
+		HasRegistryEventString, TryFromMessage,
 	},
 	Event, EventProperties, EventTypeProperties,
 };
@@ -99,16 +99,7 @@ impl EventWrapperMessageConversion for FocusEvents {
 impl TryFrom<&zbus::Message> for FocusEvents {
 	type Error = AtspiError;
 	fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
-		let header = msg.header();
-		let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
-		if interface != FocusEvents::DBUS_INTERFACE {
-			return Err(AtspiError::InterfaceMatch(format!(
-				"Interface {} does not match require interface for event: {}",
-				interface,
-				FocusEvents::DBUS_INTERFACE
-			)));
-		}
-		Self::try_from_message_interface_checked(msg)
+		Self::try_from_message(msg)
 	}
 }
 

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -2,7 +2,10 @@
 use crate::events::MessageConversion;
 use crate::{
 	error::AtspiError,
-	events::{BusProperties, HasInterfaceName, HasMatchRule, HasRegistryEventString},
+	events::{
+		BusProperties, EventWrapperMessageConversion, HasInterfaceName, HasMatchRule,
+		HasRegistryEventString,
+	},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;
@@ -78,13 +81,25 @@ impl HasInterfaceName for FocusEvents {
 }
 
 #[cfg(feature = "zbus")]
+impl EventWrapperMessageConversion for FocusEvents {
+	fn try_from_message_interface_checked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let header = msg.header();
+		let member = header.member().ok_or(AtspiError::MissingMember)?;
+		match member.as_str() {
+			"Focus" => Ok(FocusEvents::Focus(FocusEvent::try_from_message_unchecked(msg)?)),
+			_ => Err(AtspiError::MemberMatch(format!(
+				"No matching member {member} for interface {}",
+				Self::DBUS_INTERFACE,
+			))),
+		}
+	}
+}
+
+#[cfg(feature = "zbus")]
 impl TryFrom<&zbus::Message> for FocusEvents {
 	type Error = AtspiError;
 	fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
 		let header = msg.header();
-		let member = header
-			.member()
-			.ok_or(AtspiError::MemberMatch("Event without member".into()))?;
 		let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
 		if interface != FocusEvents::DBUS_INTERFACE {
 			return Err(AtspiError::InterfaceMatch(format!(
@@ -93,10 +108,7 @@ impl TryFrom<&zbus::Message> for FocusEvents {
 				FocusEvents::DBUS_INTERFACE
 			)));
 		}
-		match member.as_str() {
-			"Focus" => Ok(FocusEvents::Focus(FocusEvent::try_from_message_unchecked(msg)?)),
-			_ => Err(AtspiError::MemberMatch("No matching member for Focus".into())),
-		}
+		Self::try_from_message_interface_checked(msg)
 	}
 }
 

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -83,7 +83,9 @@ impl EventWrapperMessageConversion for FocusEvents {
 		let header = msg.header();
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
-			"Focus" => Ok(FocusEvents::Focus(FocusEvent::try_from_message_unchecked(msg)?)),
+			FocusEvent::DBUS_MEMBER => {
+				Ok(FocusEvents::Focus(FocusEvent::try_from_message_unchecked(msg)?))
+			}
 			_ => Err(AtspiError::MemberMatch(format!(
 				"No matching member {member} for interface {}",
 				Self::DBUS_INTERFACE,

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -2,7 +2,7 @@
 use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage};
 use crate::{
 	error::AtspiError,
-	events::{BusProperties, HasInterfaceName, HasMatchRule, HasRegistryEventString},
+	events::{BusProperties, HasInterfaceName, HasMatchRule, HasRegistryEventString, MessageConversionExt},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -79,7 +79,7 @@ impl MessageConversion for FocusEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -1,6 +1,9 @@
 use crate::{
 	error::AtspiError,
-	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, ObjectRef},
+	events::{
+		BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, MessageConversion,
+		ObjectRef,
+	},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;
@@ -69,10 +72,15 @@ impl BusProperties for FocusEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Focus',member='Focus'";
 	const REGISTRY_EVENT_STRING: &'static str = "Focus:";
+}
 
+impl MessageConversion for FocusEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -2,7 +2,9 @@
 use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage};
 use crate::{
 	error::AtspiError,
-	events::{BusProperties, HasInterfaceName, HasMatchRule, HasRegistryEventString, MessageConversionExt},
+	events::{
+		BusProperties, HasInterfaceName, HasMatchRule, HasRegistryEventString, MessageConversionExt,
+	},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -84,7 +84,7 @@ impl EventWrapperMessageConversion for FocusEvents {
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
 			FocusEvent::DBUS_MEMBER => {
-				Ok(FocusEvents::Focus(FocusEvent::try_from_message_unchecked(msg)?))
+				Ok(FocusEvents::Focus(FocusEvent::try_from_validated_message(msg)?))
 			}
 			_ => Err(AtspiError::MemberMatch(format!(
 				"No matching member {member} for interface {}",

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -77,7 +77,7 @@ impl BusProperties for FocusEvent {
 impl MessageConversion for FocusEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -74,20 +74,6 @@ impl BusProperties for FocusEvent {
 }
 
 #[cfg(feature = "zbus")]
-impl MessageConversion for FocusEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
-#[cfg(feature = "zbus")]
 impl TryFrom<&zbus::Message> for FocusEvents {
 	type Error = AtspiError;
 	fn try_from(ev: &zbus::Message) -> Result<Self, Self::Error> {
@@ -110,6 +96,7 @@ event_test_cases!(FocusEvent);
 impl_to_dbus_message!(FocusEvent);
 impl_from_dbus_message!(FocusEvent);
 impl_event_properties!(FocusEvent);
+impl_from_object_ref!(FocusEvent);
 impl From<FocusEvent> for EventBodyOwned {
 	fn from(_event: FocusEvent) -> Self {
 		EventBodyOwned {

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "zbus")]
-use crate::events::{MessageConversion, ObjectRef};
+use crate::events::MessageConversion;
 use crate::{
 	error::AtspiError,
 	events::{BusProperties, HasMatchRule, HasRegistryEventString},

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -1,10 +1,10 @@
 #[cfg(feature = "zbus")]
-use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage};
+use crate::events::{
+	EventWrapperMessageConversion, MessageConversion, MessageConversionExt, TryFromMessage,
+};
 use crate::{
 	error::AtspiError,
-	events::{
-		BusProperties, HasInterfaceName, HasMatchRule, HasRegistryEventString, MessageConversionExt,
-	},
+	events::{BusProperties, HasInterfaceName, HasMatchRule, HasRegistryEventString},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -86,7 +86,7 @@ impl EventWrapperMessageConversion for FocusEvents {
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
 			FocusEvent::DBUS_MEMBER => {
-				Ok(FocusEvents::Focus(FocusEvent::try_from_validated_message(msg)?))
+				Ok(FocusEvents::Focus(FocusEvent::from_message_unchecked(msg)?))
 			}
 			_ => Err(AtspiError::MemberMatch(format!(
 				"No matching member {member} for interface {}",

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -77,10 +77,8 @@ impl BusProperties for FocusEvent {
 impl MessageConversion for FocusEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -1,11 +1,8 @@
 #[cfg(feature = "zbus")]
-use crate::events::MessageConversion;
+use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage};
 use crate::{
 	error::AtspiError,
-	events::{
-		BusProperties, EventWrapperMessageConversion, HasInterfaceName, HasMatchRule,
-		HasRegistryEventString, TryFromMessage,
-	},
+	events::{BusProperties, HasInterfaceName, HasMatchRule, HasRegistryEventString},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -2,11 +2,11 @@
 use crate::events::{MessageConversion, ObjectRef};
 use crate::{
 	error::AtspiError,
-	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString},
+	events::{BusProperties, HasMatchRule, HasRegistryEventString},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;
-use zvariant::{ObjectPath, OwnedValue};
+use zvariant::ObjectPath;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
 pub enum FocusEvents {
@@ -97,17 +97,6 @@ impl_to_dbus_message!(FocusEvent);
 impl_from_dbus_message!(FocusEvent);
 impl_event_properties!(FocusEvent);
 impl_from_object_ref!(FocusEvent);
-impl From<FocusEvent> for EventBodyOwned {
-	fn from(_event: FocusEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: OwnedValue::from(0u8),
-		}
-	}
-}
 
 impl HasRegistryEventString for FocusEvents {
 	const REGISTRY_EVENT_STRING: &'static str = "Focus:";

--- a/atspi-common/src/events/focus.rs
+++ b/atspi-common/src/events/focus.rs
@@ -61,7 +61,7 @@ impl HasMatchRule for FocusEvents {
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct FocusEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -80,7 +80,7 @@ impl BusProperties for ModifiersEvent {
 impl MessageConversion for ModifiersEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -106,7 +106,7 @@ impl EventWrapperMessageConversion for KeyboardEvents {
 			.member()
 			.ok_or(AtspiError::MemberMatch("Event without member".into()))?;
 		match member.as_str() {
-			"Modifiers" => {
+			ModifiersEvent::DBUS_MEMBER => {
 				Ok(KeyboardEvents::Modifiers(ModifiersEvent::try_from_message_unchecked(msg)?))
 			}
 			_ => Err(AtspiError::MemberMatch("No matching member for Keyboard".into())),

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -80,8 +80,12 @@ impl BusProperties for ModifiersEvent {
 impl MessageConversion for ModifiersEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item, previous_modifiers: body.detail1, current_modifiers: body.detail2 })
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError> {
+		let ev_body: Self::Body = body.deserialize_unchecked()?;
+		Ok(Self { item, previous_modifiers: ev_body.detail1, current_modifiers: ev_body.detail2 })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -1,10 +1,9 @@
 #[cfg(feature = "zbus")]
-use crate::events::MessageConversion;
+use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage};
 use crate::{
 	error::AtspiError,
 	events::{
-		BusProperties, EventBodyOwned, EventWrapperMessageConversion, HasInterfaceName,
-		HasMatchRule, HasRegistryEventString, TryFromMessage,
+		BusProperties, EventBodyOwned, HasInterfaceName, HasMatchRule, HasRegistryEventString,
 	},
 	Event, EventProperties, EventTypeProperties,
 };

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -87,17 +87,17 @@ impl BusProperties for ModifiersEvent {
 impl MessageConversion for ModifiersEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		item: ObjectRef,
 		body: Self::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item, previous_modifiers: body.detail1, current_modifiers: body.detail2 })
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		let body: Self::Body = body.deserialize_unchecked()?;
-		Self::try_from_validated_message_parts(item, body)
+		Self::from_message_unchecked_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -118,7 +118,7 @@ impl EventWrapperMessageConversion for KeyboardEvents {
 			.ok_or(AtspiError::MemberMatch("Event without member".into()))?;
 		match member.as_str() {
 			ModifiersEvent::DBUS_MEMBER => {
-				Ok(KeyboardEvents::Modifiers(ModifiersEvent::try_from_validated_message(msg)?))
+				Ok(KeyboardEvents::Modifiers(ModifiersEvent::from_message_unchecked(msg)?))
 			}
 			_ => Err(AtspiError::MemberMatch("No matching member for Keyboard".into())),
 		}

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -1,6 +1,9 @@
 use crate::{
 	error::AtspiError,
-	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, ObjectRef},
+	events::{
+		BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, MessageConversion,
+		ObjectRef,
+	},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;
@@ -72,10 +75,12 @@ impl BusProperties for ModifiersEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Keyboard',member='Modifiers'";
 	const REGISTRY_EVENT_STRING: &'static str = "Keyboard:";
+}
 
+impl MessageConversion for ModifiersEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, previous_modifiers: body.detail1, current_modifiers: body.detail2 })
 	}
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "zbus")]
-use crate::events::{MessageConversion, ObjectRef};
+use crate::events::MessageConversion;
 use crate::{
 	error::AtspiError,
 	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString},
@@ -62,7 +62,7 @@ impl HasMatchRule for KeyboardEvents {
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct ModifiersEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 	pub previous_modifiers: i32,
 	pub current_modifiers: i32,

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -4,7 +4,7 @@ use crate::{
 	error::AtspiError,
 	events::{
 		BusProperties, EventBodyOwned, EventWrapperMessageConversion, HasInterfaceName,
-		HasMatchRule, HasRegistryEventString,
+		HasMatchRule, HasRegistryEventString, TryFromMessage,
 	},
 	Event, EventProperties, EventTypeProperties,
 };
@@ -119,16 +119,7 @@ impl EventWrapperMessageConversion for KeyboardEvents {
 impl TryFrom<&zbus::Message> for KeyboardEvents {
 	type Error = AtspiError;
 	fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
-		let header = msg.header();
-		let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
-		if interface != KeyboardEvents::DBUS_INTERFACE {
-			return Err(AtspiError::InterfaceMatch(format!(
-				"Interface {} does not match require interface for event: {}",
-				interface,
-				KeyboardEvents::DBUS_INTERFACE
-			)));
-		}
-		Self::try_from_message_interface_checked(msg)
+		Self::try_from_message(msg)
 	}
 }
 

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -87,10 +87,7 @@ impl BusProperties for ModifiersEvent {
 impl MessageConversion for ModifiersEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_unchecked_parts(
-		item: ObjectRef,
-		body: Self::Body,
-	) -> Result<Self, AtspiError> {
+	fn from_message_unchecked_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, previous_modifiers: body.detail1, current_modifiers: body.detail2 })
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -1,9 +1,8 @@
+#[cfg(feature = "zbus")]
+use crate::events::{MessageConversion, ObjectRef};
 use crate::{
 	error::AtspiError,
-	events::{
-		BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, MessageConversion,
-		ObjectRef,
-	},
+	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;
@@ -77,6 +76,7 @@ impl BusProperties for ModifiersEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Keyboard:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for ModifiersEvent {
 	type Body = EventBodyOwned;
 

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -7,7 +7,9 @@ use crate::{
 };
 #[cfg(feature = "zbus")]
 use crate::{
-	events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage, MessageConversionExt},
+	events::{
+		EventWrapperMessageConversion, MessageConversion, MessageConversionExt, TryFromMessage,
+	},
 	ObjectRef,
 };
 use zbus_names::UniqueName;

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -82,7 +82,7 @@ impl BusProperties for ModifiersEvent {
 impl MessageConversion for ModifiersEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		let ev_body: Self::Body = body.deserialize_unchecked()?;
@@ -107,7 +107,7 @@ impl EventWrapperMessageConversion for KeyboardEvents {
 			.ok_or(AtspiError::MemberMatch("Event without member".into()))?;
 		match member.as_str() {
 			ModifiersEvent::DBUS_MEMBER => {
-				Ok(KeyboardEvents::Modifiers(ModifiersEvent::try_from_message_unchecked(msg)?))
+				Ok(KeyboardEvents::Modifiers(ModifiersEvent::try_from_validated_message(msg)?))
 			}
 			_ => Err(AtspiError::MemberMatch("No matching member for Keyboard".into())),
 		}

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -80,10 +80,9 @@ impl BusProperties for ModifiersEvent {
 impl MessageConversion for ModifiersEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
 		let ev_body: Self::Body = body.deserialize_unchecked()?;
 		Ok(Self { item, previous_modifiers: ev_body.detail1, current_modifiers: ev_body.detail2 })
 	}

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 #[cfg(feature = "zbus")]
 use crate::{
-	events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage},
+	events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage, MessageConversionExt},
 	ObjectRef,
 };
 use zbus_names::UniqueName;

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -832,8 +832,8 @@ pub trait MessageConversion: BusProperties {
 	///
 	/// Therefore, this should only be used when one has checked the above conditions.
 	/// These must be checked manually.
-  /// Alternatively, there is the [`MessageConversionExt::try_from_message`] that will check these
-  /// conditions for you.
+	/// Alternatively, there is the [`MessageConversionExt::try_from_message`] that will check these
+	/// conditions for you.
 	///
 	/// This type also implements `TryFrom<&zbus::Message>`; consider using this if you are not an
 	/// internal developer.

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -418,8 +418,11 @@ impl BusProperties for LegacyAddAccessibleEvent {
 impl MessageConversion for LegacyAddAccessibleEvent {
 	type Body = LegacyCacheItem;
 
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item, node_added: body })
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError> {
+		Ok(Self { item, node_added: body.deserialize_unchecked()? })
 	}
 
 	fn body(&self) -> Self::Body {
@@ -458,8 +461,11 @@ impl BusProperties for AddAccessibleEvent {
 impl MessageConversion for AddAccessibleEvent {
 	type Body = CacheItem;
 
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item, node_added: body })
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError> {
+		Ok(Self { item, node_added: body.deserialize_unchecked()? })
 	}
 
 	fn body(&self) -> Self::Body {
@@ -506,8 +512,11 @@ impl BusProperties for RemoveAccessibleEvent {
 impl MessageConversion for RemoveAccessibleEvent {
 	type Body = ObjectRef;
 
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item, node_removed: body })
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError> {
+		Ok(Self { item, node_removed: body.deserialize_unchecked()? })
 	}
 	fn body(&self) -> Self::Body {
 		self.node_removed.clone()
@@ -705,8 +714,11 @@ impl BusProperties for EventListenerDeregisteredEvent {
 impl MessageConversion for EventListenerDeregisteredEvent {
 	type Body = EventListeners;
 
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item, deregistered_event: body })
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError> {
+		Ok(Self { item, deregistered_event: body.deserialize_unchecked()? })
 	}
 	fn body(&self) -> Self::Body {
 		self.deregistered_event.clone()
@@ -750,8 +762,11 @@ impl BusProperties for EventListenerRegisteredEvent {
 impl MessageConversion for EventListenerRegisteredEvent {
 	type Body = EventListeners;
 
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item, registered_event: body })
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError> {
+		Ok(Self { item, registered_event: body.deserialize_unchecked()? })
 	}
 	fn body(&self) -> Self::Body {
 		self.registered_event.clone()
@@ -796,8 +811,11 @@ impl BusProperties for AvailableEvent {
 impl MessageConversion for AvailableEvent {
 	type Body = ObjectRef;
 
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item, socket: body })
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError> {
+		Ok(Self { item, socket: body.deserialize_unchecked()? })
 	}
 	fn body(&self) -> Self::Body {
 		self.socket.clone()
@@ -969,8 +987,11 @@ pub trait MessageConversion {
 	/// When the body type does not match the [`Self::Body`] type defined in this trait.
 	/// Technically, it may also panic if you are accepting file descriptors over the
 	/// [`enum@zvariant::Value`] variant, and you are out of file descriptors for the process.
-	/// THis is considered exceptionally rare and should never happen.
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError>
+	/// This is considered exceptionally rare and should never happen.
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError>
 	where
 		Self: Sized;
 

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -321,10 +321,7 @@ where
 	T: BusProperties,
 {
 	type Body = EventBodyOwned;
-	fn from_message_unchecked_parts(
-		obj_ref: ObjectRef,
-		_: Self::Body,
-	) -> Result<Self, AtspiError> {
+	fn from_message_unchecked_parts(obj_ref: ObjectRef, _: Self::Body) -> Result<Self, AtspiError> {
 		Ok(obj_ref.into())
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
@@ -405,7 +402,7 @@ impl TryFrom<&zbus::Message> for EventBodyOwned {
 
 	fn try_from(message: &zbus::Message) -> Result<Self, Self::Error> {
 		let body = message.body();
-		let signature = body.signature().ok_or_else(|| AtspiError::MissingSignature)?;
+		let signature = body.signature().ok_or(AtspiError::MissingSignature)?;
 
 		if signature == QSPI_EVENT_SIGNATURE {
 			let qt_body = body.deserialize::<EventBodyQT>()?;

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -429,6 +429,21 @@ impl MessageConversion for LegacyAddAccessibleEvent {
 	}
 }
 
+#[cfg(feature = "zbus")]
+impl<T> MessageConversion for T
+where
+	T: From<ObjectRef>,
+{
+	type Body = EventBodyOwned;
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item: ObjectRef = msg.try_into()?;
+		Ok(item.into())
+	}
+	fn body(&self) -> Self::Body {
+		EventBodyOwned::default()
+	}
+}
+
 /// Type that contains the `zbus::Message` for meta information and
 /// the [`crate::cache::CacheItem`]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, Eq, Hash)]

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -902,7 +902,9 @@ impl TryFrom<&zbus::Message> for Event {
 			("org.a11y.atspi.Cache", "RemoveAccessible", "so" | "(so)") => {
 				Ok(RemoveAccessibleEvent::try_from(msg)?.into())
 			}
-			(_iface, _method, sig) => Err(AtspiError::UnknownBusSignature(sig.to_string())),
+			(_iface, _method, sig) => {
+				Err(AtspiError::SignatureMatch(format!("No events found with signature {}", sig)))
+			}
 		}
 	}
 }

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -418,7 +418,7 @@ impl BusProperties for LegacyAddAccessibleEvent {
 impl MessageConversion for LegacyAddAccessibleEvent {
 	type Body = LegacyCacheItem;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -461,7 +461,7 @@ impl BusProperties for AddAccessibleEvent {
 impl MessageConversion for AddAccessibleEvent {
 	type Body = CacheItem;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -512,7 +512,7 @@ impl BusProperties for RemoveAccessibleEvent {
 impl MessageConversion for RemoveAccessibleEvent {
 	type Body = ObjectRef;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -714,7 +714,7 @@ impl BusProperties for EventListenerDeregisteredEvent {
 impl MessageConversion for EventListenerDeregisteredEvent {
 	type Body = EventListeners;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -762,7 +762,7 @@ impl BusProperties for EventListenerRegisteredEvent {
 impl MessageConversion for EventListenerRegisteredEvent {
 	type Body = EventListeners;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -811,7 +811,7 @@ impl BusProperties for AvailableEvent {
 impl MessageConversion for AvailableEvent {
 	type Body = ObjectRef;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -988,7 +988,7 @@ pub trait MessageConversion {
 	/// Technically, it may also panic if you are accepting file descriptors over the
 	/// [`enum@zvariant::Value`] variant, and you are out of file descriptors for the process.
 	/// This is considered exceptionally rare and should never happen.
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError>

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -414,6 +414,7 @@ impl BusProperties for LegacyAddAccessibleEvent {
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Cache";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for LegacyAddAccessibleEvent {
 	type Body = LegacyCacheItem;
 
@@ -453,6 +454,7 @@ impl BusProperties for AddAccessibleEvent {
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Cache";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for AddAccessibleEvent {
 	type Body = CacheItem;
 
@@ -500,6 +502,7 @@ impl BusProperties for RemoveAccessibleEvent {
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Cache";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for RemoveAccessibleEvent {
 	type Body = ObjectRef;
 
@@ -698,6 +701,7 @@ impl BusProperties for EventListenerDeregisteredEvent {
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Registry";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for EventListenerDeregisteredEvent {
 	type Body = EventListeners;
 
@@ -742,6 +746,7 @@ impl BusProperties for EventListenerRegisteredEvent {
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Registry";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for EventListenerRegisteredEvent {
 	type Body = EventListeners;
 
@@ -787,6 +792,7 @@ impl BusProperties for AvailableEvent {
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Socket";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for AvailableEvent {
 	type Body = ObjectRef;
 
@@ -950,6 +956,7 @@ pub trait BusProperties {
 	const REGISTRY_EVENT_STRING: &'static str;
 }
 
+#[cfg(feature = "zbus")]
 pub trait MessageConversion {
 	/// What is the body type of this event.
 	type Body: Type + Serialize + for<'a> Deserialize<'a>;

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -823,12 +823,12 @@ pub trait MessageConversion: BusProperties {
 	/// Build an event from a [`zbus::Message`] reference.
 	/// This function will not check for any of the following error conditions:
 	///
-	/// - That the message has an interface: [`enum@AtspiError::MissingInterface`]
-	/// - That the message interface matches the one for the event: [`enum@AtspiError::InterfaceMatch`]
-	/// - That the message has an member: [`enum@AtspiError::MissingMember`]
-	/// - That the message member matches the one for the event: [`enum@AtspiError::MemberMatch`]
-	/// - That the message has an signature: [`enum@AtspiError::MissingSignature`]
-	/// - That the message signature matches the one for the event: [`enum@AtspiError::SignatureMatch`]
+	/// - That the message has an interface: [`type@AtspiError::MissingInterface`]
+	/// - That the message interface matches the one for the event: [`type@AtspiError::InterfaceMatch`]
+	/// - That the message has an member: [`type@AtspiError::MissingMember`]
+	/// - That the message member matches the one for the event: [`type@AtspiError::MemberMatch`]
+	/// - That the message has an signature: [`type@AtspiError::MissingSignature`]
+	/// - That the message signature matches the one for the event: [`type@AtspiError::SignatureMatch`]
 	///
 	/// Therefore, this should only be used when one has checked the above conditions.
 	/// These can be checked manually, or you can use the convience function provided by this trait:
@@ -839,7 +839,7 @@ pub trait MessageConversion: BusProperties {
 	///
 	/// # Errors
 	///
-	/// It is possible to get a [`enum@AtspiError::Zvariant`] error if you do not check the proper
+	/// It is possible to get a [`type@AtspiError::Zvariant`] error if you do not check the proper
 	/// conditions before calling this.
 	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError>
 	where
@@ -848,10 +848,10 @@ pub trait MessageConversion: BusProperties {
 	/// Build an event from an [`ObjectRef`] and [`Self::Body`].
 	/// This function will not check for any of the following error conditions:
 	///
-	/// - That the message has an interface: [`enum@AtspiError::MissingInterface`]
-	/// - That the message interface matches the one for the event: [`enum@AtspiError::InterfaceMatch`]
-	/// - That the message has an member: [`enum@AtspiError::MissingMember`]
-	/// - That the message member matches the one for the event: [`enum@AtspiError::MemberMatch`]
+	/// - That the message has an interface: [`type@AtspiError::MissingInterface`]
+	/// - That the message interface matches the one for the event: [`type@AtspiError::InterfaceMatch`]
+	/// - That the message has an member: [`type@AtspiError::MissingMember`]
+	/// - That the message member matches the one for the event: [`type@AtspiError::MemberMatch`]
 	///
 	/// Therefore, this should only be used when one has checked the above conditions.
 	///
@@ -866,12 +866,12 @@ pub trait MessageConversion: BusProperties {
 	where
 		Self: Sized;
 
-	/// Validate the interface string via [`zbus::Header::interface`] against [`Self::DBUS_INTERFACE`]
+	/// Validate the interface string via [`zbus::message::Header::interface`] against `Self`'s assignment of [`BusProperties::DBUS_INTERFACE`]
 	///
 	/// # Errors
 	///
-	/// - [`enum@AtspiError::MissingInterface`] if there is no interface
-	/// - [`enum@AtspiError::InterfaceMatch`] if the interfaces do not match
+	/// - [`type@AtspiError::MissingInterface`] if there is no interface
+	/// - [`type@AtspiError::InterfaceMatch`] if the interfaces do not match
 	fn validate_interface(msg: &zbus::Message) -> Result<(), AtspiError> {
 		let header = msg.header();
 		let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
@@ -884,12 +884,12 @@ pub trait MessageConversion: BusProperties {
 		}
 		Ok(())
 	}
-	/// Validate the member string via [`zbus::Header::member`] against [`Self::DBUS_MEMBER`]
+	/// Validate the member string via [`zbus::message::Header::member`] against `Self`'s assignment of [`BusProperties::DBUS_MEMBER`]
 	///
 	/// # Errors
 	///
-	/// - [`enum@AtspiError::MissingMember`] if there is no member
-	/// - [`enum@AtspiError::MemberMatch`] if the members do not match
+	/// - [`type@AtspiError::MissingMember`] if there is no member
+	/// - [`type@AtspiError::MemberMatch`] if the members do not match
 	fn validate_member(msg: &zbus::Message) -> Result<(), AtspiError> {
 		let header = msg.header();
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
@@ -903,12 +903,12 @@ pub trait MessageConversion: BusProperties {
 		}
 		Ok(())
 	}
-	/// Validate the body signature against the [`zbus::Signature`] of [`Self::Body`]
+	/// Validate the body signature against the [`zvariant::Signature`] of [`Self::Body`]
 	///
 	/// # Errors
 	///
-	/// - [`enum@AtspiError::MissingSignature`] if there is no signature
-	/// - [`enum@AtspiError::SignatureMatch`] if the signatures do not match
+	/// - [`type@AtspiError::MissingSignature`] if there is no signature
+	/// - [`type@AtspiError::SignatureMatch`] if the signatures do not match
 	fn validate_body(msg: &zbus::Message) -> Result<(), AtspiError> {
 		let body = msg.body();
 		let body_signature = body.signature().ok_or(AtspiError::MissingSignature)?;
@@ -927,12 +927,12 @@ pub trait MessageConversion: BusProperties {
 	///
 	/// # Errors
 	///
-	/// - The message does not have an interface: [`enum@AtspiError::MissingInterface`]
-	/// - The message interface does not match the one for the event: [`enum@AtspiError::InterfaceMatch`]
-	/// - The message does not have an member: [`enum@AtspiError::MissingMember`]
-	/// - The message member does not match the one for the event: [`enum@AtspiError::MemberMatch`]
-	/// - The message does not have an signature: [`enum@AtspiError::MissingSignature`]
-	/// - The message signature does not match the one for the event: [`enum@AtspiError::SignatureMatch`]
+	/// - The message does not have an interface: [`type@AtspiError::MissingInterface`]
+	/// - The message interface does not match the one for the event: [`type@AtspiError::InterfaceMatch`]
+	/// - The message does not have an member: [`type@AtspiError::MissingMember`]
+	/// - The message member does not match the one for the event: [`type@AtspiError::MemberMatch`]
+	/// - The message does not have an signature: [`type@AtspiError::MissingSignature`]
+	/// - The message signature does not match the one for the event: [`type@AtspiError::SignatureMatch`]
 	///
 	/// See [`Self::try_from_validated_message`] for info on panic condition that should never
 	/// happen.

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -498,10 +498,10 @@ impl EventWrapperMessageConversion for EventListenerEvents {
 		let header = msg.header();
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
-			"EventListenerRegistered" => Ok(EventListenerEvents::Registered(
+			EventListenerRegisteredEvent::DBUS_MEMBER => Ok(EventListenerEvents::Registered(
 				EventListenerRegisteredEvent::try_from_message_unchecked(msg)?,
 			)),
-			"EventListenerDeregistered" => Ok(EventListenerEvents::Deregistered(
+			EventListenerDeregisteredEvent::DBUS_MEMBER => Ok(EventListenerEvents::Deregistered(
 				EventListenerDeregisteredEvent::try_from_message_unchecked(msg)?,
 			)),
 			_ => Err(AtspiError::MemberMatch(format!(
@@ -675,16 +675,36 @@ impl TryFrom<&zbus::Message> for Event {
 		let interface_str = interface.as_str();
 
 		match interface_str {
-			"org.a11y.atspi.Socket" => Ok(AvailableEvent::try_from(msg)?.into()),
-			"org.a11y.atspi.Event.Object" => Ok(Event::Object(ObjectEvents::try_from_message_interface_checked(msg)?)),
-			"org.a11y.atspi.Event.Document" => Ok(Event::Document(DocumentEvents::try_from_message_interface_checked(msg)?)),
-			"org.a11y.atspi.Event.Window" => Ok(Event::Window(WindowEvents::try_from_message_interface_checked(msg)?)),
-			"org.a11y.atspi.Event.Terminal" => Ok(Event::Terminal(TerminalEvents::try_from_message_interface_checked(msg)?)),
-			"org.a11y.atspi.Event.Mouse" => Ok(Event::Mouse(MouseEvents::try_from_message_interface_checked(msg)?)),
-			"org.a11y.atspi.Event.Focus" => Ok(Event::Focus(FocusEvents::try_from_message_interface_checked(msg)?)),
-			"org.a11y.atspi.Event.Keyboard" => Ok(Event::Keyboard(KeyboardEvents::try_from_message_interface_checked(msg)?)),
-			"org.a11y.atspi.Cache" => Ok(Event::Cache(CacheEvents::try_from_message_interface_checked(msg)?)),
-			"org.a11y.atspi.Registry" => Ok(Event::Listener(EventListenerEvents::try_from_message_interface_checked(msg)?)),
+			<AvailableEvent as BusProperties>::DBUS_INTERFACE => {
+				Ok(AvailableEvent::try_from(msg)?.into())
+			}
+			ObjectEvents::DBUS_INTERFACE => {
+				Ok(Event::Object(ObjectEvents::try_from_message_interface_checked(msg)?))
+			}
+			DocumentEvents::DBUS_INTERFACE => {
+				Ok(Event::Document(DocumentEvents::try_from_message_interface_checked(msg)?))
+			}
+			WindowEvents::DBUS_INTERFACE => {
+				Ok(Event::Window(WindowEvents::try_from_message_interface_checked(msg)?))
+			}
+			TerminalEvents::DBUS_INTERFACE => {
+				Ok(Event::Terminal(TerminalEvents::try_from_message_interface_checked(msg)?))
+			}
+			MouseEvents::DBUS_INTERFACE => {
+				Ok(Event::Mouse(MouseEvents::try_from_message_interface_checked(msg)?))
+			}
+			FocusEvents::DBUS_INTERFACE => {
+				Ok(Event::Focus(FocusEvents::try_from_message_interface_checked(msg)?))
+			}
+			KeyboardEvents::DBUS_INTERFACE => {
+				Ok(Event::Keyboard(KeyboardEvents::try_from_message_interface_checked(msg)?))
+			}
+			CacheEvents::DBUS_INTERFACE => {
+				Ok(Event::Cache(CacheEvents::try_from_message_interface_checked(msg)?))
+			}
+			EventListenerEvents::DBUS_INTERFACE => {
+				Ok(Event::Listener(EventListenerEvents::try_from_message_interface_checked(msg)?))
+			}
 			_ => Err(AtspiError::InterfaceMatch(format!(
 				"No events found with interface {interface_str}"
 			))),

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -494,7 +494,10 @@ impl<T: BusProperties> HasMatchRule for T {
 impl<T: BusProperties> HasRegistryEventString for T {
 	const REGISTRY_EVENT_STRING: &'static str = <T as BusProperties>::REGISTRY_EVENT_STRING;
 }
-impl_from_dbus_message!(AddAccessibleEvent, Explicit);
+impl<T: BusProperties> HasInterfaceName for T {
+	const DBUS_INTERFACE: &'static str = <T as BusProperties>::DBUS_INTERFACE;
+}
+impl_from_dbus_message!(AddAccessibleEvent);
 impl_event_properties!(AddAccessibleEvent);
 impl_to_dbus_message!(AddAccessibleEvent);
 

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -1010,6 +1010,18 @@ pub trait MessageConversion {
 	fn body(&self) -> Self::Body;
 }
 
+/// A specific trait *only* to define an interface name.
+/// This is useful for event wrappers like [`ObjectEvents`], which, while it does not have other
+/// information required to implement the [`BusProperties`] trait, you can indeed attach in
+/// interface name for all sub events of [`ObjectEvents`].
+///
+/// This trait *is not* object-safe.
+pub trait HasInterfaceName {
+	/// A static interface string for `DBus`.
+	/// This should usually be a string that looks like this: `"org.a11y.atspi.Event.*"`;
+	const DBUS_INTERFACE: &'static str;
+}
+
 /// A specific trait *only* to define match rules.
 /// This is useful for event wrappers like [`ObjectEvents`], which, while it does not have other
 /// information required to implement the [`BusProperties`] trait, you can indeed add a match rule

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -432,7 +432,10 @@ impl MessageConversion for LegacyAddAccessibleEvent {
 #[cfg(feature = "zbus")]
 impl<T> MessageConversion for T
 where
-	T: From<ObjectRef>,
+	ObjectRef: Into<T>,
+	// this bound is not actually used for anything, but I do not want to implement this trait for
+	// just any type that has an infallible conversion from an ObjectRef
+	T: BusProperties,
 {
 	type Body = EventBodyOwned;
 	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -871,72 +871,84 @@ pub trait MessageConversion: BusProperties {
 }
 
 impl<T> MessageConversionExt<crate::LegacyCacheItem> for T
-where T: MessageConversion<Body = crate::LegacyCacheItem> {
-    fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
-        <T as MessageConversionExt<crate::LegacyCacheItem>>::validate_interface(msg)?;
-        <T as MessageConversionExt<crate::LegacyCacheItem>>::validate_member(msg)?;
-        <T as MessageConversionExt<crate::LegacyCacheItem>>::validate_body(msg)?;
-        <T as MessageConversion>::try_from_validated_message(msg)
-    }
+where
+	T: MessageConversion<Body = crate::LegacyCacheItem>,
+{
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		<T as MessageConversionExt<crate::LegacyCacheItem>>::validate_interface(msg)?;
+		<T as MessageConversionExt<crate::LegacyCacheItem>>::validate_member(msg)?;
+		<T as MessageConversionExt<crate::LegacyCacheItem>>::validate_body(msg)?;
+		<T as MessageConversion>::try_from_validated_message(msg)
+	}
 }
 
 impl<T> MessageConversionExt<EventListeners> for T
-where T: MessageConversion<Body = EventListeners> {
-    fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
-        <T as MessageConversionExt<EventListeners>>::validate_interface(msg)?;
-        <T as MessageConversionExt<EventListeners>>::validate_member(msg)?;
-        <T as MessageConversionExt<EventListeners>>::validate_body(msg)?;
-        <T as MessageConversion>::try_from_validated_message(msg)
-    }
+where
+	T: MessageConversion<Body = EventListeners>,
+{
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		<T as MessageConversionExt<EventListeners>>::validate_interface(msg)?;
+		<T as MessageConversionExt<EventListeners>>::validate_member(msg)?;
+		<T as MessageConversionExt<EventListeners>>::validate_body(msg)?;
+		<T as MessageConversion>::try_from_validated_message(msg)
+	}
 }
 
 impl<T> MessageConversionExt<crate::CacheItem> for T
-where T: MessageConversion<Body = crate::CacheItem> {
-    fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
-        <T as MessageConversionExt<crate::CacheItem>>::validate_interface(msg)?;
-        <T as MessageConversionExt<crate::CacheItem>>::validate_member(msg)?;
-        <T as MessageConversionExt<crate::CacheItem>>::validate_body(msg)?;
-        <T as MessageConversion>::try_from_validated_message(msg)
-    }
+where
+	T: MessageConversion<Body = crate::CacheItem>,
+{
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		<T as MessageConversionExt<crate::CacheItem>>::validate_interface(msg)?;
+		<T as MessageConversionExt<crate::CacheItem>>::validate_member(msg)?;
+		<T as MessageConversionExt<crate::CacheItem>>::validate_body(msg)?;
+		<T as MessageConversion>::try_from_validated_message(msg)
+	}
 }
 
 impl<T> MessageConversionExt<ObjectRef> for T
-where T: MessageConversion<Body = ObjectRef> {
-    fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
-        <T as MessageConversionExt<ObjectRef>>::validate_interface(msg)?;
-        <T as MessageConversionExt<ObjectRef>>::validate_member(msg)?;
-        <T as MessageConversionExt<ObjectRef>>::validate_body(msg)?;
-        <T as MessageConversion>::try_from_validated_message(msg)
-    }
+where
+	T: MessageConversion<Body = ObjectRef>,
+{
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		<T as MessageConversionExt<ObjectRef>>::validate_interface(msg)?;
+		<T as MessageConversionExt<ObjectRef>>::validate_member(msg)?;
+		<T as MessageConversionExt<ObjectRef>>::validate_body(msg)?;
+		<T as MessageConversion>::try_from_validated_message(msg)
+	}
 }
 
 impl<T> MessageConversionExt<EventBodyOwned> for T
-where T: MessageConversion<Body = EventBodyOwned> {
-    fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
-        <T as MessageConversionExt<EventBodyOwned>>::validate_interface(msg)?;
-        <T as MessageConversionExt<EventBodyOwned>>::validate_member(msg)?;
-        let body = msg.body();
-        let body_sig = body.signature().ok_or(AtspiError::MissingSignature)?;
-        let data_body: EventBodyOwned = if body_sig == ATSPI_EVENT_SIGNATURE {
-            body.deserialize_unchecked()?
-        } else if body_sig == QSPI_EVENT_SIGNATURE {
-            let qtbody: EventBodyQT = body.deserialize_unchecked()?;
-            qtbody.into()
-        } else {
-          return Err(AtspiError::SignatureMatch(format!(
-            "The message signature {} does not match the signal's body signature: {} or {}",
-            body_sig,
-            EventBodyOwned::signature(),
-            EventBodyQT::signature(),
-          )));
-        };
-        let item = msg.try_into()?;
-        Self::try_from_validated_message_parts(item, data_body)
-    }
+where
+	T: MessageConversion<Body = EventBodyOwned>,
+{
+	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		<T as MessageConversionExt<EventBodyOwned>>::validate_interface(msg)?;
+		<T as MessageConversionExt<EventBodyOwned>>::validate_member(msg)?;
+		let body = msg.body();
+		let body_sig = body.signature().ok_or(AtspiError::MissingSignature)?;
+		let data_body: EventBodyOwned = if body_sig == ATSPI_EVENT_SIGNATURE {
+			body.deserialize_unchecked()?
+		} else if body_sig == QSPI_EVENT_SIGNATURE {
+			let qtbody: EventBodyQT = body.deserialize_unchecked()?;
+			qtbody.into()
+		} else {
+			return Err(AtspiError::SignatureMatch(format!(
+				"The message signature {} does not match the signal's body signature: {} or {}",
+				body_sig,
+				EventBodyOwned::signature(),
+				EventBodyQT::signature(),
+			)));
+		};
+		let item = msg.try_into()?;
+		Self::try_from_validated_message_parts(item, data_body)
+	}
 }
 
-pub trait MessageConversionExt<B>: MessageConversion<Body = B> 
-where B: Type + Serialize + for<'a> Deserialize<'a> {
+pub trait MessageConversionExt<B>: MessageConversion<Body = B>
+where
+	B: Type + Serialize + for<'a> Deserialize<'a>,
+{
 	/// Convert a [`zbus::Message`] into this event type.
 	/// Does all the validation for you.
 	///

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -396,27 +396,6 @@ impl TryFrom<&zbus::Message> for ObjectRef {
 	}
 }
 
-#[cfg(feature = "zbus")]
-impl TryFrom<&zbus::Message> for EventBodyOwned {
-	type Error = AtspiError;
-
-	fn try_from(message: &zbus::Message) -> Result<Self, Self::Error> {
-		let body = message.body();
-		let signature = body.signature().ok_or(AtspiError::MissingSignature)?;
-
-		if signature == QSPI_EVENT_SIGNATURE {
-			let qt_body = body.deserialize::<EventBodyQT>()?;
-			Ok(EventBodyOwned::from(qt_body))
-		} else if signature == ATSPI_EVENT_SIGNATURE {
-			Ok(body.deserialize::<EventBodyOwned>()?)
-		} else {
-			Err(AtspiError::Conversion(
-				"Unable to convert from zbus::Message to EventBodyQT or EventBodyOwned",
-			))
-		}
-	}
-}
-
 /// Signal type emitted by `EventListenerRegistered` and `EventListenerDeregistered` signals,
 /// which belong to the `Registry` interface, implemented by the registry-daemon.
 #[validate(signal: "EventListenerRegistered")]

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -676,15 +676,15 @@ impl TryFrom<&zbus::Message> for Event {
 
 		match interface_str {
 			"org.a11y.atspi.Socket" => Ok(AvailableEvent::try_from(msg)?.into()),
-			"org.a11y.atspi.Event.Object" => Ok(Event::Object(ObjectEvents::try_from(msg)?)),
-			"org.a11y.atspi.Event.Document" => Ok(Event::Document(DocumentEvents::try_from(msg)?)),
-			"org.a11y.atspi.Event.Window" => Ok(Event::Window(WindowEvents::try_from(msg)?)),
-			"org.a11y.atspi.Event.Terminal" => Ok(Event::Terminal(TerminalEvents::try_from(msg)?)),
-			"org.a11y.atspi.Event.Mouse" => Ok(Event::Mouse(MouseEvents::try_from(msg)?)),
-			"org.a11y.atspi.Event.Focus" => Ok(Event::Focus(FocusEvents::try_from(msg)?)),
-			"org.a11y.atspi.Event.Keyboard" => Ok(Event::Keyboard(KeyboardEvents::try_from(msg)?)),
-			"org.a11y.atspi.Cache" => Ok(Event::Cache(CacheEvents::try_from(msg)?)),
-			"org.a11y.atspi.Registry" => Ok(Event::Listener(EventListenerEvents::try_from(msg)?)),
+			"org.a11y.atspi.Event.Object" => Ok(Event::Object(ObjectEvents::try_from_message_interface_checked(msg)?)),
+			"org.a11y.atspi.Event.Document" => Ok(Event::Document(DocumentEvents::try_from_message_interface_checked(msg)?)),
+			"org.a11y.atspi.Event.Window" => Ok(Event::Window(WindowEvents::try_from_message_interface_checked(msg)?)),
+			"org.a11y.atspi.Event.Terminal" => Ok(Event::Terminal(TerminalEvents::try_from_message_interface_checked(msg)?)),
+			"org.a11y.atspi.Event.Mouse" => Ok(Event::Mouse(MouseEvents::try_from_message_interface_checked(msg)?)),
+			"org.a11y.atspi.Event.Focus" => Ok(Event::Focus(FocusEvents::try_from_message_interface_checked(msg)?)),
+			"org.a11y.atspi.Event.Keyboard" => Ok(Event::Keyboard(KeyboardEvents::try_from_message_interface_checked(msg)?)),
+			"org.a11y.atspi.Cache" => Ok(Event::Cache(CacheEvents::try_from_message_interface_checked(msg)?)),
+			"org.a11y.atspi.Registry" => Ok(Event::Listener(EventListenerEvents::try_from_message_interface_checked(msg)?)),
 			_ => Err(AtspiError::InterfaceMatch(format!(
 				"No events found with interface {interface_str}"
 			))),

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -418,10 +418,9 @@ impl BusProperties for LegacyAddAccessibleEvent {
 impl MessageConversion for LegacyAddAccessibleEvent {
 	type Body = LegacyCacheItem;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
 		Ok(Self { item, node_added: body.deserialize_unchecked()? })
 	}
 
@@ -461,10 +460,9 @@ impl BusProperties for AddAccessibleEvent {
 impl MessageConversion for AddAccessibleEvent {
 	type Body = CacheItem;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
 		Ok(Self { item, node_added: body.deserialize_unchecked()? })
 	}
 
@@ -512,10 +510,9 @@ impl BusProperties for RemoveAccessibleEvent {
 impl MessageConversion for RemoveAccessibleEvent {
 	type Body = ObjectRef;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
 		Ok(Self { item, node_removed: body.deserialize_unchecked()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -714,10 +711,9 @@ impl BusProperties for EventListenerDeregisteredEvent {
 impl MessageConversion for EventListenerDeregisteredEvent {
 	type Body = EventListeners;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
 		Ok(Self { item, deregistered_event: body.deserialize_unchecked()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -762,10 +758,9 @@ impl BusProperties for EventListenerRegisteredEvent {
 impl MessageConversion for EventListenerRegisteredEvent {
 	type Body = EventListeners;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
 		Ok(Self { item, registered_event: body.deserialize_unchecked()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -811,10 +806,9 @@ impl BusProperties for AvailableEvent {
 impl MessageConversion for AvailableEvent {
 	type Body = ObjectRef;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
 		Ok(Self { item, socket: body.deserialize_unchecked()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -988,10 +982,7 @@ pub trait MessageConversion {
 	/// Technically, it may also panic if you are accepting file descriptors over the
 	/// [`enum@zvariant::Value`] variant, and you are out of file descriptors for the process.
 	/// This is considered exceptionally rare and should never happen.
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError>
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError>
 	where
 		Self: Sized;
 

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod document;
 pub mod focus;
 pub mod keyboard;
@@ -33,14 +34,11 @@ use zbus_names::{OwnedUniqueName, UniqueName};
 use zvariant::OwnedObjectPath;
 use zvariant::{ObjectPath, OwnedValue, Signature, Type, Value};
 
-use crate::{
-	cache::{CacheItem, LegacyCacheItem},
-	events::{
-		document::DocumentEvents, focus::FocusEvents, keyboard::KeyboardEvents, mouse::MouseEvents,
-		object::ObjectEvents, terminal::TerminalEvents, window::WindowEvents,
-	},
-	AtspiError, ObjectRef,
+pub use crate::events::{
+	cache::CacheEvents, document::DocumentEvents, focus::FocusEvents, keyboard::KeyboardEvents,
+	mouse::MouseEvents, object::ObjectEvents, terminal::TerminalEvents, window::WindowEvents,
 };
+use crate::{AtspiError, ObjectRef};
 
 /// Qt event body, which is not the same as other GUI frameworks.
 /// Signature:  "siiv(so)"
@@ -301,14 +299,6 @@ impl EventProperties for Event {
 	}
 }
 
-impl HasMatchRule for CacheEvents {
-	const MATCH_RULE_STRING: &'static str = "type='signal',interface='org.a11y.atspi.Cache'";
-}
-
-impl HasRegistryEventString for CacheEvents {
-	const REGISTRY_EVENT_STRING: &'static str = "Cache";
-}
-
 impl HasInterfaceName for EventListenerEvents {
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Registry";
 }
@@ -320,173 +310,6 @@ impl HasMatchRule for EventListenerEvents {
 
 impl HasRegistryEventString for EventListenerEvents {
 	const REGISTRY_EVENT_STRING: &'static str = "Event";
-}
-
-/// All events related to the `org.a11y.atspi.Cache` interface.
-/// Note that these are not telling the client that an item *has been added* to a cache.
-/// It is telling the client "here is a bunch of information to store it in your cache".
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, Hash)]
-#[allow(clippy::module_name_repetitions)]
-pub enum CacheEvents {
-	/// See: [`AddAccessibleEvent`].
-	Add(AddAccessibleEvent),
-	/// See: [`LegacyAddAccessibleEvent`].
-	LegacyAdd(LegacyAddAccessibleEvent),
-	/// See: [`RemoveAccessibleEvent`].
-	Remove(RemoveAccessibleEvent),
-}
-
-impl EventTypeProperties for CacheEvents {
-	fn member(&self) -> &'static str {
-		match self {
-			Self::Add(inner) => inner.member(),
-			Self::LegacyAdd(inner) => inner.member(),
-			Self::Remove(inner) => inner.member(),
-		}
-	}
-	fn interface(&self) -> &'static str {
-		match self {
-			Self::Add(inner) => inner.interface(),
-			Self::LegacyAdd(inner) => inner.interface(),
-			Self::Remove(inner) => inner.interface(),
-		}
-	}
-	fn match_rule(&self) -> &'static str {
-		match self {
-			Self::Add(inner) => inner.match_rule(),
-			Self::LegacyAdd(inner) => inner.match_rule(),
-			Self::Remove(inner) => inner.match_rule(),
-		}
-	}
-	fn registry_string(&self) -> &'static str {
-		match self {
-			Self::Add(inner) => inner.registry_string(),
-			Self::LegacyAdd(inner) => inner.registry_string(),
-			Self::Remove(inner) => inner.registry_string(),
-		}
-	}
-}
-
-impl EventProperties for CacheEvents {
-	fn path(&self) -> ObjectPath<'_> {
-		match self {
-			Self::Add(inner) => inner.path(),
-			Self::LegacyAdd(inner) => inner.path(),
-			Self::Remove(inner) => inner.path(),
-		}
-	}
-	fn sender(&self) -> UniqueName<'_> {
-		match self {
-			Self::Add(inner) => inner.sender(),
-			Self::LegacyAdd(inner) => inner.sender(),
-			Self::Remove(inner) => inner.sender(),
-		}
-	}
-}
-
-impl HasInterfaceName for CacheEvents {
-	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Cache";
-}
-
-#[cfg(feature = "zbus")]
-impl EventWrapperMessageConversion for CacheEvents {
-	fn try_from_message_interface_checked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let header = msg.header();
-		let member = header.member().ok_or(AtspiError::MissingMember)?;
-		match member.as_str() {
-			"AddAccessible" => {
-				let body = msg.body();
-				let sig = body.signature().ok_or(AtspiError::MissingSignature)?;
-				match sig.as_str() {
-					"(so)(so)(so)iiassusau" => {
-						Ok(CacheEvents::Add(AddAccessibleEvent::try_from_message_unchecked(msg)?))
-					}
-					"(so)(so)(so)a(so)assusau" => Ok(CacheEvents::LegacyAdd(
-						LegacyAddAccessibleEvent::try_from_message_unchecked(msg)?,
-					)),
-					_ => Err(AtspiError::SignatureMatch(format!(
-						"No matching event for signature {} in interface {}",
-						sig.as_str(),
-						Self::DBUS_INTERFACE
-					))),
-				}
-			}
-			"RemoveAccessible" => {
-				Ok(CacheEvents::Remove(RemoveAccessibleEvent::try_from_message_unchecked(msg)?))
-			}
-			_ => Err(AtspiError::MemberMatch(format!(
-				"No member {} in {}",
-				member.as_str(),
-				Self::DBUS_INTERFACE
-			))),
-		}
-	}
-}
-
-#[cfg(feature = "zbus")]
-impl TryFrom<&zbus::Message> for CacheEvents {
-	type Error = AtspiError;
-	fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
-		let header = msg.header();
-		let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
-		if interface != CacheEvents::DBUS_INTERFACE {
-			return Err(AtspiError::InterfaceMatch(format!(
-				"Interface {} does not match require interface for event: {}",
-				interface,
-				CacheEvents::DBUS_INTERFACE
-			)));
-		}
-		CacheEvents::try_from_message_interface_checked(msg)
-	}
-}
-
-/// Type that contains the `zbus::Message` for meta information and
-/// the [`crate::cache::LegacyCacheItem`]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, Eq, Hash)]
-pub struct LegacyAddAccessibleEvent {
-	/// The [`ObjectRef`] the event applies to.
-	pub item: ObjectRef,
-	/// A cache item to add to the internal cache.
-	pub node_added: LegacyCacheItem,
-}
-
-impl_from_user_facing_event_for_interface_event_enum!(
-	LegacyAddAccessibleEvent,
-	CacheEvents,
-	CacheEvents::LegacyAdd
-);
-impl_from_user_facing_type_for_event_enum!(LegacyAddAccessibleEvent, Event::Cache);
-impl_try_from_event_for_user_facing_type!(
-	LegacyAddAccessibleEvent,
-	CacheEvents::LegacyAdd,
-	Event::Cache
-);
-event_test_cases!(LegacyAddAccessibleEvent, Explicit);
-impl_from_dbus_message!(LegacyAddAccessibleEvent, Explicit);
-impl_event_properties!(LegacyAddAccessibleEvent);
-impl_to_dbus_message!(LegacyAddAccessibleEvent);
-
-impl BusProperties for LegacyAddAccessibleEvent {
-	const REGISTRY_EVENT_STRING: &'static str = "Cache:Add";
-	const MATCH_RULE_STRING: &'static str =
-		"type='signal',interface='org.a11y.atspi.Cache',member='AddAccessible'";
-	const DBUS_MEMBER: &'static str = "AddAccessible";
-	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Cache";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for LegacyAddAccessibleEvent {
-	type Body = LegacyCacheItem;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		let body = msg.body();
-		Ok(Self { item, node_added: body.deserialize_unchecked()? })
-	}
-
-	fn body(&self) -> Self::Body {
-		self.node_added.clone()
-	}
 }
 
 #[cfg(feature = "zbus")]
@@ -507,47 +330,6 @@ where
 	}
 }
 
-/// Type that contains the `zbus::Message` for meta information and
-/// the [`crate::cache::CacheItem`]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, Eq, Hash)]
-pub struct AddAccessibleEvent {
-	/// The [`ObjectRef`] the event applies to.
-	pub item: ObjectRef,
-	/// A cache item to add to the internal cache.
-	pub node_added: CacheItem,
-}
-
-impl_from_user_facing_event_for_interface_event_enum!(
-	AddAccessibleEvent,
-	CacheEvents,
-	CacheEvents::Add
-);
-impl_from_user_facing_type_for_event_enum!(AddAccessibleEvent, Event::Cache);
-impl_try_from_event_for_user_facing_type!(AddAccessibleEvent, CacheEvents::Add, Event::Cache);
-event_test_cases!(AddAccessibleEvent, Explicit);
-
-impl BusProperties for AddAccessibleEvent {
-	const REGISTRY_EVENT_STRING: &'static str = "Cache:Add";
-	const MATCH_RULE_STRING: &'static str =
-		"type='signal',interface='org.a11y.atspi.Cache',member='AddAccessible'";
-	const DBUS_MEMBER: &'static str = "AddAccessible";
-	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Cache";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for AddAccessibleEvent {
-	type Body = CacheItem;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		let body = msg.body();
-		Ok(Self { item, node_added: body.deserialize_unchecked()? })
-	}
-
-	fn body(&self) -> Self::Body {
-		self.node_added.clone()
-	}
-}
 impl<T: BusProperties> HasMatchRule for T {
 	const MATCH_RULE_STRING: &'static str = <T as BusProperties>::MATCH_RULE_STRING;
 }
@@ -557,53 +339,6 @@ impl<T: BusProperties> HasRegistryEventString for T {
 impl<T: BusProperties> HasInterfaceName for T {
 	const DBUS_INTERFACE: &'static str = <T as BusProperties>::DBUS_INTERFACE;
 }
-impl_from_dbus_message!(AddAccessibleEvent);
-impl_event_properties!(AddAccessibleEvent);
-impl_to_dbus_message!(AddAccessibleEvent);
-
-/// `Cache::RemoveAccessible` signal event type.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, Eq, Hash)]
-pub struct RemoveAccessibleEvent {
-	/// The application that emitted the signal TODO Check Me
-	/// The [`ObjectRef`] the event applies to.
-	pub item: ObjectRef,
-	/// The node that was removed from the application tree  TODO Check Me
-	pub node_removed: ObjectRef,
-}
-
-impl_from_user_facing_event_for_interface_event_enum!(
-	RemoveAccessibleEvent,
-	CacheEvents,
-	CacheEvents::Remove
-);
-impl_from_user_facing_type_for_event_enum!(RemoveAccessibleEvent, Event::Cache);
-impl_try_from_event_for_user_facing_type!(RemoveAccessibleEvent, CacheEvents::Remove, Event::Cache);
-event_test_cases!(RemoveAccessibleEvent, Explicit);
-impl BusProperties for RemoveAccessibleEvent {
-	const REGISTRY_EVENT_STRING: &'static str = "Cache:Remove";
-	const MATCH_RULE_STRING: &'static str =
-		"type='signal',interface='org.a11y.atspi.Cache',member='RemoveAccessible'";
-	const DBUS_MEMBER: &'static str = "RemoveAccessible";
-	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Cache";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for RemoveAccessibleEvent {
-	type Body = ObjectRef;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		let body = msg.body();
-		Ok(Self { item, node_removed: body.deserialize_unchecked()? })
-	}
-	fn body(&self) -> Self::Body {
-		self.node_removed.clone()
-	}
-}
-
-impl_from_dbus_message!(RemoveAccessibleEvent, Explicit);
-impl_event_properties!(RemoveAccessibleEvent);
-impl_to_dbus_message!(RemoveAccessibleEvent);
 
 #[cfg(test)]
 mod accessible_deserialization_tests {

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -321,13 +321,13 @@ where
 	T: BusProperties,
 {
 	type Body = EventBodyOwned;
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		obj_ref: ObjectRef,
 		_: Self::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(obj_ref.into())
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item: ObjectRef = msg.try_into()?;
 		Ok(item.into())
 	}
@@ -505,10 +505,10 @@ impl EventWrapperMessageConversion for EventListenerEvents {
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
 			EventListenerRegisteredEvent::DBUS_MEMBER => Ok(EventListenerEvents::Registered(
-				EventListenerRegisteredEvent::try_from_validated_message(msg)?,
+				EventListenerRegisteredEvent::from_message_unchecked(msg)?,
 			)),
 			EventListenerDeregisteredEvent::DBUS_MEMBER => Ok(EventListenerEvents::Deregistered(
-				EventListenerDeregisteredEvent::try_from_validated_message(msg)?,
+				EventListenerDeregisteredEvent::from_message_unchecked(msg)?,
 			)),
 			_ => Err(AtspiError::MemberMatch(format!(
 				"No member {} in {}",
@@ -562,16 +562,16 @@ impl BusProperties for EventListenerDeregisteredEvent {
 impl MessageConversion for EventListenerDeregisteredEvent {
 	type Body = EventListeners;
 
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		item: ObjectRef,
 		deregistered_event: Self::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item, deregistered_event })
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body().deserialize()?;
-		Self::try_from_validated_message_parts(item, body)
+		Self::from_message_unchecked_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		self.deregistered_event.clone()
@@ -615,16 +615,16 @@ impl BusProperties for EventListenerRegisteredEvent {
 impl MessageConversion for EventListenerRegisteredEvent {
 	type Body = EventListeners;
 
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		item: ObjectRef,
 		registered_event: Self::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item, registered_event })
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body().deserialize()?;
-		Self::try_from_validated_message_parts(item, body)
+		Self::from_message_unchecked_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		self.registered_event.clone()
@@ -669,16 +669,16 @@ impl BusProperties for AvailableEvent {
 impl MessageConversion for AvailableEvent {
 	type Body = ObjectRef;
 
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		item: ObjectRef,
 		socket: Self::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item, socket })
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body().deserialize()?;
-		Self::try_from_validated_message_parts(item, body)
+		Self::from_message_unchecked_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		self.socket.clone()
@@ -842,7 +842,7 @@ pub trait MessageConversion: BusProperties {
 	///
 	/// It is possible to get a [`type@AtspiError::Zvariant`] error if you do not check the proper
 	/// conditions before calling this.
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError>
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError>
 	where
 		Self: Sized;
 
@@ -860,7 +860,7 @@ pub trait MessageConversion: BusProperties {
 	///
 	/// Some [`Self::Body`] types may fallibly convert data fields contained in the body.
 	/// If this happens, then the function will return an error.
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		obj_ref: ObjectRef,
 		body: Self::Body,
 	) -> Result<Self, AtspiError>
@@ -879,7 +879,7 @@ where
 		<T as MessageConversionExt<crate::LegacyCacheItem>>::validate_interface(msg)?;
 		<T as MessageConversionExt<crate::LegacyCacheItem>>::validate_member(msg)?;
 		<T as MessageConversionExt<crate::LegacyCacheItem>>::validate_body(msg)?;
-		<T as MessageConversion>::try_from_validated_message(msg)
+		<T as MessageConversion>::from_message_unchecked(msg)
 	}
 }
 
@@ -891,7 +891,7 @@ where
 		<T as MessageConversionExt<EventListeners>>::validate_interface(msg)?;
 		<T as MessageConversionExt<EventListeners>>::validate_member(msg)?;
 		<T as MessageConversionExt<EventListeners>>::validate_body(msg)?;
-		<T as MessageConversion>::try_from_validated_message(msg)
+		<T as MessageConversion>::from_message_unchecked(msg)
 	}
 }
 
@@ -903,7 +903,7 @@ where
 		<T as MessageConversionExt<crate::CacheItem>>::validate_interface(msg)?;
 		<T as MessageConversionExt<crate::CacheItem>>::validate_member(msg)?;
 		<T as MessageConversionExt<crate::CacheItem>>::validate_body(msg)?;
-		<T as MessageConversion>::try_from_validated_message(msg)
+		<T as MessageConversion>::from_message_unchecked(msg)
 	}
 }
 
@@ -915,7 +915,7 @@ where
 		<T as MessageConversionExt<ObjectRef>>::validate_interface(msg)?;
 		<T as MessageConversionExt<ObjectRef>>::validate_member(msg)?;
 		<T as MessageConversionExt<ObjectRef>>::validate_body(msg)?;
-		<T as MessageConversion>::try_from_validated_message(msg)
+		<T as MessageConversion>::from_message_unchecked(msg)
 	}
 }
 
@@ -942,7 +942,7 @@ where
 			)));
 		};
 		let item = msg.try_into()?;
-		Self::try_from_validated_message_parts(item, data_body)
+		Self::from_message_unchecked_parts(item, data_body)
 	}
 }
 
@@ -962,7 +962,7 @@ where
 	/// - The message does not have an signature: [`type@AtspiError::MissingSignature`]
 	/// - The message signature does not match the one for the event: [`type@AtspiError::SignatureMatch`]
 	///
-	/// See [`MessageConversion::try_from_validated_message`] for info on panic condition that should never
+	/// See [`MessageConversion::from_message_unchecked`] for info on panic condition that should never
 	/// happen.
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError>
 	where

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -831,8 +831,9 @@ pub trait MessageConversion: BusProperties {
 	/// - That the message signature matches the one for the event: [`type@AtspiError::SignatureMatch`]
 	///
 	/// Therefore, this should only be used when one has checked the above conditions.
-	/// These can be checked manually, or you can use the convience function provided by this trait:
-	/// [`Self::try_from_message`] which does these checks for you.
+	/// These must be checked manually.
+  /// Alternatively, there is the [`MessageConversionExt::try_from_message`] that will check these
+  /// conditions for you.
 	///
 	/// This type also implements `TryFrom<&zbus::Message>`; consider using this if you are not an
 	/// internal developer.
@@ -961,7 +962,7 @@ where
 	/// - The message does not have an signature: [`type@AtspiError::MissingSignature`]
 	/// - The message signature does not match the one for the event: [`type@AtspiError::SignatureMatch`]
 	///
-	/// See [`Self::try_from_validated_message`] for info on panic condition that should never
+	/// See [`MessageConversion::try_from_validated_message`] for info on panic condition that should never
 	/// happen.
 	fn try_from_message(msg: &zbus::Message) -> Result<Self, AtspiError>
 	where
@@ -1003,7 +1004,7 @@ where
 		}
 		Ok(())
 	}
-	/// Validate the body signature against the [`zvariant::Signature`] of [`Self::Body`]
+	/// Validate the body signature against the [`zvariant::Signature`] of [`MessageConversion::Body`]
 	///
 	/// # Errors
 	///

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -868,6 +868,7 @@ pub trait MessageConversion: BusProperties {
 	fn body(&self) -> Self::Body;
 }
 
+#[cfg(feature = "zbus")]
 impl<T> MessageConversionExt<crate::LegacyCacheItem> for T
 where
 	T: MessageConversion<Body = crate::LegacyCacheItem>,
@@ -880,6 +881,7 @@ where
 	}
 }
 
+#[cfg(feature = "zbus")]
 impl<T> MessageConversionExt<EventListeners> for T
 where
 	T: MessageConversion<Body = EventListeners>,
@@ -892,6 +894,7 @@ where
 	}
 }
 
+#[cfg(feature = "zbus")]
 impl<T> MessageConversionExt<crate::CacheItem> for T
 where
 	T: MessageConversion<Body = crate::CacheItem>,
@@ -904,6 +907,7 @@ where
 	}
 }
 
+#[cfg(feature = "zbus")]
 impl<T> MessageConversionExt<ObjectRef> for T
 where
 	T: MessageConversion<Body = ObjectRef>,
@@ -916,6 +920,7 @@ where
 	}
 }
 
+#[cfg(feature = "zbus")]
 impl<T> MessageConversionExt<EventBodyOwned> for T
 where
 	T: MessageConversion<Body = EventBodyOwned>,
@@ -943,6 +948,7 @@ where
 	}
 }
 
+#[cfg(feature = "zbus")]
 pub trait MessageConversionExt<B>: MessageConversion<Body = B>
 where
 	B: Type + Serialize + for<'a> Deserialize<'a>,

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -321,7 +321,7 @@ where
 	T: BusProperties,
 {
 	type Body = EventBodyOwned;
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item: ObjectRef = msg.try_into()?;
 		Ok(item.into())
 	}
@@ -499,10 +499,10 @@ impl EventWrapperMessageConversion for EventListenerEvents {
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
 			EventListenerRegisteredEvent::DBUS_MEMBER => Ok(EventListenerEvents::Registered(
-				EventListenerRegisteredEvent::try_from_message_unchecked(msg)?,
+				EventListenerRegisteredEvent::try_from_validated_message(msg)?,
 			)),
 			EventListenerDeregisteredEvent::DBUS_MEMBER => Ok(EventListenerEvents::Deregistered(
-				EventListenerDeregisteredEvent::try_from_message_unchecked(msg)?,
+				EventListenerDeregisteredEvent::try_from_validated_message(msg)?,
 			)),
 			_ => Err(AtspiError::MemberMatch(format!(
 				"No member {} in {}",
@@ -556,7 +556,7 @@ impl BusProperties for EventListenerDeregisteredEvent {
 impl MessageConversion for EventListenerDeregisteredEvent {
 	type Body = EventListeners;
 
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		Ok(Self { item, deregistered_event: body.deserialize_unchecked()? })
@@ -603,7 +603,7 @@ impl BusProperties for EventListenerRegisteredEvent {
 impl MessageConversion for EventListenerRegisteredEvent {
 	type Body = EventListeners;
 
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		Ok(Self { item, registered_event: body.deserialize_unchecked()? })
@@ -651,7 +651,7 @@ impl BusProperties for AvailableEvent {
 impl MessageConversion for AvailableEvent {
 	type Body = ObjectRef;
 
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		Ok(Self { item, socket: body.deserialize_unchecked()? })
@@ -805,7 +805,7 @@ pub trait MessageConversion {
 	/// Technically, it may also panic if you are accepting file descriptors over the
 	/// [`enum@zvariant::Value`] variant, and you are out of file descriptors for the process.
 	/// This is considered exceptionally rare and should never happen.
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError>
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError>
 	where
 		Self: Sized;
 

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -903,7 +903,7 @@ impl TryFrom<&zbus::Message> for Event {
 				Ok(RemoveAccessibleEvent::try_from(msg)?.into())
 			}
 			(_iface, _method, sig) => {
-				Err(AtspiError::SignatureMatch(format!("No events found with signature {}", sig)))
+				Err(AtspiError::SignatureMatch(format!("No events found with signature {sig}")))
 			}
 		}
 	}

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -1,10 +1,9 @@
 #[cfg(feature = "zbus")]
-use crate::events::MessageConversion;
+use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage};
 use crate::{
 	error::AtspiError,
 	events::{
-		BusProperties, EventBodyOwned, EventWrapperMessageConversion, HasInterfaceName,
-		HasMatchRule, HasRegistryEventString, TryFromMessage,
+		BusProperties, EventBodyOwned, HasInterfaceName, HasMatchRule, HasRegistryEventString,
 	},
 	Event, EventProperties, EventTypeProperties,
 };

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -112,8 +112,12 @@ impl BusProperties for AbsEvent {
 impl MessageConversion for AbsEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item, x: body.detail1, y: body.detail2 })
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError> {
+		let ev_body: Self::Body = body.deserialize_unchecked()?;
+		Ok(Self { item, x: ev_body.detail1, y: ev_body.detail2 })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -133,8 +137,12 @@ impl BusProperties for RelEvent {
 impl MessageConversion for RelEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item, x: body.detail1, y: body.detail2 })
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError> {
+		let ev_body: Self::Body = body.deserialize_unchecked()?;
+		Ok(Self { item, x: ev_body.detail1, y: ev_body.detail2 })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -154,8 +162,12 @@ impl BusProperties for ButtonEvent {
 impl MessageConversion for ButtonEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item, detail: body.kind, mouse_x: body.detail1, mouse_y: body.detail2 })
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError> {
+		let ev_body: Self::Body = body.deserialize_unchecked()?;
+		Ok(Self { item, detail: ev_body.kind, mouse_x: ev_body.detail1, mouse_y: ev_body.detail2 })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -4,7 +4,7 @@ use crate::{
 	error::AtspiError,
 	events::{
 		BusProperties, EventBodyOwned, EventWrapperMessageConversion, HasInterfaceName,
-		HasMatchRule, HasRegistryEventString,
+		HasMatchRule, HasRegistryEventString, TryFromMessage,
 	},
 	Event, EventProperties, EventTypeProperties,
 };
@@ -196,16 +196,7 @@ impl EventWrapperMessageConversion for MouseEvents {
 impl TryFrom<&zbus::Message> for MouseEvents {
 	type Error = AtspiError;
 	fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
-		let header = msg.header();
-		let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
-		if interface != MouseEvents::DBUS_INTERFACE {
-			return Err(AtspiError::InterfaceMatch(format!(
-				"Interface {} does not match required interface for event: {}",
-				interface,
-				MouseEvents::DBUS_INTERFACE
-			)));
-		}
-		Self::try_from_message_interface_checked(msg)
+		Self::try_from_message(msg)
 	}
 }
 

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -119,10 +119,7 @@ impl BusProperties for AbsEvent {
 impl MessageConversion for AbsEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_unchecked_parts(
-		item: ObjectRef,
-		body: Self::Body,
-	) -> Result<Self, AtspiError> {
+	fn from_message_unchecked_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, x: body.detail1, y: body.detail2 })
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
@@ -149,10 +146,7 @@ impl BusProperties for RelEvent {
 impl MessageConversion for RelEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_unchecked_parts(
-		item: ObjectRef,
-		body: Self::Body,
-	) -> Result<Self, AtspiError> {
+	fn from_message_unchecked_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, x: body.detail1, y: body.detail2 })
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
@@ -179,10 +173,7 @@ impl BusProperties for ButtonEvent {
 impl MessageConversion for ButtonEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_unchecked_parts(
-		item: ObjectRef,
-		body: Self::Body,
-	) -> Result<Self, AtspiError> {
+	fn from_message_unchecked_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, detail: body.kind, mouse_x: body.detail1, mouse_y: body.detail2 })
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
@@ -206,12 +197,8 @@ impl EventWrapperMessageConversion for MouseEvents {
 		let header = msg.header();
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
-			AbsEvent::DBUS_MEMBER => {
-				Ok(MouseEvents::Abs(AbsEvent::from_message_unchecked(msg)?))
-			}
-			RelEvent::DBUS_MEMBER => {
-				Ok(MouseEvents::Rel(RelEvent::from_message_unchecked(msg)?))
-			}
+			AbsEvent::DBUS_MEMBER => Ok(MouseEvents::Abs(AbsEvent::from_message_unchecked(msg)?)),
+			RelEvent::DBUS_MEMBER => Ok(MouseEvents::Rel(RelEvent::from_message_unchecked(msg)?)),
 			ButtonEvent::DBUS_MEMBER => {
 				Ok(MouseEvents::Button(ButtonEvent::from_message_unchecked(msg)?))
 			}

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -1,6 +1,9 @@
 use crate::{
 	error::AtspiError,
-	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, ObjectRef},
+	events::{
+		BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, MessageConversion,
+		ObjectRef,
+	},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;
@@ -104,10 +107,12 @@ impl BusProperties for AbsEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Mouse',member='Abs'";
 	const REGISTRY_EVENT_STRING: &'static str = "Mouse:";
+}
 
+impl MessageConversion for AbsEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, x: body.detail1, y: body.detail2 })
 	}
 	fn body(&self) -> Self::Body {
@@ -122,10 +127,12 @@ impl BusProperties for RelEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Mouse',member='Rel'";
 	const REGISTRY_EVENT_STRING: &'static str = "Mouse:";
+}
 
+impl MessageConversion for RelEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, x: body.detail1, y: body.detail2 })
 	}
 	fn body(&self) -> Self::Body {
@@ -140,10 +147,12 @@ impl BusProperties for ButtonEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Mouse',member='Button'";
 	const REGISTRY_EVENT_STRING: &'static str = "Mouse:";
+}
 
+impl MessageConversion for ButtonEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, detail: body.kind, mouse_x: body.detail1, mouse_y: body.detail2 })
 	}
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -7,7 +7,9 @@ use crate::{
 };
 #[cfg(feature = "zbus")]
 use crate::{
-	events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage, MessageConversionExt},
+	events::{
+		EventWrapperMessageConversion, MessageConversion, MessageConversionExt, TryFromMessage,
+	},
 	ObjectRef,
 };
 use zbus_names::UniqueName;

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -1,11 +1,14 @@
-#[cfg(feature = "zbus")]
-use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage};
 use crate::{
 	error::AtspiError,
 	events::{
 		BusProperties, EventBodyOwned, HasInterfaceName, HasMatchRule, HasRegistryEventString,
 	},
 	Event, EventProperties, EventTypeProperties,
+};
+#[cfg(feature = "zbus")]
+use crate::{
+	events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage},
+	ObjectRef,
 };
 use zbus_names::UniqueName;
 use zvariant::ObjectPath;
@@ -114,11 +117,17 @@ impl BusProperties for AbsEvent {
 impl MessageConversion for AbsEvent {
 	type Body = EventBodyOwned;
 
+	fn try_from_validated_message_parts(
+		item: ObjectRef,
+		body: Self::Body,
+	) -> Result<Self, AtspiError> {
+		Ok(Self { item, x: body.detail1, y: body.detail2 })
+	}
 	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
-		let ev_body: Self::Body = body.deserialize_unchecked()?;
-		Ok(Self { item, x: ev_body.detail1, y: ev_body.detail2 })
+		let body: Self::Body = body.deserialize_unchecked()?;
+		Self::try_from_validated_message_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -138,11 +147,17 @@ impl BusProperties for RelEvent {
 impl MessageConversion for RelEvent {
 	type Body = EventBodyOwned;
 
+	fn try_from_validated_message_parts(
+		item: ObjectRef,
+		body: Self::Body,
+	) -> Result<Self, AtspiError> {
+		Ok(Self { item, x: body.detail1, y: body.detail2 })
+	}
 	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
-		let ev_body: Self::Body = body.deserialize_unchecked()?;
-		Ok(Self { item, x: ev_body.detail1, y: ev_body.detail2 })
+		let body: Self::Body = body.deserialize_unchecked()?;
+		Self::try_from_validated_message_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -162,11 +177,17 @@ impl BusProperties for ButtonEvent {
 impl MessageConversion for ButtonEvent {
 	type Body = EventBodyOwned;
 
+	fn try_from_validated_message_parts(
+		item: ObjectRef,
+		body: Self::Body,
+	) -> Result<Self, AtspiError> {
+		Ok(Self { item, detail: body.kind, mouse_x: body.detail1, mouse_y: body.detail2 })
+	}
 	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
-		let ev_body: Self::Body = body.deserialize_unchecked()?;
-		Ok(Self { item, detail: ev_body.kind, mouse_x: ev_body.detail1, mouse_y: ev_body.detail2 })
+		let body: Self::Body = body.deserialize_unchecked()?;
+		Self::try_from_validated_message_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "zbus")]
-use crate::events::{MessageConversion, ObjectRef};
+use crate::events::MessageConversion;
 use crate::{
 	error::AtspiError,
 	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString},
@@ -77,7 +77,7 @@ impl HasMatchRule for MouseEvents {
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct AbsEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 	pub x: i32,
 	pub y: i32,
@@ -85,7 +85,7 @@ pub struct AbsEvent {
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct RelEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 	pub x: i32,
 	pub y: i32,
@@ -93,7 +93,7 @@ pub struct RelEvent {
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct ButtonEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 	pub detail: String,
 	pub mouse_x: i32,

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -183,9 +183,15 @@ impl EventWrapperMessageConversion for MouseEvents {
 		let header = msg.header();
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
-			"Abs" => Ok(MouseEvents::Abs(AbsEvent::try_from_message_unchecked(msg)?)),
-			"Rel" => Ok(MouseEvents::Rel(RelEvent::try_from_message_unchecked(msg)?)),
-			"Button" => Ok(MouseEvents::Button(ButtonEvent::try_from_message_unchecked(msg)?)),
+			AbsEvent::DBUS_MEMBER => {
+				Ok(MouseEvents::Abs(AbsEvent::try_from_message_unchecked(msg)?))
+			}
+			RelEvent::DBUS_MEMBER => {
+				Ok(MouseEvents::Rel(RelEvent::try_from_message_unchecked(msg)?))
+			}
+			ButtonEvent::DBUS_MEMBER => {
+				Ok(MouseEvents::Button(ButtonEvent::try_from_message_unchecked(msg)?))
+			}
 			_ => Err(AtspiError::MemberMatch("No matching member for Mouse".into())),
 		}
 	}

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -1,9 +1,8 @@
+#[cfg(feature = "zbus")]
+use crate::events::{MessageConversion, ObjectRef};
 use crate::{
 	error::AtspiError,
-	events::{
-		BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, MessageConversion,
-		ObjectRef,
-	},
+	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;
@@ -109,6 +108,7 @@ impl BusProperties for AbsEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Mouse:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for AbsEvent {
 	type Body = EventBodyOwned;
 
@@ -129,6 +129,7 @@ impl BusProperties for RelEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Mouse:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for RelEvent {
 	type Body = EventBodyOwned;
 
@@ -149,6 +150,7 @@ impl BusProperties for ButtonEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Mouse:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for ButtonEvent {
 	type Body = EventBodyOwned;
 

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -119,17 +119,17 @@ impl BusProperties for AbsEvent {
 impl MessageConversion for AbsEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		item: ObjectRef,
 		body: Self::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item, x: body.detail1, y: body.detail2 })
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		let body: Self::Body = body.deserialize_unchecked()?;
-		Self::try_from_validated_message_parts(item, body)
+		Self::from_message_unchecked_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -149,17 +149,17 @@ impl BusProperties for RelEvent {
 impl MessageConversion for RelEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		item: ObjectRef,
 		body: Self::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item, x: body.detail1, y: body.detail2 })
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		let body: Self::Body = body.deserialize_unchecked()?;
-		Self::try_from_validated_message_parts(item, body)
+		Self::from_message_unchecked_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -179,17 +179,17 @@ impl BusProperties for ButtonEvent {
 impl MessageConversion for ButtonEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		item: ObjectRef,
 		body: Self::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item, detail: body.kind, mouse_x: body.detail1, mouse_y: body.detail2 })
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		let body: Self::Body = body.deserialize_unchecked()?;
-		Self::try_from_validated_message_parts(item, body)
+		Self::from_message_unchecked_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -207,13 +207,13 @@ impl EventWrapperMessageConversion for MouseEvents {
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
 			AbsEvent::DBUS_MEMBER => {
-				Ok(MouseEvents::Abs(AbsEvent::try_from_validated_message(msg)?))
+				Ok(MouseEvents::Abs(AbsEvent::from_message_unchecked(msg)?))
 			}
 			RelEvent::DBUS_MEMBER => {
-				Ok(MouseEvents::Rel(RelEvent::try_from_validated_message(msg)?))
+				Ok(MouseEvents::Rel(RelEvent::from_message_unchecked(msg)?))
 			}
 			ButtonEvent::DBUS_MEMBER => {
-				Ok(MouseEvents::Button(ButtonEvent::try_from_validated_message(msg)?))
+				Ok(MouseEvents::Button(ButtonEvent::from_message_unchecked(msg)?))
 			}
 			_ => Err(AtspiError::MemberMatch("No matching member for Mouse".into())),
 		}

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -112,10 +112,9 @@ impl BusProperties for AbsEvent {
 impl MessageConversion for AbsEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
 		let ev_body: Self::Body = body.deserialize_unchecked()?;
 		Ok(Self { item, x: ev_body.detail1, y: ev_body.detail2 })
 	}
@@ -137,10 +136,9 @@ impl BusProperties for RelEvent {
 impl MessageConversion for RelEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
 		let ev_body: Self::Body = body.deserialize_unchecked()?;
 		Ok(Self { item, x: ev_body.detail1, y: ev_body.detail2 })
 	}
@@ -162,10 +160,9 @@ impl BusProperties for ButtonEvent {
 impl MessageConversion for ButtonEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
 		let ev_body: Self::Body = body.deserialize_unchecked()?;
 		Ok(Self { item, detail: ev_body.kind, mouse_x: ev_body.detail1, mouse_y: ev_body.detail2 })
 	}

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -114,7 +114,7 @@ impl BusProperties for AbsEvent {
 impl MessageConversion for AbsEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		let ev_body: Self::Body = body.deserialize_unchecked()?;
@@ -138,7 +138,7 @@ impl BusProperties for RelEvent {
 impl MessageConversion for RelEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		let ev_body: Self::Body = body.deserialize_unchecked()?;
@@ -162,7 +162,7 @@ impl BusProperties for ButtonEvent {
 impl MessageConversion for ButtonEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		let ev_body: Self::Body = body.deserialize_unchecked()?;
@@ -184,13 +184,13 @@ impl EventWrapperMessageConversion for MouseEvents {
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
 			AbsEvent::DBUS_MEMBER => {
-				Ok(MouseEvents::Abs(AbsEvent::try_from_message_unchecked(msg)?))
+				Ok(MouseEvents::Abs(AbsEvent::try_from_validated_message(msg)?))
 			}
 			RelEvent::DBUS_MEMBER => {
-				Ok(MouseEvents::Rel(RelEvent::try_from_message_unchecked(msg)?))
+				Ok(MouseEvents::Rel(RelEvent::try_from_validated_message(msg)?))
 			}
 			ButtonEvent::DBUS_MEMBER => {
-				Ok(MouseEvents::Button(ButtonEvent::try_from_message_unchecked(msg)?))
+				Ok(MouseEvents::Button(ButtonEvent::try_from_validated_message(msg)?))
 			}
 			_ => Err(AtspiError::MemberMatch("No matching member for Mouse".into())),
 		}

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 #[cfg(feature = "zbus")]
 use crate::{
-	events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage},
+	events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage, MessageConversionExt},
 	ObjectRef,
 };
 use zbus_names::UniqueName;

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -112,7 +112,7 @@ impl BusProperties for AbsEvent {
 impl MessageConversion for AbsEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -137,7 +137,7 @@ impl BusProperties for RelEvent {
 impl MessageConversion for RelEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -162,7 +162,7 @@ impl BusProperties for ButtonEvent {
 impl MessageConversion for ButtonEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -1,11 +1,10 @@
 use std::hash::Hash;
 
+#[cfg(feature = "zbus")]
+use crate::events::MessageConversion;
 use crate::{
 	error::AtspiError,
-	events::{
-		BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, MessageConversion,
-		ObjectRef,
-	},
+	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, ObjectRef},
 	Event, EventProperties, EventTypeProperties, State,
 };
 use zbus_names::UniqueName;
@@ -601,6 +600,7 @@ impl BusProperties for PropertyChangeEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for PropertyChangeEvent {
 	type Body = EventBodyOwned;
 
@@ -623,6 +623,7 @@ impl BusProperties for BoundsChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for BoundsChangedEvent {
 	type Body = EventBodyOwned;
 
@@ -646,6 +647,7 @@ impl BusProperties for LinkSelectedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for LinkSelectedEvent {
 	type Body = EventBodyOwned;
 
@@ -669,6 +671,7 @@ impl BusProperties for StateChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for StateChangedEvent {
 	type Body = EventBodyOwned;
 
@@ -689,6 +692,7 @@ impl BusProperties for ChildrenChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for ChildrenChangedEvent {
 	type Body = EventBodyOwned;
 
@@ -714,6 +718,7 @@ impl BusProperties for VisibleDataChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for VisibleDataChangedEvent {
 	type Body = EventBodyOwned;
 
@@ -737,6 +742,7 @@ impl BusProperties for SelectionChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for SelectionChangedEvent {
 	type Body = EventBodyOwned;
 
@@ -760,6 +766,7 @@ impl BusProperties for ModelChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for ModelChangedEvent {
 	type Body = EventBodyOwned;
 
@@ -783,6 +790,7 @@ impl BusProperties for ActiveDescendantChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for ActiveDescendantChangedEvent {
 	type Body = EventBodyOwned;
 
@@ -803,6 +811,7 @@ impl BusProperties for AnnouncementEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for AnnouncementEvent {
 	type Body = EventBodyOwned;
 
@@ -827,6 +836,7 @@ impl BusProperties for AttributesChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for AttributesChangedEvent {
 	type Body = EventBodyOwned;
 
@@ -850,6 +860,7 @@ impl BusProperties for RowInsertedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for RowInsertedEvent {
 	type Body = EventBodyOwned;
 
@@ -873,6 +884,7 @@ impl BusProperties for RowReorderedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for RowReorderedEvent {
 	type Body = EventBodyOwned;
 
@@ -896,6 +908,7 @@ impl BusProperties for RowDeletedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for RowDeletedEvent {
 	type Body = EventBodyOwned;
 
@@ -919,6 +932,7 @@ impl BusProperties for ColumnInsertedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for ColumnInsertedEvent {
 	type Body = EventBodyOwned;
 
@@ -942,6 +956,7 @@ impl BusProperties for ColumnReorderedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for ColumnReorderedEvent {
 	type Body = EventBodyOwned;
 
@@ -965,6 +980,7 @@ impl BusProperties for ColumnDeletedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for ColumnDeletedEvent {
 	type Body = EventBodyOwned;
 
@@ -988,6 +1004,7 @@ impl BusProperties for TextBoundsChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for TextBoundsChangedEvent {
 	type Body = EventBodyOwned;
 
@@ -1011,6 +1028,7 @@ impl BusProperties for TextSelectionChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for TextSelectionChangedEvent {
 	type Body = EventBodyOwned;
 
@@ -1034,6 +1052,7 @@ impl BusProperties for TextChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for TextChangedEvent {
 	type Body = EventBodyOwned;
 
@@ -1060,6 +1079,7 @@ impl BusProperties for TextAttributesChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for TextAttributesChangedEvent {
 	type Body = EventBodyOwned;
 
@@ -1083,6 +1103,7 @@ impl BusProperties for TextCaretMovedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for TextCaretMovedEvent {
 	type Body = EventBodyOwned;
 

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -607,7 +607,7 @@ impl BusProperties for PropertyChangeEvent {
 impl MessageConversion for PropertyChangeEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		let ev_body: Self::Body = body.deserialize_unchecked()?;
@@ -649,7 +649,7 @@ impl BusProperties for StateChangedEvent {
 impl MessageConversion for StateChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		let ev_body: Self::Body = body.deserialize_unchecked()?;
@@ -673,7 +673,7 @@ impl BusProperties for ChildrenChangedEvent {
 impl MessageConversion for ChildrenChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		let ev_body: Self::Body = body.deserialize_unchecked()?;
@@ -726,7 +726,7 @@ impl BusProperties for ActiveDescendantChangedEvent {
 impl MessageConversion for ActiveDescendantChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		Ok(Self { item, child: body.deserialize_unchecked::<Self::Body>()?.any_data.try_into()? })
@@ -749,7 +749,7 @@ impl BusProperties for AnnouncementEvent {
 impl MessageConversion for AnnouncementEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		let ev_body: Self::Body = body.deserialize_unchecked()?;
@@ -852,7 +852,7 @@ impl BusProperties for TextChangedEvent {
 impl MessageConversion for TextChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		let ev_body: Self::Body = body.deserialize_unchecked()?;
@@ -890,7 +890,7 @@ impl BusProperties for TextCaretMovedEvent {
 impl MessageConversion for TextCaretMovedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		Ok(Self { item, position: body.deserialize_unchecked::<Self::Body>()?.detail1 })
@@ -912,70 +912,70 @@ impl EventWrapperMessageConversion for ObjectEvents {
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
 			PropertyChangeEvent::DBUS_MEMBER => Ok(ObjectEvents::PropertyChange(
-				PropertyChangeEvent::try_from_message_unchecked(msg)?,
+				PropertyChangeEvent::try_from_validated_message(msg)?,
 			)),
 			BoundsChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::BoundsChanged(
-				BoundsChangedEvent::try_from_message_unchecked(msg)?,
+				BoundsChangedEvent::try_from_validated_message(msg)?,
 			)),
 			LinkSelectedEvent::DBUS_MEMBER => {
-				Ok(ObjectEvents::LinkSelected(LinkSelectedEvent::try_from_message_unchecked(msg)?))
+				Ok(ObjectEvents::LinkSelected(LinkSelectedEvent::try_from_validated_message(msg)?))
 			}
 			StateChangedEvent::DBUS_MEMBER => {
-				Ok(ObjectEvents::StateChanged(StateChangedEvent::try_from_message_unchecked(msg)?))
+				Ok(ObjectEvents::StateChanged(StateChangedEvent::try_from_validated_message(msg)?))
 			}
 			ChildrenChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::ChildrenChanged(
-				ChildrenChangedEvent::try_from_message_unchecked(msg)?,
+				ChildrenChangedEvent::try_from_validated_message(msg)?,
 			)),
 			VisibleDataChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::VisibleDataChanged(
-				VisibleDataChangedEvent::try_from_message_unchecked(msg)?,
+				VisibleDataChangedEvent::try_from_validated_message(msg)?,
 			)),
 			SelectionChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::SelectionChanged(
-				SelectionChangedEvent::try_from_message_unchecked(msg)?,
+				SelectionChangedEvent::try_from_validated_message(msg)?,
 			)),
 			ModelChangedEvent::DBUS_MEMBER => {
-				Ok(ObjectEvents::ModelChanged(ModelChangedEvent::try_from_message_unchecked(msg)?))
+				Ok(ObjectEvents::ModelChanged(ModelChangedEvent::try_from_validated_message(msg)?))
 			}
 			ActiveDescendantChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::ActiveDescendantChanged(
-				ActiveDescendantChangedEvent::try_from_message_unchecked(msg)?,
+				ActiveDescendantChangedEvent::try_from_validated_message(msg)?,
 			)),
 			AnnouncementEvent::DBUS_MEMBER => {
-				Ok(ObjectEvents::Announcement(AnnouncementEvent::try_from_message_unchecked(msg)?))
+				Ok(ObjectEvents::Announcement(AnnouncementEvent::try_from_validated_message(msg)?))
 			}
 			AttributesChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::AttributesChanged(
-				AttributesChangedEvent::try_from_message_unchecked(msg)?,
+				AttributesChangedEvent::try_from_validated_message(msg)?,
 			)),
 			RowInsertedEvent::DBUS_MEMBER => {
-				Ok(ObjectEvents::RowInserted(RowInsertedEvent::try_from_message_unchecked(msg)?))
+				Ok(ObjectEvents::RowInserted(RowInsertedEvent::try_from_validated_message(msg)?))
 			}
 			RowReorderedEvent::DBUS_MEMBER => {
-				Ok(ObjectEvents::RowReordered(RowReorderedEvent::try_from_message_unchecked(msg)?))
+				Ok(ObjectEvents::RowReordered(RowReorderedEvent::try_from_validated_message(msg)?))
 			}
 			RowDeletedEvent::DBUS_MEMBER => {
-				Ok(ObjectEvents::RowDeleted(RowDeletedEvent::try_from_message_unchecked(msg)?))
+				Ok(ObjectEvents::RowDeleted(RowDeletedEvent::try_from_validated_message(msg)?))
 			}
 			ColumnInsertedEvent::DBUS_MEMBER => Ok(ObjectEvents::ColumnInserted(
-				ColumnInsertedEvent::try_from_message_unchecked(msg)?,
+				ColumnInsertedEvent::try_from_validated_message(msg)?,
 			)),
 			ColumnReorderedEvent::DBUS_MEMBER => Ok(ObjectEvents::ColumnReordered(
-				ColumnReorderedEvent::try_from_message_unchecked(msg)?,
+				ColumnReorderedEvent::try_from_validated_message(msg)?,
 			)),
 			ColumnDeletedEvent::DBUS_MEMBER => Ok(ObjectEvents::ColumnDeleted(
-				ColumnDeletedEvent::try_from_message_unchecked(msg)?,
+				ColumnDeletedEvent::try_from_validated_message(msg)?,
 			)),
 			TextBoundsChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::TextBoundsChanged(
-				TextBoundsChangedEvent::try_from_message_unchecked(msg)?,
+				TextBoundsChangedEvent::try_from_validated_message(msg)?,
 			)),
 			TextSelectionChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::TextSelectionChanged(
-				TextSelectionChangedEvent::try_from_message_unchecked(msg)?,
+				TextSelectionChangedEvent::try_from_validated_message(msg)?,
 			)),
 			TextChangedEvent::DBUS_MEMBER => {
-				Ok(ObjectEvents::TextChanged(TextChangedEvent::try_from_message_unchecked(msg)?))
+				Ok(ObjectEvents::TextChanged(TextChangedEvent::try_from_validated_message(msg)?))
 			}
 			TextAttributesChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::TextAttributesChanged(
-				TextAttributesChangedEvent::try_from_message_unchecked(msg)?,
+				TextAttributesChangedEvent::try_from_validated_message(msg)?,
 			)),
 			TextCaretMovedEvent::DBUS_MEMBER => Ok(ObjectEvents::TextCaretMoved(
-				TextCaretMovedEvent::try_from_message_unchecked(msg)?,
+				TextCaretMovedEvent::try_from_validated_message(msg)?,
 			)),
 			_ => Err(AtspiError::MemberMatch(format!(
 				"No matching member {member} for interface {}",

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -911,70 +911,70 @@ impl EventWrapperMessageConversion for ObjectEvents {
 		let header = msg.header();
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
-			"PropertyChange" => Ok(ObjectEvents::PropertyChange(
+			PropertyChangeEvent::DBUS_MEMBER => Ok(ObjectEvents::PropertyChange(
 				PropertyChangeEvent::try_from_message_unchecked(msg)?,
 			)),
-			"BoundsChanged" => Ok(ObjectEvents::BoundsChanged(
+			BoundsChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::BoundsChanged(
 				BoundsChangedEvent::try_from_message_unchecked(msg)?,
 			)),
-			"LinkSelected" => {
+			LinkSelectedEvent::DBUS_MEMBER => {
 				Ok(ObjectEvents::LinkSelected(LinkSelectedEvent::try_from_message_unchecked(msg)?))
 			}
-			"StateChanged" => {
+			StateChangedEvent::DBUS_MEMBER => {
 				Ok(ObjectEvents::StateChanged(StateChangedEvent::try_from_message_unchecked(msg)?))
 			}
-			"ChildrenChanged" => Ok(ObjectEvents::ChildrenChanged(
+			ChildrenChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::ChildrenChanged(
 				ChildrenChangedEvent::try_from_message_unchecked(msg)?,
 			)),
-			"VisibleDataChanged" => Ok(ObjectEvents::VisibleDataChanged(
+			VisibleDataChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::VisibleDataChanged(
 				VisibleDataChangedEvent::try_from_message_unchecked(msg)?,
 			)),
-			"SelectionChanged" => Ok(ObjectEvents::SelectionChanged(
+			SelectionChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::SelectionChanged(
 				SelectionChangedEvent::try_from_message_unchecked(msg)?,
 			)),
-			"ModelChanged" => {
+			ModelChangedEvent::DBUS_MEMBER => {
 				Ok(ObjectEvents::ModelChanged(ModelChangedEvent::try_from_message_unchecked(msg)?))
 			}
-			"ActiveDescendantChanged" => Ok(ObjectEvents::ActiveDescendantChanged(
+			ActiveDescendantChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::ActiveDescendantChanged(
 				ActiveDescendantChangedEvent::try_from_message_unchecked(msg)?,
 			)),
-			"Announcement" => {
+			AnnouncementEvent::DBUS_MEMBER => {
 				Ok(ObjectEvents::Announcement(AnnouncementEvent::try_from_message_unchecked(msg)?))
 			}
-			"AttributesChanged" => Ok(ObjectEvents::AttributesChanged(
+			AttributesChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::AttributesChanged(
 				AttributesChangedEvent::try_from_message_unchecked(msg)?,
 			)),
-			"RowInserted" => {
+			RowInsertedEvent::DBUS_MEMBER => {
 				Ok(ObjectEvents::RowInserted(RowInsertedEvent::try_from_message_unchecked(msg)?))
 			}
-			"RowReordered" => {
+			RowReorderedEvent::DBUS_MEMBER => {
 				Ok(ObjectEvents::RowReordered(RowReorderedEvent::try_from_message_unchecked(msg)?))
 			}
-			"RowDeleted" => {
+			RowDeletedEvent::DBUS_MEMBER => {
 				Ok(ObjectEvents::RowDeleted(RowDeletedEvent::try_from_message_unchecked(msg)?))
 			}
-			"ColumnInserted" => Ok(ObjectEvents::ColumnInserted(
+			ColumnInsertedEvent::DBUS_MEMBER => Ok(ObjectEvents::ColumnInserted(
 				ColumnInsertedEvent::try_from_message_unchecked(msg)?,
 			)),
-			"ColumnReordered" => Ok(ObjectEvents::ColumnReordered(
+			ColumnReorderedEvent::DBUS_MEMBER => Ok(ObjectEvents::ColumnReordered(
 				ColumnReorderedEvent::try_from_message_unchecked(msg)?,
 			)),
-			"ColumnDeleted" => Ok(ObjectEvents::ColumnDeleted(
+			ColumnDeletedEvent::DBUS_MEMBER => Ok(ObjectEvents::ColumnDeleted(
 				ColumnDeletedEvent::try_from_message_unchecked(msg)?,
 			)),
-			"TextBoundsChanged" => Ok(ObjectEvents::TextBoundsChanged(
+			TextBoundsChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::TextBoundsChanged(
 				TextBoundsChangedEvent::try_from_message_unchecked(msg)?,
 			)),
-			"TextSelectionChanged" => Ok(ObjectEvents::TextSelectionChanged(
+			TextSelectionChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::TextSelectionChanged(
 				TextSelectionChangedEvent::try_from_message_unchecked(msg)?,
 			)),
-			"TextChanged" => {
+			TextChangedEvent::DBUS_MEMBER => {
 				Ok(ObjectEvents::TextChanged(TextChangedEvent::try_from_message_unchecked(msg)?))
 			}
-			"TextAttributesChanged" => Ok(ObjectEvents::TextAttributesChanged(
+			TextAttributesChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::TextAttributesChanged(
 				TextAttributesChangedEvent::try_from_message_unchecked(msg)?,
 			)),
-			"TextCaretMoved" => Ok(ObjectEvents::TextCaretMoved(
+			TextCaretMovedEvent::DBUS_MEMBER => Ok(ObjectEvents::TextCaretMoved(
 				TextCaretMovedEvent::try_from_message_unchecked(msg)?,
 			)),
 			_ => Err(AtspiError::MemberMatch(format!(

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -1,7 +1,7 @@
 use std::hash::Hash;
 
 #[cfg(feature = "zbus")]
-use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage};
+use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage, MessageConversionExt};
 use crate::{
 	error::AtspiError,
 	events::{

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -619,7 +619,13 @@ impl MessageConversion for PropertyChangeEvent {
 	}
 	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
-		let body = msg.body().deserialize()?;
+		let body = if msg.body().signature().ok_or(AtspiError::MissingSignature)?
+			== crate::events::QSPI_EVENT_SIGNATURE
+		{
+			msg.body().deserialize::<crate::events::EventBodyQT>()?.into()
+		} else {
+			msg.body().deserialize()?
+		};
 		Self::try_from_validated_message_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
@@ -664,7 +670,13 @@ impl MessageConversion for StateChangedEvent {
 	}
 	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
-		let body = msg.body().deserialize()?;
+		let body = if msg.body().signature().ok_or(AtspiError::MissingSignature)?
+			== crate::events::QSPI_EVENT_SIGNATURE
+		{
+			msg.body().deserialize::<crate::events::EventBodyQT>()?.into()
+		} else {
+			msg.body().deserialize()?
+		};
 		Self::try_from_validated_message_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
@@ -698,7 +710,13 @@ impl MessageConversion for ChildrenChangedEvent {
 	}
 	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
-		let body = msg.body().deserialize()?;
+		let body = if msg.body().signature().ok_or(AtspiError::MissingSignature)?
+			== crate::events::QSPI_EVENT_SIGNATURE
+		{
+			msg.body().deserialize::<crate::events::EventBodyQT>()?.into()
+		} else {
+			msg.body().deserialize()?
+		};
 		Self::try_from_validated_message_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
@@ -751,7 +769,13 @@ impl MessageConversion for ActiveDescendantChangedEvent {
 	}
 	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
-		let body = msg.body().deserialize_unchecked()?;
+		let body = if msg.body().signature().ok_or(AtspiError::MissingSignature)?
+			== crate::events::QSPI_EVENT_SIGNATURE
+		{
+			msg.body().deserialize::<crate::events::EventBodyQT>()?.into()
+		} else {
+			msg.body().deserialize()?
+		};
 		Self::try_from_validated_message_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
@@ -784,7 +808,13 @@ impl MessageConversion for AnnouncementEvent {
 	}
 	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
-		let body = msg.body().deserialize_unchecked()?;
+		let body = if msg.body().signature().ok_or(AtspiError::MissingSignature)?
+			== crate::events::QSPI_EVENT_SIGNATURE
+		{
+			msg.body().deserialize::<crate::events::EventBodyQT>()?.into()
+		} else {
+			msg.body().deserialize()?
+		};
 		Self::try_from_validated_message_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
@@ -891,7 +921,13 @@ impl MessageConversion for TextChangedEvent {
 	}
 	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
-		let body = msg.body().deserialize_unchecked()?;
+		let body = if msg.body().signature().ok_or(AtspiError::MissingSignature)?
+			== crate::events::QSPI_EVENT_SIGNATURE
+		{
+			msg.body().deserialize::<crate::events::EventBodyQT>()?.into()
+		} else {
+			msg.body().deserialize()?
+		};
 		Self::try_from_validated_message_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
@@ -928,7 +964,13 @@ impl MessageConversion for TextCaretMovedEvent {
 	}
 	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
-		let body = msg.body().deserialize()?;
+		let body = if msg.body().signature().ok_or(AtspiError::MissingSignature)?
+			== crate::events::QSPI_EVENT_SIGNATURE
+		{
+			msg.body().deserialize::<crate::events::EventBodyQT>()?.into()
+		} else {
+			msg.body().deserialize()?
+		};
 		Self::try_from_validated_message_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -2,7 +2,10 @@ use std::hash::Hash;
 
 use crate::{
 	error::AtspiError,
-	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, ObjectRef},
+	events::{
+		BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, MessageConversion,
+		ObjectRef,
+	},
 	Event, EventProperties, EventTypeProperties, State,
 };
 use zbus_names::UniqueName;
@@ -596,10 +599,12 @@ impl BusProperties for PropertyChangeEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='PropertyChange'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for PropertyChangeEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		let property = body.kind.clone();
 		let value: Property = body.try_into()?;
 		Ok(Self { item, property, value })
@@ -616,10 +621,15 @@ impl BusProperties for BoundsChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='BoundsChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for BoundsChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -634,10 +644,15 @@ impl BusProperties for LinkSelectedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='LinkSelected'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for LinkSelectedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -652,10 +667,12 @@ impl BusProperties for StateChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='StateChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for StateChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, state: body.kind.into(), enabled: body.detail1 > 0 })
 	}
 	fn body(&self) -> Self::Body {
@@ -670,10 +687,12 @@ impl BusProperties for ChildrenChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='ChildrenChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for ChildrenChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self {
 			item,
 			operation: body.kind.as_str().parse()?,
@@ -693,10 +712,15 @@ impl BusProperties for VisibleDataChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='VisibleDataChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for VisibleDataChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -711,10 +735,15 @@ impl BusProperties for SelectionChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='SelectionChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for SelectionChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -729,10 +758,15 @@ impl BusProperties for ModelChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='ModelChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for ModelChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -747,10 +781,12 @@ impl BusProperties for ActiveDescendantChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='ActiveDescendantChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for ActiveDescendantChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, child: body.any_data.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -765,10 +801,12 @@ impl BusProperties for AnnouncementEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='Announcement'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for AnnouncementEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self {
 			item,
 			text: body.any_data.try_into().map_err(|_| AtspiError::Conversion("text"))?,
@@ -787,10 +825,15 @@ impl BusProperties for AttributesChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='AttributesChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for AttributesChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -805,10 +848,15 @@ impl BusProperties for RowInsertedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='RowInserted'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for RowInsertedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -823,10 +871,15 @@ impl BusProperties for RowReorderedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='RowReordered'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for RowReorderedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -841,10 +894,15 @@ impl BusProperties for RowDeletedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='RowDeleted'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for RowDeletedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -859,10 +917,15 @@ impl BusProperties for ColumnInsertedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='ColumnInserted'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for ColumnInsertedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -877,10 +940,15 @@ impl BusProperties for ColumnReorderedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='ColumnReordered'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for ColumnReorderedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -895,10 +963,15 @@ impl BusProperties for ColumnDeletedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='ColumnDeleted'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for ColumnDeletedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -913,10 +986,15 @@ impl BusProperties for TextBoundsChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='TextBoundsChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for TextBoundsChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -931,10 +1009,15 @@ impl BusProperties for TextSelectionChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='TextSelectionChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for TextSelectionChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -949,10 +1032,12 @@ impl BusProperties for TextChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='TextChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for TextChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self {
 			item,
 			operation: body.kind.as_str().parse()?,
@@ -973,10 +1058,15 @@ impl BusProperties for TextAttributesChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='TextAttributesChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for TextAttributesChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -991,10 +1081,12 @@ impl BusProperties for TextCaretMovedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='TextCaretMoved'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
+}
 
+impl MessageConversion for TextCaretMovedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, position: body.detail1 })
 	}
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -604,10 +604,9 @@ impl BusProperties for PropertyChangeEvent {
 impl MessageConversion for PropertyChangeEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
 		let ev_body: Self::Body = body.deserialize_unchecked()?;
 		let property = ev_body.kind.to_string();
 		let value: Property = ev_body.try_into()?;
@@ -631,10 +630,8 @@ impl BusProperties for BoundsChangedEvent {
 impl MessageConversion for BoundsChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -655,10 +652,8 @@ impl BusProperties for LinkSelectedEvent {
 impl MessageConversion for LinkSelectedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -679,10 +674,9 @@ impl BusProperties for StateChangedEvent {
 impl MessageConversion for StateChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
 		let ev_body: Self::Body = body.deserialize_unchecked()?;
 		Ok(Self { item, state: ev_body.kind.into(), enabled: ev_body.detail1 > 0 })
 	}
@@ -704,10 +698,9 @@ impl BusProperties for ChildrenChangedEvent {
 impl MessageConversion for ChildrenChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
 		let ev_body: Self::Body = body.deserialize_unchecked()?;
 		Ok(Self {
 			item,
@@ -734,10 +727,8 @@ impl BusProperties for VisibleDataChangedEvent {
 impl MessageConversion for VisibleDataChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -758,10 +749,8 @@ impl BusProperties for SelectionChangedEvent {
 impl MessageConversion for SelectionChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -782,10 +771,8 @@ impl BusProperties for ModelChangedEvent {
 impl MessageConversion for ModelChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -806,10 +793,9 @@ impl BusProperties for ActiveDescendantChangedEvent {
 impl MessageConversion for ActiveDescendantChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
 		Ok(Self { item, child: body.deserialize_unchecked::<Self::Body>()?.any_data.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
@@ -830,10 +816,9 @@ impl BusProperties for AnnouncementEvent {
 impl MessageConversion for AnnouncementEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
 		let ev_body: Self::Body = body.deserialize_unchecked()?;
 		Ok(Self {
 			item,
@@ -862,10 +847,8 @@ impl BusProperties for AttributesChangedEvent {
 impl MessageConversion for AttributesChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -886,10 +869,8 @@ impl BusProperties for RowInsertedEvent {
 impl MessageConversion for RowInsertedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -910,10 +891,8 @@ impl BusProperties for RowReorderedEvent {
 impl MessageConversion for RowReorderedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -934,10 +913,8 @@ impl BusProperties for RowDeletedEvent {
 impl MessageConversion for RowDeletedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -958,10 +935,8 @@ impl BusProperties for ColumnInsertedEvent {
 impl MessageConversion for ColumnInsertedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -982,10 +957,8 @@ impl BusProperties for ColumnReorderedEvent {
 impl MessageConversion for ColumnReorderedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -1006,10 +979,8 @@ impl BusProperties for ColumnDeletedEvent {
 impl MessageConversion for ColumnDeletedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -1030,10 +1001,8 @@ impl BusProperties for TextBoundsChangedEvent {
 impl MessageConversion for TextBoundsChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -1054,10 +1023,8 @@ impl BusProperties for TextSelectionChangedEvent {
 impl MessageConversion for TextSelectionChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -1078,10 +1045,9 @@ impl BusProperties for TextChangedEvent {
 impl MessageConversion for TextChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
 		let ev_body: Self::Body = body.deserialize_unchecked()?;
 		Ok(Self {
 			item,
@@ -1109,10 +1075,8 @@ impl BusProperties for TextAttributesChangedEvent {
 impl MessageConversion for TextAttributesChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -1133,10 +1097,9 @@ impl BusProperties for TextCaretMovedEvent {
 impl MessageConversion for TextCaretMovedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
 		Ok(Self { item, position: body.deserialize_unchecked::<Self::Body>()?.detail1 })
 	}
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -6,7 +6,7 @@ use crate::{
 	error::AtspiError,
 	events::{
 		BusProperties, EventBodyOwned, EventWrapperMessageConversion, HasInterfaceName,
-		HasMatchRule, HasRegistryEventString, ObjectRef,
+		HasMatchRule, HasRegistryEventString, ObjectRef, TryFromMessage,
 	},
 	Event, EventProperties, EventTypeProperties, State,
 };
@@ -989,16 +989,7 @@ impl EventWrapperMessageConversion for ObjectEvents {
 impl TryFrom<&zbus::Message> for ObjectEvents {
 	type Error = AtspiError;
 	fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
-		let header = msg.header();
-		let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
-		if interface != ObjectEvents::DBUS_INTERFACE {
-			return Err(AtspiError::InterfaceMatch(format!(
-				"Interface {} does not match require interface for event: {}",
-				interface,
-				ObjectEvents::DBUS_INTERFACE
-			)));
-		}
-		ObjectEvents::try_from_message_interface_checked(msg)
+		Self::try_from_message(msg)
 	}
 }
 

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -1,7 +1,9 @@
 use std::hash::Hash;
 
 #[cfg(feature = "zbus")]
-use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage, MessageConversionExt};
+use crate::events::{
+	EventWrapperMessageConversion, MessageConversion, MessageConversionExt, TryFromMessage,
+};
 use crate::{
 	error::AtspiError,
 	events::{

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -908,8 +908,8 @@ impl HasInterfaceName for ObjectEvents {
 #[cfg(feature = "zbus")]
 impl TryFrom<&zbus::Message> for ObjectEvents {
 	type Error = AtspiError;
-	fn try_from(ev: &zbus::Message) -> Result<Self, Self::Error> {
-		let header = ev.header();
+	fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
+		let header = msg.header();
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
 		if interface != ObjectEvents::DBUS_INTERFACE {
@@ -920,29 +920,75 @@ impl TryFrom<&zbus::Message> for ObjectEvents {
 			)));
 		}
 		match member.as_str() {
-			"PropertyChange" => Ok(ObjectEvents::PropertyChange(ev.try_into()?)),
-			"BoundsChanged" => Ok(ObjectEvents::BoundsChanged(ev.try_into()?)),
-			"LinkSelected" => Ok(ObjectEvents::LinkSelected(ev.try_into()?)),
-			"StateChanged" => Ok(ObjectEvents::StateChanged(ev.try_into()?)),
-			"ChildrenChanged" => Ok(ObjectEvents::ChildrenChanged(ev.try_into()?)),
-			"VisibleDataChanged" => Ok(ObjectEvents::VisibleDataChanged(ev.try_into()?)),
-			"SelectionChanged" => Ok(ObjectEvents::SelectionChanged(ev.try_into()?)),
-			"ModelChanged" => Ok(ObjectEvents::ModelChanged(ev.try_into()?)),
-			"ActiveDescendantChanged" => Ok(ObjectEvents::ActiveDescendantChanged(ev.try_into()?)),
-			"Announcement" => Ok(ObjectEvents::Announcement(ev.try_into()?)),
-			"AttributesChanged" => Ok(ObjectEvents::AttributesChanged(ev.try_into()?)),
-			"RowInserted" => Ok(ObjectEvents::RowInserted(ev.try_into()?)),
-			"RowReordered" => Ok(ObjectEvents::RowReordered(ev.try_into()?)),
-			"RowDeleted" => Ok(ObjectEvents::RowDeleted(ev.try_into()?)),
-			"ColumnInserted" => Ok(ObjectEvents::ColumnInserted(ev.try_into()?)),
-			"ColumnReordered" => Ok(ObjectEvents::ColumnReordered(ev.try_into()?)),
-			"ColumnDeleted" => Ok(ObjectEvents::ColumnDeleted(ev.try_into()?)),
-			"TextBoundsChanged" => Ok(ObjectEvents::TextBoundsChanged(ev.try_into()?)),
-			"TextSelectionChanged" => Ok(ObjectEvents::TextSelectionChanged(ev.try_into()?)),
-			"TextChanged" => Ok(ObjectEvents::TextChanged(ev.try_into()?)),
-			"TextAttributesChanged" => Ok(ObjectEvents::TextAttributesChanged(ev.try_into()?)),
-			"TextCaretMoved" => Ok(ObjectEvents::TextCaretMoved(ev.try_into()?)),
-			_ => Err(AtspiError::MemberMatch("No matching member for Object".into())),
+			"PropertyChange" => Ok(ObjectEvents::PropertyChange(
+				PropertyChangeEvent::try_from_message_unchecked(msg)?,
+			)),
+			"BoundsChanged" => Ok(ObjectEvents::BoundsChanged(
+				BoundsChangedEvent::try_from_message_unchecked(msg)?,
+			)),
+			"LinkSelected" => {
+				Ok(ObjectEvents::LinkSelected(LinkSelectedEvent::try_from_message_unchecked(msg)?))
+			}
+			"StateChanged" => {
+				Ok(ObjectEvents::StateChanged(StateChangedEvent::try_from_message_unchecked(msg)?))
+			}
+			"ChildrenChanged" => Ok(ObjectEvents::ChildrenChanged(
+				ChildrenChangedEvent::try_from_message_unchecked(msg)?,
+			)),
+			"VisibleDataChanged" => Ok(ObjectEvents::VisibleDataChanged(
+				VisibleDataChangedEvent::try_from_message_unchecked(msg)?,
+			)),
+			"SelectionChanged" => Ok(ObjectEvents::SelectionChanged(
+				SelectionChangedEvent::try_from_message_unchecked(msg)?,
+			)),
+			"ModelChanged" => {
+				Ok(ObjectEvents::ModelChanged(ModelChangedEvent::try_from_message_unchecked(msg)?))
+			}
+			"ActiveDescendantChanged" => Ok(ObjectEvents::ActiveDescendantChanged(
+				ActiveDescendantChangedEvent::try_from_message_unchecked(msg)?,
+			)),
+			"Announcement" => {
+				Ok(ObjectEvents::Announcement(AnnouncementEvent::try_from_message_unchecked(msg)?))
+			}
+			"AttributesChanged" => Ok(ObjectEvents::AttributesChanged(
+				AttributesChangedEvent::try_from_message_unchecked(msg)?,
+			)),
+			"RowInserted" => {
+				Ok(ObjectEvents::RowInserted(RowInsertedEvent::try_from_message_unchecked(msg)?))
+			}
+			"RowReordered" => {
+				Ok(ObjectEvents::RowReordered(RowReorderedEvent::try_from_message_unchecked(msg)?))
+			}
+			"RowDeleted" => {
+				Ok(ObjectEvents::RowDeleted(RowDeletedEvent::try_from_message_unchecked(msg)?))
+			}
+			"ColumnInserted" => Ok(ObjectEvents::ColumnInserted(
+				ColumnInsertedEvent::try_from_message_unchecked(msg)?,
+			)),
+			"ColumnReordered" => Ok(ObjectEvents::ColumnReordered(
+				ColumnReorderedEvent::try_from_message_unchecked(msg)?,
+			)),
+			"ColumnDeleted" => Ok(ObjectEvents::ColumnDeleted(
+				ColumnDeletedEvent::try_from_message_unchecked(msg)?,
+			)),
+			"TextBoundsChanged" => Ok(ObjectEvents::TextBoundsChanged(
+				TextBoundsChangedEvent::try_from_message_unchecked(msg)?,
+			)),
+			"TextSelectionChanged" => Ok(ObjectEvents::TextSelectionChanged(
+				TextSelectionChangedEvent::try_from_message_unchecked(msg)?,
+			)),
+			"TextChanged" => {
+				Ok(ObjectEvents::TextChanged(TextChangedEvent::try_from_message_unchecked(msg)?))
+			}
+			"TextAttributesChanged" => Ok(ObjectEvents::TextAttributesChanged(
+				TextAttributesChangedEvent::try_from_message_unchecked(msg)?,
+			)),
+			"TextCaretMoved" => Ok(ObjectEvents::TextCaretMoved(
+				TextCaretMovedEvent::try_from_message_unchecked(msg)?,
+			)),
+			_ => Err(AtspiError::MemberMatch(format!(
+				"No matching member {member} for interface {interface}",
+			))),
 		}
 	}
 }

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -232,7 +232,7 @@ impl HasMatchRule for ObjectEvents {
 /// The `org.a11y.atspi.Event.Object:PropertyChange` event.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PropertyChangeEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 	// TODO: this is not necessary since the string is encoded in the `Property` type.
 	pub property: String,
@@ -257,7 +257,7 @@ impl Default for PropertyChangeEvent {
 	}
 }
 
-/// Any accessibility related property on an [`ObjectRef`].
+/// Any accessibility related property on an [`crate::ObjectRef`].
 /// This is used only in the [`PropertyChangeEvent`]; this event gets triggered if a role or accessible
 /// description of an item changes.
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -404,21 +404,21 @@ impl From<Property> for OwnedValue {
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct BoundsChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct LinkSelectedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 /// A state of an object has been modified.
-/// A [`State`] can be added or removed from any [`ObjectRef`].
+/// A [`State`] can be added or removed from any [`crate::ObjectRef`].
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct StateChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 	/// The state to be enabled/disabled.
 	pub state: State,
@@ -451,10 +451,10 @@ mod i32_bool_conversion {
 	}
 }
 
-/// A child of an [`ObjectRef`] has been added or removed.
+/// A child of an [`crate::ObjectRef`] has been added or removed.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct ChildrenChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 	/// The [`crate::Operation`] being performed.
 	pub operation: crate::Operation,
@@ -466,32 +466,32 @@ pub struct ChildrenChangedEvent {
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct VisibleDataChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct SelectionChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct ModelChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct ActiveDescendantChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 	pub child: ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct AnnouncementEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 	/// Text of the announcement.
 	pub text: String,
@@ -501,7 +501,7 @@ pub struct AnnouncementEvent {
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct AttributesChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
@@ -549,20 +549,20 @@ pub struct ColumnDeletedEvent {
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct TextBoundsChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct TextSelectionChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
-/// Text has changed within an [`ObjectRef`].
+/// Text has changed within an [`crate::ObjectRef`].
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct TextChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 	/// The [`crate::Operation`] being performed.
 	pub operation: crate::Operation,
@@ -579,7 +579,7 @@ pub struct TextChangedEvent {
 /// changed.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct TextAttributesChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
@@ -1046,7 +1046,7 @@ impl From<ChildrenChangedEvent> for EventBodyOwned {
 			kind: event.operation.to_string(),
 			detail1: event.index_in_parent,
 			detail2: i32::default(),
-			// `OwnedValue` is constructed from the `ObjectRef`
+			// `OwnedValue` is constructed from the `crate::ObjectRef`
 			// Only path to fail is to convert a Fd into an `OwnedValue`.
 			// Therefore, this is safe.
 			any_data: Value::from(event.child)
@@ -1129,7 +1129,7 @@ impl From<ActiveDescendantChangedEvent> for EventBodyOwned {
 			kind: String::default(),
 			detail1: i32::default(),
 			detail2: i32::default(),
-			// `OwnedValue` is constructed from the `ObjectRef`
+			// `OwnedValue` is constructed from the `crate::ObjectRef`
 			// Only path to fail is to convert a Fd into an `OwnedValue`.
 			// Therefore, this is safe.
 			any_data: Value::from(event.child)

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -979,17 +979,6 @@ impl_to_dbus_message!(BoundsChangedEvent);
 impl_from_dbus_message!(BoundsChangedEvent);
 impl_event_properties!(BoundsChangedEvent);
 impl_from_object_ref!(BoundsChangedEvent);
-impl From<BoundsChangedEvent> for EventBodyOwned {
-	fn from(_event: BoundsChangedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	LinkSelectedEvent,
@@ -1007,17 +996,6 @@ impl_to_dbus_message!(LinkSelectedEvent);
 impl_from_dbus_message!(LinkSelectedEvent);
 impl_event_properties!(LinkSelectedEvent);
 impl_from_object_ref!(LinkSelectedEvent);
-impl From<LinkSelectedEvent> for EventBodyOwned {
-	fn from(_event: LinkSelectedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	StateChangedEvent,
@@ -1094,17 +1072,6 @@ impl_to_dbus_message!(VisibleDataChangedEvent);
 impl_from_dbus_message!(VisibleDataChangedEvent);
 impl_event_properties!(VisibleDataChangedEvent);
 impl_from_object_ref!(VisibleDataChangedEvent);
-impl From<VisibleDataChangedEvent> for EventBodyOwned {
-	fn from(_event: VisibleDataChangedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	SelectionChangedEvent,
@@ -1122,17 +1089,6 @@ impl_to_dbus_message!(SelectionChangedEvent);
 impl_from_dbus_message!(SelectionChangedEvent);
 impl_event_properties!(SelectionChangedEvent);
 impl_from_object_ref!(SelectionChangedEvent);
-impl From<SelectionChangedEvent> for EventBodyOwned {
-	fn from(_event: SelectionChangedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	ModelChangedEvent,
@@ -1150,17 +1106,6 @@ impl_to_dbus_message!(ModelChangedEvent);
 impl_from_dbus_message!(ModelChangedEvent);
 impl_event_properties!(ModelChangedEvent);
 impl_from_object_ref!(ModelChangedEvent);
-impl From<ModelChangedEvent> for EventBodyOwned {
-	fn from(_event: ModelChangedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	ActiveDescendantChangedEvent,
@@ -1239,17 +1184,6 @@ impl_to_dbus_message!(AttributesChangedEvent);
 impl_from_dbus_message!(AttributesChangedEvent);
 impl_event_properties!(AttributesChangedEvent);
 impl_from_object_ref!(AttributesChangedEvent);
-impl From<AttributesChangedEvent> for EventBodyOwned {
-	fn from(_event: AttributesChangedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	RowInsertedEvent,
@@ -1267,17 +1201,6 @@ impl_to_dbus_message!(RowInsertedEvent);
 impl_from_dbus_message!(RowInsertedEvent);
 impl_event_properties!(RowInsertedEvent);
 impl_from_object_ref!(RowInsertedEvent);
-impl From<RowInsertedEvent> for EventBodyOwned {
-	fn from(_event: RowInsertedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	RowReorderedEvent,
@@ -1295,17 +1218,6 @@ impl_to_dbus_message!(RowReorderedEvent);
 impl_from_dbus_message!(RowReorderedEvent);
 impl_event_properties!(RowReorderedEvent);
 impl_from_object_ref!(RowReorderedEvent);
-impl From<RowReorderedEvent> for EventBodyOwned {
-	fn from(_event: RowReorderedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	RowDeletedEvent,
@@ -1319,17 +1231,6 @@ impl_to_dbus_message!(RowDeletedEvent);
 impl_from_dbus_message!(RowDeletedEvent);
 impl_event_properties!(RowDeletedEvent);
 impl_from_object_ref!(RowDeletedEvent);
-impl From<RowDeletedEvent> for EventBodyOwned {
-	fn from(_event: RowDeletedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	ColumnInsertedEvent,
@@ -1347,17 +1248,6 @@ impl_to_dbus_message!(ColumnInsertedEvent);
 impl_from_dbus_message!(ColumnInsertedEvent);
 impl_event_properties!(ColumnInsertedEvent);
 impl_from_object_ref!(ColumnInsertedEvent);
-impl From<ColumnInsertedEvent> for EventBodyOwned {
-	fn from(_event: ColumnInsertedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	ColumnReorderedEvent,
@@ -1375,17 +1265,6 @@ impl_to_dbus_message!(ColumnReorderedEvent);
 impl_from_dbus_message!(ColumnReorderedEvent);
 impl_event_properties!(ColumnReorderedEvent);
 impl_from_object_ref!(ColumnReorderedEvent);
-impl From<ColumnReorderedEvent> for EventBodyOwned {
-	fn from(_event: ColumnReorderedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	ColumnDeletedEvent,
@@ -1403,17 +1282,6 @@ impl_to_dbus_message!(ColumnDeletedEvent);
 impl_from_dbus_message!(ColumnDeletedEvent);
 impl_event_properties!(ColumnDeletedEvent);
 impl_from_object_ref!(ColumnDeletedEvent);
-impl From<ColumnDeletedEvent> for EventBodyOwned {
-	fn from(_event: ColumnDeletedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	TextBoundsChangedEvent,
@@ -1431,17 +1299,6 @@ impl_to_dbus_message!(TextBoundsChangedEvent);
 impl_from_dbus_message!(TextBoundsChangedEvent);
 impl_event_properties!(TextBoundsChangedEvent);
 impl_from_object_ref!(TextBoundsChangedEvent);
-impl From<TextBoundsChangedEvent> for EventBodyOwned {
-	fn from(_event: TextBoundsChangedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	TextSelectionChangedEvent,
@@ -1459,17 +1316,6 @@ impl_to_dbus_message!(TextSelectionChangedEvent);
 impl_from_dbus_message!(TextSelectionChangedEvent);
 impl_event_properties!(TextSelectionChangedEvent);
 impl_from_object_ref!(TextSelectionChangedEvent);
-impl From<TextSelectionChangedEvent> for EventBodyOwned {
-	fn from(_event: TextSelectionChangedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	TextChangedEvent,
@@ -1519,17 +1365,6 @@ impl_to_dbus_message!(TextAttributesChangedEvent);
 impl_from_dbus_message!(TextAttributesChangedEvent);
 impl_event_properties!(TextAttributesChangedEvent);
 impl_from_object_ref!(TextAttributesChangedEvent);
-impl From<TextAttributesChangedEvent> for EventBodyOwned {
-	fn from(_event: TextAttributesChangedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	TextCaretMovedEvent,

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -1,12 +1,12 @@
 use std::hash::Hash;
 
 #[cfg(feature = "zbus")]
-use crate::events::MessageConversion;
+use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage};
 use crate::{
 	error::AtspiError,
 	events::{
-		BusProperties, EventBodyOwned, EventWrapperMessageConversion, HasInterfaceName,
-		HasMatchRule, HasRegistryEventString, ObjectRef, TryFromMessage,
+		BusProperties, EventBodyOwned, HasInterfaceName, HasMatchRule, HasRegistryEventString,
+		ObjectRef,
 	},
 	Event, EventProperties, EventTypeProperties, State,
 };

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -626,40 +626,12 @@ impl BusProperties for BoundsChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for BoundsChangedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for LinkSelectedEvent {
 	const DBUS_MEMBER: &'static str = "LinkSelected";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Object";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='LinkSelected'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for LinkSelectedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 impl BusProperties for StateChangedEvent {
@@ -723,20 +695,6 @@ impl BusProperties for VisibleDataChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for VisibleDataChangedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for SelectionChangedEvent {
 	const DBUS_MEMBER: &'static str = "SelectionChanged";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Object";
@@ -745,40 +703,12 @@ impl BusProperties for SelectionChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for SelectionChangedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for ModelChangedEvent {
 	const DBUS_MEMBER: &'static str = "ModelChanged";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Object";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='ModelChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for ModelChangedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 impl BusProperties for ActiveDescendantChangedEvent {
@@ -843,40 +773,12 @@ impl BusProperties for AttributesChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for AttributesChangedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for RowInsertedEvent {
 	const DBUS_MEMBER: &'static str = "RowInserted";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Object";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='RowInserted'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for RowInsertedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 impl BusProperties for RowReorderedEvent {
@@ -887,40 +789,12 @@ impl BusProperties for RowReorderedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for RowReorderedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for RowDeletedEvent {
 	const DBUS_MEMBER: &'static str = "RowDeleted";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Object";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='RowDeleted'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for RowDeletedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 impl BusProperties for ColumnInsertedEvent {
@@ -931,40 +805,12 @@ impl BusProperties for ColumnInsertedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for ColumnInsertedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for ColumnReorderedEvent {
 	const DBUS_MEMBER: &'static str = "ColumnReordered";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Object";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='ColumnReordered'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for ColumnReorderedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 impl BusProperties for ColumnDeletedEvent {
@@ -975,20 +821,6 @@ impl BusProperties for ColumnDeletedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for ColumnDeletedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for TextBoundsChangedEvent {
 	const DBUS_MEMBER: &'static str = "TextBoundsChanged";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Object";
@@ -997,40 +829,12 @@ impl BusProperties for TextBoundsChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for TextBoundsChangedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for TextSelectionChangedEvent {
 	const DBUS_MEMBER: &'static str = "TextSelectionChanged";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Object";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='TextSelectionChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for TextSelectionChangedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 impl BusProperties for TextChangedEvent {
@@ -1069,20 +873,6 @@ impl BusProperties for TextAttributesChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Object',member='TextAttributesChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Object:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for TextAttributesChangedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 impl BusProperties for TextCaretMovedEvent {
@@ -1188,6 +978,7 @@ event_test_cases!(BoundsChangedEvent);
 impl_to_dbus_message!(BoundsChangedEvent);
 impl_from_dbus_message!(BoundsChangedEvent);
 impl_event_properties!(BoundsChangedEvent);
+impl_from_object_ref!(BoundsChangedEvent);
 impl From<BoundsChangedEvent> for EventBodyOwned {
 	fn from(_event: BoundsChangedEvent) -> Self {
 		EventBodyOwned {
@@ -1215,6 +1006,7 @@ event_test_cases!(LinkSelectedEvent);
 impl_to_dbus_message!(LinkSelectedEvent);
 impl_from_dbus_message!(LinkSelectedEvent);
 impl_event_properties!(LinkSelectedEvent);
+impl_from_object_ref!(LinkSelectedEvent);
 impl From<LinkSelectedEvent> for EventBodyOwned {
 	fn from(_event: LinkSelectedEvent) -> Self {
 		EventBodyOwned {
@@ -1301,6 +1093,7 @@ event_test_cases!(VisibleDataChangedEvent);
 impl_to_dbus_message!(VisibleDataChangedEvent);
 impl_from_dbus_message!(VisibleDataChangedEvent);
 impl_event_properties!(VisibleDataChangedEvent);
+impl_from_object_ref!(VisibleDataChangedEvent);
 impl From<VisibleDataChangedEvent> for EventBodyOwned {
 	fn from(_event: VisibleDataChangedEvent) -> Self {
 		EventBodyOwned {
@@ -1328,6 +1121,7 @@ event_test_cases!(SelectionChangedEvent);
 impl_to_dbus_message!(SelectionChangedEvent);
 impl_from_dbus_message!(SelectionChangedEvent);
 impl_event_properties!(SelectionChangedEvent);
+impl_from_object_ref!(SelectionChangedEvent);
 impl From<SelectionChangedEvent> for EventBodyOwned {
 	fn from(_event: SelectionChangedEvent) -> Self {
 		EventBodyOwned {
@@ -1355,6 +1149,7 @@ event_test_cases!(ModelChangedEvent);
 impl_to_dbus_message!(ModelChangedEvent);
 impl_from_dbus_message!(ModelChangedEvent);
 impl_event_properties!(ModelChangedEvent);
+impl_from_object_ref!(ModelChangedEvent);
 impl From<ModelChangedEvent> for EventBodyOwned {
 	fn from(_event: ModelChangedEvent) -> Self {
 		EventBodyOwned {
@@ -1443,6 +1238,7 @@ event_test_cases!(AttributesChangedEvent);
 impl_to_dbus_message!(AttributesChangedEvent);
 impl_from_dbus_message!(AttributesChangedEvent);
 impl_event_properties!(AttributesChangedEvent);
+impl_from_object_ref!(AttributesChangedEvent);
 impl From<AttributesChangedEvent> for EventBodyOwned {
 	fn from(_event: AttributesChangedEvent) -> Self {
 		EventBodyOwned {
@@ -1470,6 +1266,7 @@ event_test_cases!(RowInsertedEvent);
 impl_to_dbus_message!(RowInsertedEvent);
 impl_from_dbus_message!(RowInsertedEvent);
 impl_event_properties!(RowInsertedEvent);
+impl_from_object_ref!(RowInsertedEvent);
 impl From<RowInsertedEvent> for EventBodyOwned {
 	fn from(_event: RowInsertedEvent) -> Self {
 		EventBodyOwned {
@@ -1497,6 +1294,7 @@ event_test_cases!(RowReorderedEvent);
 impl_to_dbus_message!(RowReorderedEvent);
 impl_from_dbus_message!(RowReorderedEvent);
 impl_event_properties!(RowReorderedEvent);
+impl_from_object_ref!(RowReorderedEvent);
 impl From<RowReorderedEvent> for EventBodyOwned {
 	fn from(_event: RowReorderedEvent) -> Self {
 		EventBodyOwned {
@@ -1520,6 +1318,7 @@ event_test_cases!(RowDeletedEvent);
 impl_to_dbus_message!(RowDeletedEvent);
 impl_from_dbus_message!(RowDeletedEvent);
 impl_event_properties!(RowDeletedEvent);
+impl_from_object_ref!(RowDeletedEvent);
 impl From<RowDeletedEvent> for EventBodyOwned {
 	fn from(_event: RowDeletedEvent) -> Self {
 		EventBodyOwned {
@@ -1547,6 +1346,7 @@ event_test_cases!(ColumnInsertedEvent);
 impl_to_dbus_message!(ColumnInsertedEvent);
 impl_from_dbus_message!(ColumnInsertedEvent);
 impl_event_properties!(ColumnInsertedEvent);
+impl_from_object_ref!(ColumnInsertedEvent);
 impl From<ColumnInsertedEvent> for EventBodyOwned {
 	fn from(_event: ColumnInsertedEvent) -> Self {
 		EventBodyOwned {
@@ -1574,6 +1374,7 @@ event_test_cases!(ColumnReorderedEvent);
 impl_to_dbus_message!(ColumnReorderedEvent);
 impl_from_dbus_message!(ColumnReorderedEvent);
 impl_event_properties!(ColumnReorderedEvent);
+impl_from_object_ref!(ColumnReorderedEvent);
 impl From<ColumnReorderedEvent> for EventBodyOwned {
 	fn from(_event: ColumnReorderedEvent) -> Self {
 		EventBodyOwned {
@@ -1601,6 +1402,7 @@ event_test_cases!(ColumnDeletedEvent);
 impl_to_dbus_message!(ColumnDeletedEvent);
 impl_from_dbus_message!(ColumnDeletedEvent);
 impl_event_properties!(ColumnDeletedEvent);
+impl_from_object_ref!(ColumnDeletedEvent);
 impl From<ColumnDeletedEvent> for EventBodyOwned {
 	fn from(_event: ColumnDeletedEvent) -> Self {
 		EventBodyOwned {
@@ -1628,6 +1430,7 @@ event_test_cases!(TextBoundsChangedEvent);
 impl_to_dbus_message!(TextBoundsChangedEvent);
 impl_from_dbus_message!(TextBoundsChangedEvent);
 impl_event_properties!(TextBoundsChangedEvent);
+impl_from_object_ref!(TextBoundsChangedEvent);
 impl From<TextBoundsChangedEvent> for EventBodyOwned {
 	fn from(_event: TextBoundsChangedEvent) -> Self {
 		EventBodyOwned {
@@ -1655,6 +1458,7 @@ event_test_cases!(TextSelectionChangedEvent);
 impl_to_dbus_message!(TextSelectionChangedEvent);
 impl_from_dbus_message!(TextSelectionChangedEvent);
 impl_event_properties!(TextSelectionChangedEvent);
+impl_from_object_ref!(TextSelectionChangedEvent);
 impl From<TextSelectionChangedEvent> for EventBodyOwned {
 	fn from(_event: TextSelectionChangedEvent) -> Self {
 		EventBodyOwned {
@@ -1714,6 +1518,7 @@ event_test_cases!(TextAttributesChangedEvent);
 impl_to_dbus_message!(TextAttributesChangedEvent);
 impl_from_dbus_message!(TextAttributesChangedEvent);
 impl_event_properties!(TextAttributesChangedEvent);
+impl_from_object_ref!(TextAttributesChangedEvent);
 impl From<TextAttributesChangedEvent> for EventBodyOwned {
 	fn from(_event: TextAttributesChangedEvent) -> Self {
 		EventBodyOwned {

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -609,7 +609,7 @@ impl BusProperties for PropertyChangeEvent {
 impl MessageConversion for PropertyChangeEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		item: ObjectRef,
 		body: Self::Body,
 	) -> Result<Self, AtspiError> {
@@ -617,7 +617,7 @@ impl MessageConversion for PropertyChangeEvent {
 		let value: Property = body.try_into()?;
 		Ok(Self { item, property, value })
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = if msg.body().signature().ok_or(AtspiError::MissingSignature)?
 			== crate::events::QSPI_EVENT_SIGNATURE
@@ -626,7 +626,7 @@ impl MessageConversion for PropertyChangeEvent {
 		} else {
 			msg.body().deserialize()?
 		};
-		Self::try_from_validated_message_parts(item, body)
+		Self::from_message_unchecked_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -662,13 +662,13 @@ impl BusProperties for StateChangedEvent {
 impl MessageConversion for StateChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		item: ObjectRef,
 		body: Self::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item, state: body.kind.into(), enabled: body.detail1 > 0 })
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = if msg.body().signature().ok_or(AtspiError::MissingSignature)?
 			== crate::events::QSPI_EVENT_SIGNATURE
@@ -677,7 +677,7 @@ impl MessageConversion for StateChangedEvent {
 		} else {
 			msg.body().deserialize()?
 		};
-		Self::try_from_validated_message_parts(item, body)
+		Self::from_message_unchecked_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -697,7 +697,7 @@ impl BusProperties for ChildrenChangedEvent {
 impl MessageConversion for ChildrenChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		item: ObjectRef,
 		body: Self::Body,
 	) -> Result<Self, AtspiError> {
@@ -708,7 +708,7 @@ impl MessageConversion for ChildrenChangedEvent {
 			child: body.any_data.try_into()?,
 		})
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = if msg.body().signature().ok_or(AtspiError::MissingSignature)?
 			== crate::events::QSPI_EVENT_SIGNATURE
@@ -717,7 +717,7 @@ impl MessageConversion for ChildrenChangedEvent {
 		} else {
 			msg.body().deserialize()?
 		};
-		Self::try_from_validated_message_parts(item, body)
+		Self::from_message_unchecked_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -761,13 +761,13 @@ impl BusProperties for ActiveDescendantChangedEvent {
 impl MessageConversion for ActiveDescendantChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		item: ObjectRef,
 		body: Self::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item, child: body.any_data.try_into()? })
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = if msg.body().signature().ok_or(AtspiError::MissingSignature)?
 			== crate::events::QSPI_EVENT_SIGNATURE
@@ -776,7 +776,7 @@ impl MessageConversion for ActiveDescendantChangedEvent {
 		} else {
 			msg.body().deserialize()?
 		};
-		Self::try_from_validated_message_parts(item, body)
+		Self::from_message_unchecked_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -796,7 +796,7 @@ impl BusProperties for AnnouncementEvent {
 impl MessageConversion for AnnouncementEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		item: ObjectRef,
 		body: Self::Body,
 	) -> Result<Self, AtspiError> {
@@ -806,7 +806,7 @@ impl MessageConversion for AnnouncementEvent {
 			live: body.detail1.try_into()?,
 		})
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = if msg.body().signature().ok_or(AtspiError::MissingSignature)?
 			== crate::events::QSPI_EVENT_SIGNATURE
@@ -815,7 +815,7 @@ impl MessageConversion for AnnouncementEvent {
 		} else {
 			msg.body().deserialize()?
 		};
-		Self::try_from_validated_message_parts(item, body)
+		Self::from_message_unchecked_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -907,7 +907,7 @@ impl BusProperties for TextChangedEvent {
 impl MessageConversion for TextChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		item: ObjectRef,
 		body: Self::Body,
 	) -> Result<Self, AtspiError> {
@@ -919,7 +919,7 @@ impl MessageConversion for TextChangedEvent {
 			text: body.any_data.try_into()?,
 		})
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = if msg.body().signature().ok_or(AtspiError::MissingSignature)?
 			== crate::events::QSPI_EVENT_SIGNATURE
@@ -928,7 +928,7 @@ impl MessageConversion for TextChangedEvent {
 		} else {
 			msg.body().deserialize()?
 		};
-		Self::try_from_validated_message_parts(item, body)
+		Self::from_message_unchecked_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -956,13 +956,13 @@ impl BusProperties for TextCaretMovedEvent {
 impl MessageConversion for TextCaretMovedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		item: ObjectRef,
 		body: Self::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item, position: body.detail1 })
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = if msg.body().signature().ok_or(AtspiError::MissingSignature)?
 			== crate::events::QSPI_EVENT_SIGNATURE
@@ -971,7 +971,7 @@ impl MessageConversion for TextCaretMovedEvent {
 		} else {
 			msg.body().deserialize()?
 		};
-		Self::try_from_validated_message_parts(item, body)
+		Self::from_message_unchecked_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -990,70 +990,70 @@ impl EventWrapperMessageConversion for ObjectEvents {
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
 			PropertyChangeEvent::DBUS_MEMBER => Ok(ObjectEvents::PropertyChange(
-				PropertyChangeEvent::try_from_validated_message(msg)?,
+				PropertyChangeEvent::from_message_unchecked(msg)?,
 			)),
 			BoundsChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::BoundsChanged(
-				BoundsChangedEvent::try_from_validated_message(msg)?,
+				BoundsChangedEvent::from_message_unchecked(msg)?,
 			)),
 			LinkSelectedEvent::DBUS_MEMBER => {
-				Ok(ObjectEvents::LinkSelected(LinkSelectedEvent::try_from_validated_message(msg)?))
+				Ok(ObjectEvents::LinkSelected(LinkSelectedEvent::from_message_unchecked(msg)?))
 			}
 			StateChangedEvent::DBUS_MEMBER => {
-				Ok(ObjectEvents::StateChanged(StateChangedEvent::try_from_validated_message(msg)?))
+				Ok(ObjectEvents::StateChanged(StateChangedEvent::from_message_unchecked(msg)?))
 			}
 			ChildrenChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::ChildrenChanged(
-				ChildrenChangedEvent::try_from_validated_message(msg)?,
+				ChildrenChangedEvent::from_message_unchecked(msg)?,
 			)),
 			VisibleDataChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::VisibleDataChanged(
-				VisibleDataChangedEvent::try_from_validated_message(msg)?,
+				VisibleDataChangedEvent::from_message_unchecked(msg)?,
 			)),
 			SelectionChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::SelectionChanged(
-				SelectionChangedEvent::try_from_validated_message(msg)?,
+				SelectionChangedEvent::from_message_unchecked(msg)?,
 			)),
 			ModelChangedEvent::DBUS_MEMBER => {
-				Ok(ObjectEvents::ModelChanged(ModelChangedEvent::try_from_validated_message(msg)?))
+				Ok(ObjectEvents::ModelChanged(ModelChangedEvent::from_message_unchecked(msg)?))
 			}
 			ActiveDescendantChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::ActiveDescendantChanged(
-				ActiveDescendantChangedEvent::try_from_validated_message(msg)?,
+				ActiveDescendantChangedEvent::from_message_unchecked(msg)?,
 			)),
 			AnnouncementEvent::DBUS_MEMBER => {
-				Ok(ObjectEvents::Announcement(AnnouncementEvent::try_from_validated_message(msg)?))
+				Ok(ObjectEvents::Announcement(AnnouncementEvent::from_message_unchecked(msg)?))
 			}
 			AttributesChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::AttributesChanged(
-				AttributesChangedEvent::try_from_validated_message(msg)?,
+				AttributesChangedEvent::from_message_unchecked(msg)?,
 			)),
 			RowInsertedEvent::DBUS_MEMBER => {
-				Ok(ObjectEvents::RowInserted(RowInsertedEvent::try_from_validated_message(msg)?))
+				Ok(ObjectEvents::RowInserted(RowInsertedEvent::from_message_unchecked(msg)?))
 			}
 			RowReorderedEvent::DBUS_MEMBER => {
-				Ok(ObjectEvents::RowReordered(RowReorderedEvent::try_from_validated_message(msg)?))
+				Ok(ObjectEvents::RowReordered(RowReorderedEvent::from_message_unchecked(msg)?))
 			}
 			RowDeletedEvent::DBUS_MEMBER => {
-				Ok(ObjectEvents::RowDeleted(RowDeletedEvent::try_from_validated_message(msg)?))
+				Ok(ObjectEvents::RowDeleted(RowDeletedEvent::from_message_unchecked(msg)?))
 			}
 			ColumnInsertedEvent::DBUS_MEMBER => Ok(ObjectEvents::ColumnInserted(
-				ColumnInsertedEvent::try_from_validated_message(msg)?,
+				ColumnInsertedEvent::from_message_unchecked(msg)?,
 			)),
 			ColumnReorderedEvent::DBUS_MEMBER => Ok(ObjectEvents::ColumnReordered(
-				ColumnReorderedEvent::try_from_validated_message(msg)?,
+				ColumnReorderedEvent::from_message_unchecked(msg)?,
 			)),
 			ColumnDeletedEvent::DBUS_MEMBER => Ok(ObjectEvents::ColumnDeleted(
-				ColumnDeletedEvent::try_from_validated_message(msg)?,
+				ColumnDeletedEvent::from_message_unchecked(msg)?,
 			)),
 			TextBoundsChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::TextBoundsChanged(
-				TextBoundsChangedEvent::try_from_validated_message(msg)?,
+				TextBoundsChangedEvent::from_message_unchecked(msg)?,
 			)),
 			TextSelectionChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::TextSelectionChanged(
-				TextSelectionChangedEvent::try_from_validated_message(msg)?,
+				TextSelectionChangedEvent::from_message_unchecked(msg)?,
 			)),
 			TextChangedEvent::DBUS_MEMBER => {
-				Ok(ObjectEvents::TextChanged(TextChangedEvent::try_from_validated_message(msg)?))
+				Ok(ObjectEvents::TextChanged(TextChangedEvent::from_message_unchecked(msg)?))
 			}
 			TextAttributesChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::TextAttributesChanged(
-				TextAttributesChangedEvent::try_from_validated_message(msg)?,
+				TextAttributesChangedEvent::from_message_unchecked(msg)?,
 			)),
 			TextCaretMovedEvent::DBUS_MEMBER => Ok(ObjectEvents::TextCaretMoved(
-				TextCaretMovedEvent::try_from_validated_message(msg)?,
+				TextCaretMovedEvent::from_message_unchecked(msg)?,
 			)),
 			_ => Err(AtspiError::MemberMatch(format!(
 				"No matching member {member} for interface {}",

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -604,9 +604,13 @@ impl BusProperties for PropertyChangeEvent {
 impl MessageConversion for PropertyChangeEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
-		let property = body.kind.clone();
-		let value: Property = body.try_into()?;
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError> {
+		let ev_body: Self::Body = body.deserialize_unchecked()?;
+		let property = ev_body.kind.to_string();
+		let value: Property = ev_body.try_into()?;
 		Ok(Self { item, property, value })
 	}
 	fn body(&self) -> Self::Body {
@@ -629,7 +633,7 @@ impl MessageConversion for BoundsChangedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -653,7 +657,7 @@ impl MessageConversion for LinkSelectedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -675,8 +679,12 @@ impl BusProperties for StateChangedEvent {
 impl MessageConversion for StateChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item, state: body.kind.into(), enabled: body.detail1 > 0 })
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError> {
+		let ev_body: Self::Body = body.deserialize_unchecked()?;
+		Ok(Self { item, state: ev_body.kind.into(), enabled: ev_body.detail1 > 0 })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -696,12 +704,16 @@ impl BusProperties for ChildrenChangedEvent {
 impl MessageConversion for ChildrenChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError> {
+		let ev_body: Self::Body = body.deserialize_unchecked()?;
 		Ok(Self {
 			item,
-			operation: body.kind.as_str().parse()?,
-			index_in_parent: body.detail1,
-			child: body.any_data.try_into()?,
+			operation: ev_body.kind.as_str().parse()?,
+			index_in_parent: ev_body.detail1,
+			child: ev_body.any_data.try_into()?,
 		})
 	}
 	fn body(&self) -> Self::Body {
@@ -724,7 +736,7 @@ impl MessageConversion for VisibleDataChangedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -748,7 +760,7 @@ impl MessageConversion for SelectionChangedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -772,7 +784,7 @@ impl MessageConversion for ModelChangedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -794,8 +806,11 @@ impl BusProperties for ActiveDescendantChangedEvent {
 impl MessageConversion for ActiveDescendantChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item, child: body.any_data.try_into()? })
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError> {
+		Ok(Self { item, child: body.deserialize_unchecked::<Self::Body>()?.any_data.try_into()? })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -815,11 +830,18 @@ impl BusProperties for AnnouncementEvent {
 impl MessageConversion for AnnouncementEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError> {
+		let ev_body: Self::Body = body.deserialize_unchecked()?;
 		Ok(Self {
 			item,
-			text: body.any_data.try_into().map_err(|_| AtspiError::Conversion("text"))?,
-			live: body.detail1.try_into()?,
+			text: ev_body
+				.any_data
+				.try_into()
+				.map_err(|_| AtspiError::Conversion("text"))?,
+			live: ev_body.detail1.try_into()?,
 		})
 	}
 	fn body(&self) -> Self::Body {
@@ -842,7 +864,7 @@ impl MessageConversion for AttributesChangedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -866,7 +888,7 @@ impl MessageConversion for RowInsertedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -890,7 +912,7 @@ impl MessageConversion for RowReorderedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -914,7 +936,7 @@ impl MessageConversion for RowDeletedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -938,7 +960,7 @@ impl MessageConversion for ColumnInsertedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -962,7 +984,7 @@ impl MessageConversion for ColumnReorderedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -986,7 +1008,7 @@ impl MessageConversion for ColumnDeletedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -1010,7 +1032,7 @@ impl MessageConversion for TextBoundsChangedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -1034,7 +1056,7 @@ impl MessageConversion for TextSelectionChangedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -1056,13 +1078,17 @@ impl BusProperties for TextChangedEvent {
 impl MessageConversion for TextChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError> {
+		let ev_body: Self::Body = body.deserialize_unchecked()?;
 		Ok(Self {
 			item,
-			operation: body.kind.as_str().parse()?,
-			start_pos: body.detail1,
-			length: body.detail2,
-			text: body.any_data.try_into()?,
+			operation: ev_body.kind.as_str().parse()?,
+			start_pos: ev_body.detail1,
+			length: ev_body.detail2,
+			text: ev_body.any_data.try_into()?,
 		})
 	}
 	fn body(&self) -> Self::Body {
@@ -1085,7 +1111,7 @@ impl MessageConversion for TextAttributesChangedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -1107,8 +1133,11 @@ impl BusProperties for TextCaretMovedEvent {
 impl MessageConversion for TextCaretMovedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item, position: body.detail1 })
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError> {
+		Ok(Self { item, position: body.deserialize_unchecked::<Self::Body>()?.detail1 })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -604,7 +604,7 @@ impl BusProperties for PropertyChangeEvent {
 impl MessageConversion for PropertyChangeEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -631,7 +631,7 @@ impl BusProperties for BoundsChangedEvent {
 impl MessageConversion for BoundsChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -655,7 +655,7 @@ impl BusProperties for LinkSelectedEvent {
 impl MessageConversion for LinkSelectedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -679,7 +679,7 @@ impl BusProperties for StateChangedEvent {
 impl MessageConversion for StateChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -704,7 +704,7 @@ impl BusProperties for ChildrenChangedEvent {
 impl MessageConversion for ChildrenChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -734,7 +734,7 @@ impl BusProperties for VisibleDataChangedEvent {
 impl MessageConversion for VisibleDataChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -758,7 +758,7 @@ impl BusProperties for SelectionChangedEvent {
 impl MessageConversion for SelectionChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -782,7 +782,7 @@ impl BusProperties for ModelChangedEvent {
 impl MessageConversion for ModelChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -806,7 +806,7 @@ impl BusProperties for ActiveDescendantChangedEvent {
 impl MessageConversion for ActiveDescendantChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -830,7 +830,7 @@ impl BusProperties for AnnouncementEvent {
 impl MessageConversion for AnnouncementEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -862,7 +862,7 @@ impl BusProperties for AttributesChangedEvent {
 impl MessageConversion for AttributesChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -886,7 +886,7 @@ impl BusProperties for RowInsertedEvent {
 impl MessageConversion for RowInsertedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -910,7 +910,7 @@ impl BusProperties for RowReorderedEvent {
 impl MessageConversion for RowReorderedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -934,7 +934,7 @@ impl BusProperties for RowDeletedEvent {
 impl MessageConversion for RowDeletedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -958,7 +958,7 @@ impl BusProperties for ColumnInsertedEvent {
 impl MessageConversion for ColumnInsertedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -982,7 +982,7 @@ impl BusProperties for ColumnReorderedEvent {
 impl MessageConversion for ColumnReorderedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -1006,7 +1006,7 @@ impl BusProperties for ColumnDeletedEvent {
 impl MessageConversion for ColumnDeletedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -1030,7 +1030,7 @@ impl BusProperties for TextBoundsChangedEvent {
 impl MessageConversion for TextBoundsChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -1054,7 +1054,7 @@ impl BusProperties for TextSelectionChangedEvent {
 impl MessageConversion for TextSelectionChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -1078,7 +1078,7 @@ impl BusProperties for TextChangedEvent {
 impl MessageConversion for TextChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -1109,7 +1109,7 @@ impl BusProperties for TextAttributesChangedEvent {
 impl MessageConversion for TextAttributesChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -1133,7 +1133,7 @@ impl BusProperties for TextCaretMovedEvent {
 impl MessageConversion for TextCaretMovedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -609,10 +609,7 @@ impl BusProperties for PropertyChangeEvent {
 impl MessageConversion for PropertyChangeEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_unchecked_parts(
-		item: ObjectRef,
-		body: Self::Body,
-	) -> Result<Self, AtspiError> {
+	fn from_message_unchecked_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		let property = body.kind.to_string();
 		let value: Property = body.try_into()?;
 		Ok(Self { item, property, value })
@@ -662,10 +659,7 @@ impl BusProperties for StateChangedEvent {
 impl MessageConversion for StateChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_unchecked_parts(
-		item: ObjectRef,
-		body: Self::Body,
-	) -> Result<Self, AtspiError> {
+	fn from_message_unchecked_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, state: body.kind.into(), enabled: body.detail1 > 0 })
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
@@ -697,10 +691,7 @@ impl BusProperties for ChildrenChangedEvent {
 impl MessageConversion for ChildrenChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_unchecked_parts(
-		item: ObjectRef,
-		body: Self::Body,
-	) -> Result<Self, AtspiError> {
+	fn from_message_unchecked_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self {
 			item,
 			operation: body.kind.as_str().parse()?,
@@ -761,10 +752,7 @@ impl BusProperties for ActiveDescendantChangedEvent {
 impl MessageConversion for ActiveDescendantChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_unchecked_parts(
-		item: ObjectRef,
-		body: Self::Body,
-	) -> Result<Self, AtspiError> {
+	fn from_message_unchecked_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, child: body.any_data.try_into()? })
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
@@ -796,10 +784,7 @@ impl BusProperties for AnnouncementEvent {
 impl MessageConversion for AnnouncementEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_unchecked_parts(
-		item: ObjectRef,
-		body: Self::Body,
-	) -> Result<Self, AtspiError> {
+	fn from_message_unchecked_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self {
 			item,
 			text: body.any_data.try_into().map_err(|_| AtspiError::Conversion("text"))?,
@@ -907,10 +892,7 @@ impl BusProperties for TextChangedEvent {
 impl MessageConversion for TextChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_unchecked_parts(
-		item: ObjectRef,
-		body: Self::Body,
-	) -> Result<Self, AtspiError> {
+	fn from_message_unchecked_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self {
 			item,
 			operation: body.kind.as_str().parse()?,
@@ -956,10 +938,7 @@ impl BusProperties for TextCaretMovedEvent {
 impl MessageConversion for TextCaretMovedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_unchecked_parts(
-		item: ObjectRef,
-		body: Self::Body,
-	) -> Result<Self, AtspiError> {
+	fn from_message_unchecked_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, position: body.detail1 })
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
@@ -989,12 +968,12 @@ impl EventWrapperMessageConversion for ObjectEvents {
 		let header = msg.header();
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
-			PropertyChangeEvent::DBUS_MEMBER => Ok(ObjectEvents::PropertyChange(
-				PropertyChangeEvent::from_message_unchecked(msg)?,
-			)),
-			BoundsChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::BoundsChanged(
-				BoundsChangedEvent::from_message_unchecked(msg)?,
-			)),
+			PropertyChangeEvent::DBUS_MEMBER => {
+				Ok(ObjectEvents::PropertyChange(PropertyChangeEvent::from_message_unchecked(msg)?))
+			}
+			BoundsChangedEvent::DBUS_MEMBER => {
+				Ok(ObjectEvents::BoundsChanged(BoundsChangedEvent::from_message_unchecked(msg)?))
+			}
 			LinkSelectedEvent::DBUS_MEMBER => {
 				Ok(ObjectEvents::LinkSelected(LinkSelectedEvent::from_message_unchecked(msg)?))
 			}
@@ -1031,15 +1010,15 @@ impl EventWrapperMessageConversion for ObjectEvents {
 			RowDeletedEvent::DBUS_MEMBER => {
 				Ok(ObjectEvents::RowDeleted(RowDeletedEvent::from_message_unchecked(msg)?))
 			}
-			ColumnInsertedEvent::DBUS_MEMBER => Ok(ObjectEvents::ColumnInserted(
-				ColumnInsertedEvent::from_message_unchecked(msg)?,
-			)),
+			ColumnInsertedEvent::DBUS_MEMBER => {
+				Ok(ObjectEvents::ColumnInserted(ColumnInsertedEvent::from_message_unchecked(msg)?))
+			}
 			ColumnReorderedEvent::DBUS_MEMBER => Ok(ObjectEvents::ColumnReordered(
 				ColumnReorderedEvent::from_message_unchecked(msg)?,
 			)),
-			ColumnDeletedEvent::DBUS_MEMBER => Ok(ObjectEvents::ColumnDeleted(
-				ColumnDeletedEvent::from_message_unchecked(msg)?,
-			)),
+			ColumnDeletedEvent::DBUS_MEMBER => {
+				Ok(ObjectEvents::ColumnDeleted(ColumnDeletedEvent::from_message_unchecked(msg)?))
+			}
 			TextBoundsChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::TextBoundsChanged(
 				TextBoundsChangedEvent::from_message_unchecked(msg)?,
 			)),
@@ -1052,9 +1031,9 @@ impl EventWrapperMessageConversion for ObjectEvents {
 			TextAttributesChangedEvent::DBUS_MEMBER => Ok(ObjectEvents::TextAttributesChanged(
 				TextAttributesChangedEvent::from_message_unchecked(msg)?,
 			)),
-			TextCaretMovedEvent::DBUS_MEMBER => Ok(ObjectEvents::TextCaretMoved(
-				TextCaretMovedEvent::from_message_unchecked(msg)?,
-			)),
+			TextCaretMovedEvent::DBUS_MEMBER => {
+				Ok(ObjectEvents::TextCaretMoved(TextCaretMovedEvent::from_message_unchecked(msg)?))
+			}
 			_ => Err(AtspiError::MemberMatch(format!(
 				"No matching member {member} for interface {}",
 				Self::DBUS_INTERFACE,

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -183,19 +183,19 @@ impl EventWrapperMessageConversion for TerminalEvents {
 			.ok_or(AtspiError::MemberMatch("Event without member".into()))?;
 		match member.as_str() {
 			LineChangedEvent::DBUS_MEMBER => {
-				Ok(TerminalEvents::LineChanged(LineChangedEvent::try_from_message_unchecked(msg)?))
+				Ok(TerminalEvents::LineChanged(LineChangedEvent::try_from_validated_message(msg)?))
 			}
 			ColumnCountChangedEvent::DBUS_MEMBER => Ok(TerminalEvents::ColumnCountChanged(
-				ColumnCountChangedEvent::try_from_message_unchecked(msg)?,
+				ColumnCountChangedEvent::try_from_validated_message(msg)?,
 			)),
 			LineCountChangedEvent::DBUS_MEMBER => Ok(TerminalEvents::LineCountChanged(
-				LineCountChangedEvent::try_from_message_unchecked(msg)?,
+				LineCountChangedEvent::try_from_validated_message(msg)?,
 			)),
 			ApplicationChangedEvent::DBUS_MEMBER => Ok(TerminalEvents::ApplicationChanged(
-				ApplicationChangedEvent::try_from_message_unchecked(msg)?,
+				ApplicationChangedEvent::try_from_validated_message(msg)?,
 			)),
 			CharWidthChangedEvent::DBUS_MEMBER => Ok(TerminalEvents::CharWidthChanged(
-				CharWidthChangedEvent::try_from_message_unchecked(msg)?,
+				CharWidthChangedEvent::try_from_validated_message(msg)?,
 			)),
 			_ => Err(AtspiError::MemberMatch("No matching member for Terminal".into())),
 		}

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -185,19 +185,19 @@ impl EventWrapperMessageConversion for TerminalEvents {
 			.ok_or(AtspiError::MemberMatch("Event without member".into()))?;
 		match member.as_str() {
 			LineChangedEvent::DBUS_MEMBER => {
-				Ok(TerminalEvents::LineChanged(LineChangedEvent::try_from_validated_message(msg)?))
+				Ok(TerminalEvents::LineChanged(LineChangedEvent::from_message_unchecked(msg)?))
 			}
 			ColumnCountChangedEvent::DBUS_MEMBER => Ok(TerminalEvents::ColumnCountChanged(
-				ColumnCountChangedEvent::try_from_validated_message(msg)?,
+				ColumnCountChangedEvent::from_message_unchecked(msg)?,
 			)),
 			LineCountChangedEvent::DBUS_MEMBER => Ok(TerminalEvents::LineCountChanged(
-				LineCountChangedEvent::try_from_validated_message(msg)?,
+				LineCountChangedEvent::from_message_unchecked(msg)?,
 			)),
 			ApplicationChangedEvent::DBUS_MEMBER => Ok(TerminalEvents::ApplicationChanged(
-				ApplicationChangedEvent::try_from_validated_message(msg)?,
+				ApplicationChangedEvent::from_message_unchecked(msg)?,
 			)),
 			CharWidthChangedEvent::DBUS_MEMBER => Ok(TerminalEvents::CharWidthChanged(
-				CharWidthChangedEvent::try_from_validated_message(msg)?,
+				CharWidthChangedEvent::from_message_unchecked(msg)?,
 			)),
 			_ => Err(AtspiError::MemberMatch("No matching member for Terminal".into())),
 		}

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -4,7 +4,7 @@ use crate::{
 	error::AtspiError,
 	events::{
 		BusProperties, EventWrapperMessageConversion, HasInterfaceName, HasMatchRule,
-		HasRegistryEventString,
+		HasRegistryEventString, TryFromMessage,
 	},
 	Event, EventProperties, EventTypeProperties,
 };
@@ -209,16 +209,7 @@ impl EventWrapperMessageConversion for TerminalEvents {
 impl TryFrom<&zbus::Message> for TerminalEvents {
 	type Error = AtspiError;
 	fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
-		let header = msg.header();
-		let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
-		if interface != TerminalEvents::DBUS_INTERFACE {
-			return Err(AtspiError::InterfaceMatch(format!(
-				"Interface {} does not match require interface for event: {}",
-				interface,
-				TerminalEvents::DBUS_INTERFACE
-			)));
-		}
-		Self::try_from_message_interface_checked(msg)
+		Self::try_from_message(msg)
 	}
 }
 

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -142,10 +142,8 @@ impl BusProperties for LineChangedEvent {
 impl MessageConversion for LineChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -166,10 +164,8 @@ impl BusProperties for ColumnCountChangedEvent {
 impl MessageConversion for ColumnCountChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -190,10 +186,8 @@ impl BusProperties for LineCountChangedEvent {
 impl MessageConversion for LineCountChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -214,10 +208,8 @@ impl BusProperties for ApplicationChangedEvent {
 impl MessageConversion for ApplicationChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -238,10 +230,8 @@ impl BusProperties for CharWidthChangedEvent {
 impl MessageConversion for CharWidthChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -138,40 +138,12 @@ impl BusProperties for LineChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Terminal:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for LineChangedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for ColumnCountChangedEvent {
 	const DBUS_MEMBER: &'static str = "ColumncountChanged";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Terminal";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Terminal',member='ColumncountChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Terminal:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for ColumnCountChangedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 impl BusProperties for LineCountChangedEvent {
@@ -182,20 +154,6 @@ impl BusProperties for LineCountChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Terminal:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for LineCountChangedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for ApplicationChangedEvent {
 	const DBUS_MEMBER: &'static str = "ApplicationChanged";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Terminal";
@@ -204,40 +162,12 @@ impl BusProperties for ApplicationChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Terminal:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for ApplicationChangedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for CharWidthChangedEvent {
 	const DBUS_MEMBER: &'static str = "CharwidthChanged";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Terminal";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Terminal',member='CharwidthChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Terminal:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for CharWidthChangedEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 #[cfg(feature = "zbus")]
@@ -274,6 +204,7 @@ event_test_cases!(LineChangedEvent);
 impl_to_dbus_message!(LineChangedEvent);
 impl_from_dbus_message!(LineChangedEvent);
 impl_event_properties!(LineChangedEvent);
+impl_from_object_ref!(LineChangedEvent);
 impl From<LineChangedEvent> for EventBodyOwned {
 	fn from(_event: LineChangedEvent) -> Self {
 		EventBodyOwned {
@@ -301,6 +232,7 @@ event_test_cases!(ColumnCountChangedEvent);
 impl_to_dbus_message!(ColumnCountChangedEvent);
 impl_from_dbus_message!(ColumnCountChangedEvent);
 impl_event_properties!(ColumnCountChangedEvent);
+impl_from_object_ref!(ColumnCountChangedEvent);
 impl From<ColumnCountChangedEvent> for EventBodyOwned {
 	fn from(_event: ColumnCountChangedEvent) -> Self {
 		EventBodyOwned {
@@ -328,6 +260,7 @@ event_test_cases!(LineCountChangedEvent);
 impl_to_dbus_message!(LineCountChangedEvent);
 impl_from_dbus_message!(LineCountChangedEvent);
 impl_event_properties!(LineCountChangedEvent);
+impl_from_object_ref!(LineCountChangedEvent);
 impl From<LineCountChangedEvent> for EventBodyOwned {
 	fn from(_event: LineCountChangedEvent) -> Self {
 		EventBodyOwned {
@@ -355,6 +288,7 @@ event_test_cases!(ApplicationChangedEvent);
 impl_to_dbus_message!(ApplicationChangedEvent);
 impl_from_dbus_message!(ApplicationChangedEvent);
 impl_event_properties!(ApplicationChangedEvent);
+impl_from_object_ref!(ApplicationChangedEvent);
 impl From<ApplicationChangedEvent> for EventBodyOwned {
 	fn from(_event: ApplicationChangedEvent) -> Self {
 		EventBodyOwned {
@@ -382,6 +316,7 @@ event_test_cases!(CharWidthChangedEvent);
 impl_to_dbus_message!(CharWidthChangedEvent);
 impl_from_dbus_message!(CharWidthChangedEvent);
 impl_event_properties!(CharWidthChangedEvent);
+impl_from_object_ref!(CharWidthChangedEvent);
 impl From<CharWidthChangedEvent> for EventBodyOwned {
 	fn from(_event: CharWidthChangedEvent) -> Self {
 		EventBodyOwned {

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -1,9 +1,8 @@
+#[cfg(feature = "zbus")]
+use crate::events::{MessageConversion, ObjectRef};
 use crate::{
 	error::AtspiError,
-	events::{
-		BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, MessageConversion,
-		ObjectRef,
-	},
+	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;
@@ -139,6 +138,7 @@ impl BusProperties for LineChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Terminal:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for LineChangedEvent {
 	type Body = EventBodyOwned;
 
@@ -162,6 +162,7 @@ impl BusProperties for ColumnCountChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Terminal:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for ColumnCountChangedEvent {
 	type Body = EventBodyOwned;
 
@@ -185,6 +186,7 @@ impl BusProperties for LineCountChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Terminal:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for LineCountChangedEvent {
 	type Body = EventBodyOwned;
 
@@ -208,6 +210,7 @@ impl BusProperties for ApplicationChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Terminal:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for ApplicationChangedEvent {
 	type Body = EventBodyOwned;
 
@@ -231,6 +234,7 @@ impl BusProperties for CharWidthChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Terminal:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for CharWidthChangedEvent {
 	type Body = EventBodyOwned;
 

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "zbus")]
-use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage};
+use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage, MessageConversionExt};
 use crate::{
 	error::AtspiError,
 	events::{BusProperties, HasInterfaceName, HasMatchRule, HasRegistryEventString},

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "zbus")]
-use crate::events::{MessageConversion, ObjectRef};
+use crate::events::MessageConversion;
 use crate::{
 	error::AtspiError,
 	events::{BusProperties, HasMatchRule, HasRegistryEventString},

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -182,19 +182,19 @@ impl EventWrapperMessageConversion for TerminalEvents {
 			.member()
 			.ok_or(AtspiError::MemberMatch("Event without member".into()))?;
 		match member.as_str() {
-			"LineChanged" => {
+			LineChangedEvent::DBUS_MEMBER => {
 				Ok(TerminalEvents::LineChanged(LineChangedEvent::try_from_message_unchecked(msg)?))
 			}
-			"ColumncountChanged" => Ok(TerminalEvents::ColumnCountChanged(
+			ColumnCountChangedEvent::DBUS_MEMBER => Ok(TerminalEvents::ColumnCountChanged(
 				ColumnCountChangedEvent::try_from_message_unchecked(msg)?,
 			)),
-			"LinecountChanged" => Ok(TerminalEvents::LineCountChanged(
+			LineCountChangedEvent::DBUS_MEMBER => Ok(TerminalEvents::LineCountChanged(
 				LineCountChangedEvent::try_from_message_unchecked(msg)?,
 			)),
-			"ApplicationChanged" => Ok(TerminalEvents::ApplicationChanged(
+			ApplicationChangedEvent::DBUS_MEMBER => Ok(TerminalEvents::ApplicationChanged(
 				ApplicationChangedEvent::try_from_message_unchecked(msg)?,
 			)),
-			"CharwidthChanged" => Ok(TerminalEvents::CharWidthChanged(
+			CharWidthChangedEvent::DBUS_MEMBER => Ok(TerminalEvents::CharWidthChanged(
 				CharWidthChangedEvent::try_from_message_unchecked(msg)?,
 			)),
 			_ => Err(AtspiError::MemberMatch("No matching member for Terminal".into())),

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -1,6 +1,9 @@
 use crate::{
 	error::AtspiError,
-	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, ObjectRef},
+	events::{
+		BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, MessageConversion,
+		ObjectRef,
+	},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;
@@ -134,10 +137,15 @@ impl BusProperties for LineChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Terminal',member='LineChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Terminal:";
+}
 
+impl MessageConversion for LineChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -152,10 +160,15 @@ impl BusProperties for ColumnCountChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Terminal',member='ColumncountChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Terminal:";
+}
 
+impl MessageConversion for ColumnCountChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -170,10 +183,15 @@ impl BusProperties for LineCountChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Terminal',member='LinecountChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Terminal:";
+}
 
+impl MessageConversion for LineCountChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -188,10 +206,15 @@ impl BusProperties for ApplicationChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Terminal',member='ApplicationChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Terminal:";
+}
 
+impl MessageConversion for ApplicationChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -206,10 +229,15 @@ impl BusProperties for CharWidthChangedEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Terminal',member='CharwidthChanged'";
 	const REGISTRY_EVENT_STRING: &'static str = "Terminal:";
+}
 
+impl MessageConversion for CharWidthChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -96,7 +96,7 @@ impl HasMatchRule for TerminalEvents {
 /// A line of text has been changed.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct LineChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
@@ -104,7 +104,7 @@ pub struct LineChangedEvent {
 /// able to fit on one *visual* line has changed.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct ColumnCountChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
@@ -112,13 +112,13 @@ pub struct ColumnCountChangedEvent {
 /// able to fit within the terminal has changed.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct LineCountChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct ApplicationChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
@@ -126,7 +126,7 @@ pub struct ApplicationChangedEvent {
 /// able to fit on one *visual* line has changed.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct CharWidthChangedEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -1,11 +1,8 @@
 #[cfg(feature = "zbus")]
-use crate::events::MessageConversion;
+use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage};
 use crate::{
 	error::AtspiError,
-	events::{
-		BusProperties, EventWrapperMessageConversion, HasInterfaceName, HasMatchRule,
-		HasRegistryEventString, TryFromMessage,
-	},
+	events::{BusProperties, HasInterfaceName, HasMatchRule, HasRegistryEventString},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "zbus")]
-use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage, MessageConversionExt};
+use crate::events::{
+	EventWrapperMessageConversion, MessageConversion, MessageConversionExt, TryFromMessage,
+};
 use crate::{
 	error::AtspiError,
 	events::{BusProperties, HasInterfaceName, HasMatchRule, HasRegistryEventString},

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -142,7 +142,7 @@ impl BusProperties for LineChangedEvent {
 impl MessageConversion for LineChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -166,7 +166,7 @@ impl BusProperties for ColumnCountChangedEvent {
 impl MessageConversion for ColumnCountChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -190,7 +190,7 @@ impl BusProperties for LineCountChangedEvent {
 impl MessageConversion for LineCountChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -214,7 +214,7 @@ impl BusProperties for ApplicationChangedEvent {
 impl MessageConversion for ApplicationChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -238,7 +238,7 @@ impl BusProperties for CharWidthChangedEvent {
 impl MessageConversion for CharWidthChangedEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -2,7 +2,7 @@
 use crate::events::{MessageConversion, ObjectRef};
 use crate::{
 	error::AtspiError,
-	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString},
+	events::{BusProperties, HasMatchRule, HasRegistryEventString},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;
@@ -205,17 +205,6 @@ impl_to_dbus_message!(LineChangedEvent);
 impl_from_dbus_message!(LineChangedEvent);
 impl_event_properties!(LineChangedEvent);
 impl_from_object_ref!(LineChangedEvent);
-impl From<LineChangedEvent> for EventBodyOwned {
-	fn from(_event: LineChangedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	ColumnCountChangedEvent,
@@ -233,17 +222,6 @@ impl_to_dbus_message!(ColumnCountChangedEvent);
 impl_from_dbus_message!(ColumnCountChangedEvent);
 impl_event_properties!(ColumnCountChangedEvent);
 impl_from_object_ref!(ColumnCountChangedEvent);
-impl From<ColumnCountChangedEvent> for EventBodyOwned {
-	fn from(_event: ColumnCountChangedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	LineCountChangedEvent,
@@ -261,17 +239,6 @@ impl_to_dbus_message!(LineCountChangedEvent);
 impl_from_dbus_message!(LineCountChangedEvent);
 impl_event_properties!(LineCountChangedEvent);
 impl_from_object_ref!(LineCountChangedEvent);
-impl From<LineCountChangedEvent> for EventBodyOwned {
-	fn from(_event: LineCountChangedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	ApplicationChangedEvent,
@@ -289,17 +256,6 @@ impl_to_dbus_message!(ApplicationChangedEvent);
 impl_from_dbus_message!(ApplicationChangedEvent);
 impl_event_properties!(ApplicationChangedEvent);
 impl_from_object_ref!(ApplicationChangedEvent);
-impl From<ApplicationChangedEvent> for EventBodyOwned {
-	fn from(_event: ApplicationChangedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	CharWidthChangedEvent,
@@ -317,17 +273,6 @@ impl_to_dbus_message!(CharWidthChangedEvent);
 impl_from_dbus_message!(CharWidthChangedEvent);
 impl_event_properties!(CharWidthChangedEvent);
 impl_from_object_ref!(CharWidthChangedEvent);
-impl From<CharWidthChangedEvent> for EventBodyOwned {
-	fn from(_event: CharWidthChangedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl HasRegistryEventString for TerminalEvents {
 	const REGISTRY_EVENT_STRING: &'static str = "Terminal:";

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -144,7 +144,7 @@ impl MessageConversion for LineChangedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -168,7 +168,7 @@ impl MessageConversion for ColumnCountChangedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -192,7 +192,7 @@ impl MessageConversion for LineCountChangedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -216,7 +216,7 @@ impl MessageConversion for ApplicationChangedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -240,7 +240,7 @@ impl MessageConversion for CharWidthChangedEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}

--- a/atspi-common/src/events/terminal.rs
+++ b/atspi-common/src/events/terminal.rs
@@ -2,7 +2,7 @@
 use crate::events::MessageConversion;
 use crate::{
 	error::AtspiError,
-	events::{BusProperties, HasMatchRule, HasRegistryEventString},
+	events::{BusProperties, HasInterfaceName, HasMatchRule, HasRegistryEventString},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;
@@ -170,20 +170,42 @@ impl BusProperties for CharWidthChangedEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Terminal:";
 }
 
+impl HasInterfaceName for TerminalEvents {
+	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Terminal";
+}
+
 #[cfg(feature = "zbus")]
 impl TryFrom<&zbus::Message> for TerminalEvents {
 	type Error = AtspiError;
-	fn try_from(ev: &zbus::Message) -> Result<Self, Self::Error> {
-		let header = ev.header();
+	fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
+		let header = msg.header();
 		let member = header
 			.member()
 			.ok_or(AtspiError::MemberMatch("Event without member".into()))?;
+		let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
+		if interface != TerminalEvents::DBUS_INTERFACE {
+			return Err(AtspiError::InterfaceMatch(format!(
+				"Interface {} does not match require interface for event: {}",
+				interface,
+				TerminalEvents::DBUS_INTERFACE
+			)));
+		}
 		match member.as_str() {
-			"LineChanged" => Ok(TerminalEvents::LineChanged(ev.try_into()?)),
-			"ColumncountChanged" => Ok(TerminalEvents::ColumnCountChanged(ev.try_into()?)),
-			"LinecountChanged" => Ok(TerminalEvents::LineCountChanged(ev.try_into()?)),
-			"ApplicationChanged" => Ok(TerminalEvents::ApplicationChanged(ev.try_into()?)),
-			"CharwidthChanged" => Ok(TerminalEvents::CharWidthChanged(ev.try_into()?)),
+			"LineChanged" => {
+				Ok(TerminalEvents::LineChanged(LineChangedEvent::try_from_message_unchecked(msg)?))
+			}
+			"ColumncountChanged" => Ok(TerminalEvents::ColumnCountChanged(
+				ColumnCountChangedEvent::try_from_message_unchecked(msg)?,
+			)),
+			"LinecountChanged" => Ok(TerminalEvents::LineCountChanged(
+				LineCountChangedEvent::try_from_message_unchecked(msg)?,
+			)),
+			"ApplicationChanged" => Ok(TerminalEvents::ApplicationChanged(
+				ApplicationChangedEvent::try_from_message_unchecked(msg)?,
+			)),
+			"CharwidthChanged" => Ok(TerminalEvents::CharWidthChanged(
+				CharWidthChangedEvent::try_from_message_unchecked(msg)?,
+			)),
 			_ => Err(AtspiError::MemberMatch("No matching member for Terminal".into())),
 		}
 	}

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -345,13 +345,13 @@ impl BusProperties for PropertyChangeEvent {
 impl MessageConversion for PropertyChangeEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_validated_message_parts(
+	fn from_message_unchecked_parts(
 		item: ObjectRef,
 		body: Self::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item, property: body.kind })
 	}
-	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = if msg.body().signature().ok_or(AtspiError::MissingSignature)?
 			== crate::events::QSPI_EVENT_SIGNATURE
@@ -360,7 +360,7 @@ impl MessageConversion for PropertyChangeEvent {
 		} else {
 			msg.body().deserialize()?
 		};
-		Self::try_from_validated_message_parts(item, body)
+		Self::from_message_unchecked_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -523,44 +523,44 @@ impl EventWrapperMessageConversion for WindowEvents {
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
 			PropertyChangeEvent::DBUS_MEMBER => Ok(WindowEvents::PropertyChange(
-				PropertyChangeEvent::try_from_validated_message(msg)?,
+				PropertyChangeEvent::from_message_unchecked(msg)?,
 			)),
 			MinimizeEvent::DBUS_MEMBER => {
-				Ok(WindowEvents::Minimize(MinimizeEvent::try_from_validated_message(msg)?))
+				Ok(WindowEvents::Minimize(MinimizeEvent::from_message_unchecked(msg)?))
 			}
 			MaximizeEvent::DBUS_MEMBER => {
-				Ok(WindowEvents::Maximize(MaximizeEvent::try_from_validated_message(msg)?))
+				Ok(WindowEvents::Maximize(MaximizeEvent::from_message_unchecked(msg)?))
 			}
 			RestoreEvent::DBUS_MEMBER => {
-				Ok(WindowEvents::Restore(RestoreEvent::try_from_validated_message(msg)?))
+				Ok(WindowEvents::Restore(RestoreEvent::from_message_unchecked(msg)?))
 			}
-			"Close" => Ok(WindowEvents::Close(CloseEvent::try_from_validated_message(msg)?)),
+			"Close" => Ok(WindowEvents::Close(CloseEvent::from_message_unchecked(msg)?)),
 			CreateEvent::DBUS_MEMBER => {
-				Ok(WindowEvents::Create(CreateEvent::try_from_validated_message(msg)?))
+				Ok(WindowEvents::Create(CreateEvent::from_message_unchecked(msg)?))
 			}
 			ReparentEvent::DBUS_MEMBER => {
-				Ok(WindowEvents::Reparent(ReparentEvent::try_from_validated_message(msg)?))
+				Ok(WindowEvents::Reparent(ReparentEvent::from_message_unchecked(msg)?))
 			}
 			"DesktopCreate" => Ok(WindowEvents::DesktopCreate(
-				DesktopCreateEvent::try_from_validated_message(msg)?,
+				DesktopCreateEvent::from_message_unchecked(msg)?,
 			)),
 			"DesktopDestroy" => Ok(WindowEvents::DesktopDestroy(
-				DesktopDestroyEvent::try_from_validated_message(msg)?,
+				DesktopDestroyEvent::from_message_unchecked(msg)?,
 			)),
-			"Destroy" => Ok(WindowEvents::Destroy(DestroyEvent::try_from_validated_message(msg)?)),
+			"Destroy" => Ok(WindowEvents::Destroy(DestroyEvent::from_message_unchecked(msg)?)),
 			"Activate" => {
-				Ok(WindowEvents::Activate(ActivateEvent::try_from_validated_message(msg)?))
+				Ok(WindowEvents::Activate(ActivateEvent::from_message_unchecked(msg)?))
 			}
 			"Deactivate" => {
-				Ok(WindowEvents::Deactivate(DeactivateEvent::try_from_validated_message(msg)?))
+				Ok(WindowEvents::Deactivate(DeactivateEvent::from_message_unchecked(msg)?))
 			}
-			"Raise" => Ok(WindowEvents::Raise(RaiseEvent::try_from_validated_message(msg)?)),
-			"Lower" => Ok(WindowEvents::Lower(LowerEvent::try_from_validated_message(msg)?)),
-			"Move" => Ok(WindowEvents::Move(MoveEvent::try_from_validated_message(msg)?)),
-			"Resize" => Ok(WindowEvents::Resize(ResizeEvent::try_from_validated_message(msg)?)),
-			"Shade" => Ok(WindowEvents::Shade(ShadeEvent::try_from_validated_message(msg)?)),
-			"uUshade" => Ok(WindowEvents::UUshade(UUshadeEvent::try_from_validated_message(msg)?)),
-			"Restyle" => Ok(WindowEvents::Restyle(RestyleEvent::try_from_validated_message(msg)?)),
+			"Raise" => Ok(WindowEvents::Raise(RaiseEvent::from_message_unchecked(msg)?)),
+			"Lower" => Ok(WindowEvents::Lower(LowerEvent::from_message_unchecked(msg)?)),
+			"Move" => Ok(WindowEvents::Move(MoveEvent::from_message_unchecked(msg)?)),
+			"Resize" => Ok(WindowEvents::Resize(ResizeEvent::from_message_unchecked(msg)?)),
+			"Shade" => Ok(WindowEvents::Shade(ShadeEvent::from_message_unchecked(msg)?)),
+			"uUshade" => Ok(WindowEvents::UUshade(UUshadeEvent::from_message_unchecked(msg)?)),
+			"Restyle" => Ok(WindowEvents::Restyle(RestyleEvent::from_message_unchecked(msg)?)),
 			_ => Err(AtspiError::MemberMatch("No matching member for Window".into())),
 		}
 	}

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -3,7 +3,8 @@ use crate::events::MessageConversion;
 use crate::{
 	error::AtspiError,
 	events::{
-		BusProperties, EventBodyOwned, HasInterfaceName, HasMatchRule, HasRegistryEventString,
+		BusProperties, EventBodyOwned, EventWrapperMessageConversion, HasInterfaceName,
+		HasMatchRule, HasRegistryEventString,
 	},
 	Event, EventProperties, EventTypeProperties,
 };
@@ -500,19 +501,10 @@ impl HasInterfaceName for WindowEvents {
 }
 
 #[cfg(feature = "zbus")]
-impl TryFrom<&zbus::Message> for WindowEvents {
-	type Error = AtspiError;
-	fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
+impl EventWrapperMessageConversion for WindowEvents {
+	fn try_from_message_interface_checked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let header = msg.header();
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
-		let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
-		if interface != WindowEvents::DBUS_INTERFACE {
-			return Err(AtspiError::InterfaceMatch(format!(
-				"Interface {} does not match require interface for event: {}",
-				interface,
-				WindowEvents::DBUS_INTERFACE
-			)));
-		}
 		match member.as_str() {
 			"PropertyChange" => Ok(WindowEvents::PropertyChange(
 				PropertyChangeEvent::try_from_message_unchecked(msg)?,
@@ -551,6 +543,23 @@ impl TryFrom<&zbus::Message> for WindowEvents {
 			"Restyle" => Ok(WindowEvents::Restyle(RestyleEvent::try_from_message_unchecked(msg)?)),
 			_ => Err(AtspiError::MemberMatch("No matching member for Window".into())),
 		}
+	}
+}
+
+#[cfg(feature = "zbus")]
+impl TryFrom<&zbus::Message> for WindowEvents {
+	type Error = AtspiError;
+	fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
+		let header = msg.header();
+		let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
+		if interface != WindowEvents::DBUS_INTERFACE {
+			return Err(AtspiError::InterfaceMatch(format!(
+				"Interface {} does not match require interface for event: {}",
+				interface,
+				WindowEvents::DBUS_INTERFACE
+			)));
+		}
+		Self::try_from_message_interface_checked(msg)
 	}
 }
 

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -345,10 +345,7 @@ impl BusProperties for PropertyChangeEvent {
 impl MessageConversion for PropertyChangeEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_unchecked_parts(
-		item: ObjectRef,
-		body: Self::Body,
-	) -> Result<Self, AtspiError> {
+	fn from_message_unchecked_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, property: body.kind })
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
@@ -522,9 +519,9 @@ impl EventWrapperMessageConversion for WindowEvents {
 		let header = msg.header();
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
-			PropertyChangeEvent::DBUS_MEMBER => Ok(WindowEvents::PropertyChange(
-				PropertyChangeEvent::from_message_unchecked(msg)?,
-			)),
+			PropertyChangeEvent::DBUS_MEMBER => {
+				Ok(WindowEvents::PropertyChange(PropertyChangeEvent::from_message_unchecked(msg)?))
+			}
 			MinimizeEvent::DBUS_MEMBER => {
 				Ok(WindowEvents::Minimize(MinimizeEvent::from_message_unchecked(msg)?))
 			}
@@ -541,16 +538,14 @@ impl EventWrapperMessageConversion for WindowEvents {
 			ReparentEvent::DBUS_MEMBER => {
 				Ok(WindowEvents::Reparent(ReparentEvent::from_message_unchecked(msg)?))
 			}
-			"DesktopCreate" => Ok(WindowEvents::DesktopCreate(
-				DesktopCreateEvent::from_message_unchecked(msg)?,
-			)),
-			"DesktopDestroy" => Ok(WindowEvents::DesktopDestroy(
-				DesktopDestroyEvent::from_message_unchecked(msg)?,
-			)),
-			"Destroy" => Ok(WindowEvents::Destroy(DestroyEvent::from_message_unchecked(msg)?)),
-			"Activate" => {
-				Ok(WindowEvents::Activate(ActivateEvent::from_message_unchecked(msg)?))
+			"DesktopCreate" => {
+				Ok(WindowEvents::DesktopCreate(DesktopCreateEvent::from_message_unchecked(msg)?))
 			}
+			"DesktopDestroy" => {
+				Ok(WindowEvents::DesktopDestroy(DesktopDestroyEvent::from_message_unchecked(msg)?))
+			}
+			"Destroy" => Ok(WindowEvents::Destroy(DestroyEvent::from_message_unchecked(msg)?)),
+			"Activate" => Ok(WindowEvents::Activate(ActivateEvent::from_message_unchecked(msg)?)),
 			"Deactivate" => {
 				Ok(WindowEvents::Deactivate(DeactivateEvent::from_message_unchecked(msg)?))
 			}

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -1,9 +1,8 @@
+#[cfg(feature = "zbus")]
+use crate::events::{MessageConversion, ObjectRef};
 use crate::{
 	error::AtspiError,
-	events::{
-		BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, MessageConversion,
-		ObjectRef,
-	},
+	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;
@@ -335,6 +334,7 @@ impl BusProperties for PropertyChangeEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for PropertyChangeEvent {
 	type Body = EventBodyOwned;
 
@@ -355,6 +355,7 @@ impl BusProperties for MinimizeEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for MinimizeEvent {
 	type Body = EventBodyOwned;
 
@@ -378,6 +379,7 @@ impl BusProperties for MaximizeEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for MaximizeEvent {
 	type Body = EventBodyOwned;
 
@@ -401,6 +403,7 @@ impl BusProperties for RestoreEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for RestoreEvent {
 	type Body = EventBodyOwned;
 
@@ -424,6 +427,7 @@ impl BusProperties for CloseEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for CloseEvent {
 	type Body = EventBodyOwned;
 
@@ -447,6 +451,7 @@ impl BusProperties for CreateEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for CreateEvent {
 	type Body = EventBodyOwned;
 
@@ -470,6 +475,7 @@ impl BusProperties for ReparentEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for ReparentEvent {
 	type Body = EventBodyOwned;
 
@@ -493,6 +499,7 @@ impl BusProperties for DesktopCreateEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for DesktopCreateEvent {
 	type Body = EventBodyOwned;
 
@@ -516,6 +523,7 @@ impl BusProperties for DesktopDestroyEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for DesktopDestroyEvent {
 	type Body = EventBodyOwned;
 
@@ -539,6 +547,7 @@ impl BusProperties for DestroyEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for DestroyEvent {
 	type Body = EventBodyOwned;
 
@@ -562,6 +571,7 @@ impl BusProperties for ActivateEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for ActivateEvent {
 	type Body = EventBodyOwned;
 
@@ -585,6 +595,7 @@ impl BusProperties for DeactivateEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for DeactivateEvent {
 	type Body = EventBodyOwned;
 
@@ -608,6 +619,7 @@ impl BusProperties for RaiseEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for RaiseEvent {
 	type Body = EventBodyOwned;
 
@@ -631,6 +643,7 @@ impl BusProperties for LowerEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for LowerEvent {
 	type Body = EventBodyOwned;
 
@@ -654,6 +667,7 @@ impl BusProperties for MoveEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for MoveEvent {
 	type Body = EventBodyOwned;
 
@@ -677,6 +691,7 @@ impl BusProperties for ResizeEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for ResizeEvent {
 	type Body = EventBodyOwned;
 
@@ -700,6 +715,7 @@ impl BusProperties for ShadeEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for ShadeEvent {
 	type Body = EventBodyOwned;
 
@@ -723,6 +739,7 @@ impl BusProperties for UUshadeEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for UUshadeEvent {
 	type Body = EventBodyOwned;
 
@@ -746,6 +763,7 @@ impl BusProperties for RestyleEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
+#[cfg(feature = "zbus")]
 impl MessageConversion for RestyleEvent {
 	type Body = EventBodyOwned;
 

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -1,10 +1,9 @@
 #[cfg(feature = "zbus")]
-use crate::events::MessageConversion;
+use crate::events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage};
 use crate::{
 	error::AtspiError,
 	events::{
-		BusProperties, EventBodyOwned, EventWrapperMessageConversion, HasInterfaceName,
-		HasMatchRule, HasRegistryEventString, TryFromMessage,
+		BusProperties, EventBodyOwned, HasInterfaceName, HasMatchRule, HasRegistryEventString,
 	},
 	Event, EventProperties, EventTypeProperties,
 };

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -565,17 +565,6 @@ impl_to_dbus_message!(MinimizeEvent);
 impl_from_dbus_message!(MinimizeEvent);
 impl_event_properties!(MinimizeEvent);
 impl_from_object_ref!(MinimizeEvent);
-impl From<MinimizeEvent> for EventBodyOwned {
-	fn from(_event: MinimizeEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	MaximizeEvent,
@@ -589,17 +578,6 @@ impl_to_dbus_message!(MaximizeEvent);
 impl_from_dbus_message!(MaximizeEvent);
 impl_event_properties!(MaximizeEvent);
 impl_from_object_ref!(MaximizeEvent);
-impl From<MaximizeEvent> for EventBodyOwned {
-	fn from(_event: MaximizeEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	RestoreEvent,
@@ -613,17 +591,6 @@ impl_to_dbus_message!(RestoreEvent);
 impl_from_dbus_message!(RestoreEvent);
 impl_event_properties!(RestoreEvent);
 impl_from_object_ref!(RestoreEvent);
-impl From<RestoreEvent> for EventBodyOwned {
-	fn from(_event: RestoreEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	CloseEvent,
@@ -637,17 +604,6 @@ impl_to_dbus_message!(CloseEvent);
 impl_from_dbus_message!(CloseEvent);
 impl_event_properties!(CloseEvent);
 impl_from_object_ref!(CloseEvent);
-impl From<CloseEvent> for EventBodyOwned {
-	fn from(_event: CloseEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	CreateEvent,
@@ -661,17 +617,6 @@ impl_to_dbus_message!(CreateEvent);
 impl_from_dbus_message!(CreateEvent);
 impl_event_properties!(CreateEvent);
 impl_from_object_ref!(CreateEvent);
-impl From<CreateEvent> for EventBodyOwned {
-	fn from(_event: CreateEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	ReparentEvent,
@@ -685,17 +630,6 @@ impl_to_dbus_message!(ReparentEvent);
 impl_from_dbus_message!(ReparentEvent);
 impl_event_properties!(ReparentEvent);
 impl_from_object_ref!(ReparentEvent);
-impl From<ReparentEvent> for EventBodyOwned {
-	fn from(_event: ReparentEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	DesktopCreateEvent,
@@ -713,17 +647,6 @@ impl_to_dbus_message!(DesktopCreateEvent);
 impl_from_dbus_message!(DesktopCreateEvent);
 impl_event_properties!(DesktopCreateEvent);
 impl_from_object_ref!(DesktopCreateEvent);
-impl From<DesktopCreateEvent> for EventBodyOwned {
-	fn from(_event: DesktopCreateEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	DesktopDestroyEvent,
@@ -741,17 +664,6 @@ impl_to_dbus_message!(DesktopDestroyEvent);
 impl_from_dbus_message!(DesktopDestroyEvent);
 impl_event_properties!(DesktopDestroyEvent);
 impl_from_object_ref!(DesktopDestroyEvent);
-impl From<DesktopDestroyEvent> for EventBodyOwned {
-	fn from(_event: DesktopDestroyEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	DestroyEvent,
@@ -765,17 +677,6 @@ impl_to_dbus_message!(DestroyEvent);
 impl_from_dbus_message!(DestroyEvent);
 impl_event_properties!(DestroyEvent);
 impl_from_object_ref!(DestroyEvent);
-impl From<DestroyEvent> for EventBodyOwned {
-	fn from(_event: DestroyEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	ActivateEvent,
@@ -789,17 +690,6 @@ impl_to_dbus_message!(ActivateEvent);
 impl_from_dbus_message!(ActivateEvent);
 impl_event_properties!(ActivateEvent);
 impl_from_object_ref!(ActivateEvent);
-impl From<ActivateEvent> for EventBodyOwned {
-	fn from(_event: ActivateEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	DeactivateEvent,
@@ -813,17 +703,6 @@ impl_to_dbus_message!(DeactivateEvent);
 impl_from_dbus_message!(DeactivateEvent);
 impl_event_properties!(DeactivateEvent);
 impl_from_object_ref!(DeactivateEvent);
-impl From<DeactivateEvent> for EventBodyOwned {
-	fn from(_event: DeactivateEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	RaiseEvent,
@@ -837,17 +716,6 @@ impl_to_dbus_message!(RaiseEvent);
 impl_from_dbus_message!(RaiseEvent);
 impl_event_properties!(RaiseEvent);
 impl_from_object_ref!(RaiseEvent);
-impl From<RaiseEvent> for EventBodyOwned {
-	fn from(_event: RaiseEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	LowerEvent,
@@ -861,17 +729,6 @@ impl_to_dbus_message!(LowerEvent);
 impl_from_dbus_message!(LowerEvent);
 impl_event_properties!(LowerEvent);
 impl_from_object_ref!(LowerEvent);
-impl From<LowerEvent> for EventBodyOwned {
-	fn from(_event: LowerEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(MoveEvent, WindowEvents, WindowEvents::Move);
 impl_from_user_facing_type_for_event_enum!(MoveEvent, Event::Window);
@@ -881,17 +738,6 @@ impl_to_dbus_message!(MoveEvent);
 impl_from_dbus_message!(MoveEvent);
 impl_event_properties!(MoveEvent);
 impl_from_object_ref!(MoveEvent);
-impl From<MoveEvent> for EventBodyOwned {
-	fn from(_event: MoveEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	ResizeEvent,
@@ -905,17 +751,6 @@ impl_to_dbus_message!(ResizeEvent);
 impl_from_dbus_message!(ResizeEvent);
 impl_event_properties!(ResizeEvent);
 impl_from_object_ref!(ResizeEvent);
-impl From<ResizeEvent> for EventBodyOwned {
-	fn from(_event: ResizeEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	ShadeEvent,
@@ -929,17 +764,6 @@ impl_to_dbus_message!(ShadeEvent);
 impl_from_dbus_message!(ShadeEvent);
 impl_event_properties!(ShadeEvent);
 impl_from_object_ref!(ShadeEvent);
-impl From<ShadeEvent> for EventBodyOwned {
-	fn from(_event: ShadeEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: zvariant::Value::U8(0).try_into().unwrap(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	UUshadeEvent,
@@ -953,17 +777,6 @@ impl_to_dbus_message!(UUshadeEvent);
 impl_from_dbus_message!(UUshadeEvent);
 impl_event_properties!(UUshadeEvent);
 impl_from_object_ref!(UUshadeEvent);
-impl From<UUshadeEvent> for EventBodyOwned {
-	fn from(_event: UUshadeEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: zvariant::Value::U8(0).try_into().unwrap(),
-		}
-	}
-}
 
 impl_from_user_facing_event_for_interface_event_enum!(
 	RestyleEvent,
@@ -977,17 +790,6 @@ impl_to_dbus_message!(RestyleEvent);
 impl_from_dbus_message!(RestyleEvent);
 impl_event_properties!(RestyleEvent);
 impl_from_object_ref!(RestyleEvent);
-impl From<RestyleEvent> for EventBodyOwned {
-	fn from(_event: RestyleEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
-	}
-}
 
 impl HasRegistryEventString for WindowEvents {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -338,8 +338,11 @@ impl BusProperties for PropertyChangeEvent {
 impl MessageConversion for PropertyChangeEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
-		Ok(Self { item, property: body.kind })
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		body: zbus::message::Body,
+	) -> Result<Self, AtspiError> {
+		Ok(Self { item, property: body.deserialize_unchecked::<Self::Body>()?.kind })
 	}
 	fn body(&self) -> Self::Body {
 		let copy = self.clone();
@@ -361,7 +364,7 @@ impl MessageConversion for MinimizeEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -385,7 +388,7 @@ impl MessageConversion for MaximizeEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -409,7 +412,7 @@ impl MessageConversion for RestoreEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -433,7 +436,7 @@ impl MessageConversion for CloseEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -457,7 +460,7 @@ impl MessageConversion for CreateEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -481,7 +484,7 @@ impl MessageConversion for ReparentEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -505,7 +508,7 @@ impl MessageConversion for DesktopCreateEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -529,7 +532,7 @@ impl MessageConversion for DesktopDestroyEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -553,7 +556,7 @@ impl MessageConversion for DestroyEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -577,7 +580,7 @@ impl MessageConversion for ActivateEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -601,7 +604,7 @@ impl MessageConversion for DeactivateEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -625,7 +628,7 @@ impl MessageConversion for RaiseEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -649,7 +652,7 @@ impl MessageConversion for LowerEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -673,7 +676,7 @@ impl MessageConversion for MoveEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -697,7 +700,7 @@ impl MessageConversion for ResizeEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -721,7 +724,7 @@ impl MessageConversion for ShadeEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -745,7 +748,7 @@ impl MessageConversion for UUshadeEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
@@ -769,7 +772,7 @@ impl MessageConversion for RestyleEvent {
 
 	fn from_message_parts_unchecked(
 		item: ObjectRef,
-		_body: Self::Body,
+		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -338,10 +338,9 @@ impl BusProperties for PropertyChangeEvent {
 impl MessageConversion for PropertyChangeEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
+		let body = msg.body();
 		Ok(Self { item, property: body.deserialize_unchecked::<Self::Body>()?.kind })
 	}
 	fn body(&self) -> Self::Body {
@@ -362,10 +361,8 @@ impl BusProperties for MinimizeEvent {
 impl MessageConversion for MinimizeEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -386,10 +383,8 @@ impl BusProperties for MaximizeEvent {
 impl MessageConversion for MaximizeEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -410,10 +405,8 @@ impl BusProperties for RestoreEvent {
 impl MessageConversion for RestoreEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -434,10 +427,8 @@ impl BusProperties for CloseEvent {
 impl MessageConversion for CloseEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -458,10 +449,8 @@ impl BusProperties for CreateEvent {
 impl MessageConversion for CreateEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -482,10 +471,8 @@ impl BusProperties for ReparentEvent {
 impl MessageConversion for ReparentEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -506,10 +493,8 @@ impl BusProperties for DesktopCreateEvent {
 impl MessageConversion for DesktopCreateEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -530,10 +515,8 @@ impl BusProperties for DesktopDestroyEvent {
 impl MessageConversion for DesktopDestroyEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -554,10 +537,8 @@ impl BusProperties for DestroyEvent {
 impl MessageConversion for DestroyEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -578,10 +559,8 @@ impl BusProperties for ActivateEvent {
 impl MessageConversion for ActivateEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -602,10 +581,8 @@ impl BusProperties for DeactivateEvent {
 impl MessageConversion for DeactivateEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -626,10 +603,8 @@ impl BusProperties for RaiseEvent {
 impl MessageConversion for RaiseEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -650,10 +625,8 @@ impl BusProperties for LowerEvent {
 impl MessageConversion for LowerEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -674,10 +647,8 @@ impl BusProperties for MoveEvent {
 impl MessageConversion for MoveEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -698,10 +669,8 @@ impl BusProperties for ResizeEvent {
 impl MessageConversion for ResizeEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -722,10 +691,8 @@ impl BusProperties for ShadeEvent {
 impl MessageConversion for ShadeEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -746,10 +713,8 @@ impl BusProperties for UUshadeEvent {
 impl MessageConversion for UUshadeEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -770,10 +735,8 @@ impl BusProperties for RestyleEvent {
 impl MessageConversion for RestyleEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(
-		item: ObjectRef,
-		_body: zbus::message::Body,
-	) -> Result<Self, AtspiError> {
+	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+		let item = msg.try_into()?;
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -505,19 +505,23 @@ impl EventWrapperMessageConversion for WindowEvents {
 		let header = msg.header();
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
-			"PropertyChange" => Ok(WindowEvents::PropertyChange(
+			PropertyChangeEvent::DBUS_MEMBER => Ok(WindowEvents::PropertyChange(
 				PropertyChangeEvent::try_from_message_unchecked(msg)?,
 			)),
-			"Minimize" => {
+			MinimizeEvent::DBUS_MEMBER => {
 				Ok(WindowEvents::Minimize(MinimizeEvent::try_from_message_unchecked(msg)?))
 			}
-			"Maximize" => {
+			MaximizeEvent::DBUS_MEMBER => {
 				Ok(WindowEvents::Maximize(MaximizeEvent::try_from_message_unchecked(msg)?))
 			}
-			"Restore" => Ok(WindowEvents::Restore(RestoreEvent::try_from_message_unchecked(msg)?)),
+			RestoreEvent::DBUS_MEMBER => {
+				Ok(WindowEvents::Restore(RestoreEvent::try_from_message_unchecked(msg)?))
+			}
 			"Close" => Ok(WindowEvents::Close(CloseEvent::try_from_message_unchecked(msg)?)),
-			"Create" => Ok(WindowEvents::Create(CreateEvent::try_from_message_unchecked(msg)?)),
-			"Reparent" => {
+			CreateEvent::DBUS_MEMBER => {
+				Ok(WindowEvents::Create(CreateEvent::try_from_message_unchecked(msg)?))
+			}
+			ReparentEvent::DBUS_MEMBER => {
 				Ok(WindowEvents::Reparent(ReparentEvent::try_from_message_unchecked(msg)?))
 			}
 			"DesktopCreate" => Ok(WindowEvents::DesktopCreate(

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -353,7 +353,13 @@ impl MessageConversion for PropertyChangeEvent {
 	}
 	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
-		let body = msg.body().deserialize()?;
+		let body = if msg.body().signature().ok_or(AtspiError::MissingSignature)?
+			== crate::events::QSPI_EVENT_SIGNATURE
+		{
+			msg.body().deserialize::<crate::events::EventBodyQT>()?.into()
+		} else {
+			msg.body().deserialize()?
+		};
 		Self::try_from_validated_message_parts(item, body)
 	}
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -1,6 +1,9 @@
 use crate::{
 	error::AtspiError,
-	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, ObjectRef},
+	events::{
+		BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString, MessageConversion,
+		ObjectRef,
+	},
 	Event, EventProperties, EventTypeProperties,
 };
 use zbus_names::UniqueName;
@@ -330,10 +333,12 @@ impl BusProperties for PropertyChangeEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='PropertyChange'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for PropertyChangeEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(item: ObjectRef, body: Self::Body) -> Result<Self, AtspiError> {
 		Ok(Self { item, property: body.kind })
 	}
 	fn body(&self) -> Self::Body {
@@ -348,10 +353,15 @@ impl BusProperties for MinimizeEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Minimize'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for MinimizeEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -366,10 +376,15 @@ impl BusProperties for MaximizeEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Maximize'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for MaximizeEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -384,10 +399,15 @@ impl BusProperties for RestoreEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Restore'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for RestoreEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -402,10 +422,15 @@ impl BusProperties for CloseEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Close'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for CloseEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -420,10 +445,15 @@ impl BusProperties for CreateEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Create'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for CreateEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -438,10 +468,15 @@ impl BusProperties for ReparentEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Reparent'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for ReparentEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -456,10 +491,15 @@ impl BusProperties for DesktopCreateEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='DesktopCreate'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for DesktopCreateEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -474,10 +514,15 @@ impl BusProperties for DesktopDestroyEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='DesktopDestroy'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for DesktopDestroyEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -492,10 +537,15 @@ impl BusProperties for DestroyEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Destroy'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for DestroyEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -510,10 +560,15 @@ impl BusProperties for ActivateEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Activate'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for ActivateEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -528,10 +583,15 @@ impl BusProperties for DeactivateEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Deactivate'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for DeactivateEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -546,10 +606,15 @@ impl BusProperties for RaiseEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Raise'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for RaiseEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -564,10 +629,15 @@ impl BusProperties for LowerEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Lower'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for LowerEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -582,10 +652,15 @@ impl BusProperties for MoveEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Move'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for MoveEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -600,10 +675,15 @@ impl BusProperties for ResizeEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Resize'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for ResizeEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -618,10 +698,15 @@ impl BusProperties for ShadeEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Shade'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for ShadeEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -636,10 +721,15 @@ impl BusProperties for UUshadeEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='uUshade'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for UUshadeEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {
@@ -654,10 +744,15 @@ impl BusProperties for RestyleEvent {
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Restyle'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
+}
 
+impl MessageConversion for RestyleEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts(item: ObjectRef, _body: Self::Body) -> Result<Self, AtspiError> {
+	fn from_message_parts_unchecked(
+		item: ObjectRef,
+		_body: Self::Body,
+	) -> Result<Self, AtspiError> {
 		Ok(Self { item })
 	}
 	fn body(&self) -> Self::Body {

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -338,7 +338,7 @@ impl BusProperties for PropertyChangeEvent {
 impl MessageConversion for PropertyChangeEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -362,7 +362,7 @@ impl BusProperties for MinimizeEvent {
 impl MessageConversion for MinimizeEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -386,7 +386,7 @@ impl BusProperties for MaximizeEvent {
 impl MessageConversion for MaximizeEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -410,7 +410,7 @@ impl BusProperties for RestoreEvent {
 impl MessageConversion for RestoreEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -434,7 +434,7 @@ impl BusProperties for CloseEvent {
 impl MessageConversion for CloseEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -458,7 +458,7 @@ impl BusProperties for CreateEvent {
 impl MessageConversion for CreateEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -482,7 +482,7 @@ impl BusProperties for ReparentEvent {
 impl MessageConversion for ReparentEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -506,7 +506,7 @@ impl BusProperties for DesktopCreateEvent {
 impl MessageConversion for DesktopCreateEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -530,7 +530,7 @@ impl BusProperties for DesktopDestroyEvent {
 impl MessageConversion for DesktopDestroyEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -554,7 +554,7 @@ impl BusProperties for DestroyEvent {
 impl MessageConversion for DestroyEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -578,7 +578,7 @@ impl BusProperties for ActivateEvent {
 impl MessageConversion for ActivateEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -602,7 +602,7 @@ impl BusProperties for DeactivateEvent {
 impl MessageConversion for DeactivateEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -626,7 +626,7 @@ impl BusProperties for RaiseEvent {
 impl MessageConversion for RaiseEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -650,7 +650,7 @@ impl BusProperties for LowerEvent {
 impl MessageConversion for LowerEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -674,7 +674,7 @@ impl BusProperties for MoveEvent {
 impl MessageConversion for MoveEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -698,7 +698,7 @@ impl BusProperties for ResizeEvent {
 impl MessageConversion for ResizeEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -722,7 +722,7 @@ impl BusProperties for ShadeEvent {
 impl MessageConversion for ShadeEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -746,7 +746,7 @@ impl BusProperties for UUshadeEvent {
 impl MessageConversion for UUshadeEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {
@@ -770,7 +770,7 @@ impl BusProperties for RestyleEvent {
 impl MessageConversion for RestyleEvent {
 	type Body = EventBodyOwned;
 
-	fn from_message_parts_unchecked(
+	fn try_from_message_unchecked(
 		item: ObjectRef,
 		_body: zbus::message::Body,
 	) -> Result<Self, AtspiError> {

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -206,7 +206,7 @@ impl HasMatchRule for WindowEvents {
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct PropertyChangeEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 	pub property: String,
 }
@@ -357,40 +357,12 @@ impl BusProperties for MinimizeEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for MinimizeEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for MaximizeEvent {
 	const DBUS_MEMBER: &'static str = "Maximize";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Window";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Maximize'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for MaximizeEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 impl BusProperties for RestoreEvent {
@@ -401,40 +373,12 @@ impl BusProperties for RestoreEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for RestoreEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for CloseEvent {
 	const DBUS_MEMBER: &'static str = "Close";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Window";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Close'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for CloseEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 impl BusProperties for CreateEvent {
@@ -445,40 +389,12 @@ impl BusProperties for CreateEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for CreateEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for ReparentEvent {
 	const DBUS_MEMBER: &'static str = "Reparent";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Window";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Reparent'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for ReparentEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 impl BusProperties for DesktopCreateEvent {
@@ -489,40 +405,12 @@ impl BusProperties for DesktopCreateEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for DesktopCreateEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for DesktopDestroyEvent {
 	const DBUS_MEMBER: &'static str = "DesktopDestroy";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Window";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='DesktopDestroy'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for DesktopDestroyEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 impl BusProperties for DestroyEvent {
@@ -533,40 +421,12 @@ impl BusProperties for DestroyEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for DestroyEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for ActivateEvent {
 	const DBUS_MEMBER: &'static str = "Activate";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Window";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Activate'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for ActivateEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 impl BusProperties for DeactivateEvent {
@@ -577,40 +437,12 @@ impl BusProperties for DeactivateEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for DeactivateEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for RaiseEvent {
 	const DBUS_MEMBER: &'static str = "Raise";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Window";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Raise'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for RaiseEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 impl BusProperties for LowerEvent {
@@ -621,40 +453,12 @@ impl BusProperties for LowerEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for LowerEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for MoveEvent {
 	const DBUS_MEMBER: &'static str = "Move";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Window";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Move'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for MoveEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 impl BusProperties for ResizeEvent {
@@ -665,40 +469,12 @@ impl BusProperties for ResizeEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for ResizeEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for ShadeEvent {
 	const DBUS_MEMBER: &'static str = "Shade";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Window";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Shade'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for ShadeEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 impl BusProperties for UUshadeEvent {
@@ -709,40 +485,12 @@ impl BusProperties for UUshadeEvent {
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
 }
 
-#[cfg(feature = "zbus")]
-impl MessageConversion for UUshadeEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
-}
-
 impl BusProperties for RestyleEvent {
 	const DBUS_MEMBER: &'static str = "Restyle";
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Event.Window";
 	const MATCH_RULE_STRING: &'static str =
 		"type='signal',interface='org.a11y.atspi.Event.Window',member='Restyle'";
 	const REGISTRY_EVENT_STRING: &'static str = "Window:";
-}
-
-#[cfg(feature = "zbus")]
-impl MessageConversion for RestyleEvent {
-	type Body = EventBodyOwned;
-
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
-		let item = msg.try_into()?;
-		Ok(Self { item })
-	}
-	fn body(&self) -> Self::Body {
-		let copy = self.clone();
-		copy.into()
-	}
 }
 
 #[cfg(feature = "zbus")]
@@ -816,6 +564,7 @@ event_test_cases!(MinimizeEvent);
 impl_to_dbus_message!(MinimizeEvent);
 impl_from_dbus_message!(MinimizeEvent);
 impl_event_properties!(MinimizeEvent);
+impl_from_object_ref!(MinimizeEvent);
 impl From<MinimizeEvent> for EventBodyOwned {
 	fn from(_event: MinimizeEvent) -> Self {
 		EventBodyOwned {
@@ -839,6 +588,7 @@ event_test_cases!(MaximizeEvent);
 impl_to_dbus_message!(MaximizeEvent);
 impl_from_dbus_message!(MaximizeEvent);
 impl_event_properties!(MaximizeEvent);
+impl_from_object_ref!(MaximizeEvent);
 impl From<MaximizeEvent> for EventBodyOwned {
 	fn from(_event: MaximizeEvent) -> Self {
 		EventBodyOwned {
@@ -862,6 +612,7 @@ event_test_cases!(RestoreEvent);
 impl_to_dbus_message!(RestoreEvent);
 impl_from_dbus_message!(RestoreEvent);
 impl_event_properties!(RestoreEvent);
+impl_from_object_ref!(RestoreEvent);
 impl From<RestoreEvent> for EventBodyOwned {
 	fn from(_event: RestoreEvent) -> Self {
 		EventBodyOwned {
@@ -885,6 +636,7 @@ event_test_cases!(CloseEvent);
 impl_to_dbus_message!(CloseEvent);
 impl_from_dbus_message!(CloseEvent);
 impl_event_properties!(CloseEvent);
+impl_from_object_ref!(CloseEvent);
 impl From<CloseEvent> for EventBodyOwned {
 	fn from(_event: CloseEvent) -> Self {
 		EventBodyOwned {
@@ -908,6 +660,7 @@ event_test_cases!(CreateEvent);
 impl_to_dbus_message!(CreateEvent);
 impl_from_dbus_message!(CreateEvent);
 impl_event_properties!(CreateEvent);
+impl_from_object_ref!(CreateEvent);
 impl From<CreateEvent> for EventBodyOwned {
 	fn from(_event: CreateEvent) -> Self {
 		EventBodyOwned {
@@ -931,6 +684,7 @@ event_test_cases!(ReparentEvent);
 impl_to_dbus_message!(ReparentEvent);
 impl_from_dbus_message!(ReparentEvent);
 impl_event_properties!(ReparentEvent);
+impl_from_object_ref!(ReparentEvent);
 impl From<ReparentEvent> for EventBodyOwned {
 	fn from(_event: ReparentEvent) -> Self {
 		EventBodyOwned {
@@ -958,6 +712,7 @@ event_test_cases!(DesktopCreateEvent);
 impl_to_dbus_message!(DesktopCreateEvent);
 impl_from_dbus_message!(DesktopCreateEvent);
 impl_event_properties!(DesktopCreateEvent);
+impl_from_object_ref!(DesktopCreateEvent);
 impl From<DesktopCreateEvent> for EventBodyOwned {
 	fn from(_event: DesktopCreateEvent) -> Self {
 		EventBodyOwned {
@@ -985,6 +740,7 @@ event_test_cases!(DesktopDestroyEvent);
 impl_to_dbus_message!(DesktopDestroyEvent);
 impl_from_dbus_message!(DesktopDestroyEvent);
 impl_event_properties!(DesktopDestroyEvent);
+impl_from_object_ref!(DesktopDestroyEvent);
 impl From<DesktopDestroyEvent> for EventBodyOwned {
 	fn from(_event: DesktopDestroyEvent) -> Self {
 		EventBodyOwned {
@@ -1008,6 +764,7 @@ event_test_cases!(DestroyEvent);
 impl_to_dbus_message!(DestroyEvent);
 impl_from_dbus_message!(DestroyEvent);
 impl_event_properties!(DestroyEvent);
+impl_from_object_ref!(DestroyEvent);
 impl From<DestroyEvent> for EventBodyOwned {
 	fn from(_event: DestroyEvent) -> Self {
 		EventBodyOwned {
@@ -1031,6 +788,7 @@ event_test_cases!(ActivateEvent);
 impl_to_dbus_message!(ActivateEvent);
 impl_from_dbus_message!(ActivateEvent);
 impl_event_properties!(ActivateEvent);
+impl_from_object_ref!(ActivateEvent);
 impl From<ActivateEvent> for EventBodyOwned {
 	fn from(_event: ActivateEvent) -> Self {
 		EventBodyOwned {
@@ -1054,6 +812,7 @@ event_test_cases!(DeactivateEvent);
 impl_to_dbus_message!(DeactivateEvent);
 impl_from_dbus_message!(DeactivateEvent);
 impl_event_properties!(DeactivateEvent);
+impl_from_object_ref!(DeactivateEvent);
 impl From<DeactivateEvent> for EventBodyOwned {
 	fn from(_event: DeactivateEvent) -> Self {
 		EventBodyOwned {
@@ -1077,6 +836,7 @@ event_test_cases!(RaiseEvent);
 impl_to_dbus_message!(RaiseEvent);
 impl_from_dbus_message!(RaiseEvent);
 impl_event_properties!(RaiseEvent);
+impl_from_object_ref!(RaiseEvent);
 impl From<RaiseEvent> for EventBodyOwned {
 	fn from(_event: RaiseEvent) -> Self {
 		EventBodyOwned {
@@ -1100,6 +860,7 @@ event_test_cases!(LowerEvent);
 impl_to_dbus_message!(LowerEvent);
 impl_from_dbus_message!(LowerEvent);
 impl_event_properties!(LowerEvent);
+impl_from_object_ref!(LowerEvent);
 impl From<LowerEvent> for EventBodyOwned {
 	fn from(_event: LowerEvent) -> Self {
 		EventBodyOwned {
@@ -1119,6 +880,7 @@ event_test_cases!(MoveEvent);
 impl_to_dbus_message!(MoveEvent);
 impl_from_dbus_message!(MoveEvent);
 impl_event_properties!(MoveEvent);
+impl_from_object_ref!(MoveEvent);
 impl From<MoveEvent> for EventBodyOwned {
 	fn from(_event: MoveEvent) -> Self {
 		EventBodyOwned {
@@ -1142,6 +904,7 @@ event_test_cases!(ResizeEvent);
 impl_to_dbus_message!(ResizeEvent);
 impl_from_dbus_message!(ResizeEvent);
 impl_event_properties!(ResizeEvent);
+impl_from_object_ref!(ResizeEvent);
 impl From<ResizeEvent> for EventBodyOwned {
 	fn from(_event: ResizeEvent) -> Self {
 		EventBodyOwned {
@@ -1165,6 +928,7 @@ event_test_cases!(ShadeEvent);
 impl_to_dbus_message!(ShadeEvent);
 impl_from_dbus_message!(ShadeEvent);
 impl_event_properties!(ShadeEvent);
+impl_from_object_ref!(ShadeEvent);
 impl From<ShadeEvent> for EventBodyOwned {
 	fn from(_event: ShadeEvent) -> Self {
 		EventBodyOwned {
@@ -1188,6 +952,7 @@ event_test_cases!(UUshadeEvent);
 impl_to_dbus_message!(UUshadeEvent);
 impl_from_dbus_message!(UUshadeEvent);
 impl_event_properties!(UUshadeEvent);
+impl_from_object_ref!(UUshadeEvent);
 impl From<UUshadeEvent> for EventBodyOwned {
 	fn from(_event: UUshadeEvent) -> Self {
 		EventBodyOwned {
@@ -1211,6 +976,7 @@ event_test_cases!(RestyleEvent);
 impl_to_dbus_message!(RestyleEvent);
 impl_from_dbus_message!(RestyleEvent);
 impl_event_properties!(RestyleEvent);
+impl_from_object_ref!(RestyleEvent);
 impl From<RestyleEvent> for EventBodyOwned {
 	fn from(_event: RestyleEvent) -> Self {
 		EventBodyOwned {

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -227,7 +227,7 @@ pub struct MaximizeEvent {
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct RestoreEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
@@ -247,7 +247,7 @@ pub struct CreateEvent {
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct ReparentEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
@@ -267,37 +267,37 @@ pub struct DesktopDestroyEvent {
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct DestroyEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct ActivateEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct DeactivateEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct RaiseEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct LowerEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct MoveEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
@@ -310,19 +310,19 @@ pub struct ResizeEvent {
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct ShadeEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct UUshadeEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct RestyleEvent {
-	/// The [`ObjectRef`] which the event applies to.
+	/// The [`crate::ObjectRef`] which the event applies to.
 	pub item: crate::events::ObjectRef,
 }
 

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -7,7 +7,9 @@ use crate::{
 };
 #[cfg(feature = "zbus")]
 use crate::{
-	events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage, MessageConversionExt},
+	events::{
+		EventWrapperMessageConversion, MessageConversion, MessageConversionExt, TryFromMessage,
+	},
 	ObjectRef,
 };
 use zbus_names::UniqueName;

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -340,7 +340,7 @@ impl BusProperties for PropertyChangeEvent {
 impl MessageConversion for PropertyChangeEvent {
 	type Body = EventBodyOwned;
 
-	fn try_from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
+	fn try_from_validated_message(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = msg.body();
 		Ok(Self { item, property: body.deserialize_unchecked::<Self::Body>()?.kind })
@@ -506,44 +506,44 @@ impl EventWrapperMessageConversion for WindowEvents {
 		let member = header.member().ok_or(AtspiError::MissingMember)?;
 		match member.as_str() {
 			PropertyChangeEvent::DBUS_MEMBER => Ok(WindowEvents::PropertyChange(
-				PropertyChangeEvent::try_from_message_unchecked(msg)?,
+				PropertyChangeEvent::try_from_validated_message(msg)?,
 			)),
 			MinimizeEvent::DBUS_MEMBER => {
-				Ok(WindowEvents::Minimize(MinimizeEvent::try_from_message_unchecked(msg)?))
+				Ok(WindowEvents::Minimize(MinimizeEvent::try_from_validated_message(msg)?))
 			}
 			MaximizeEvent::DBUS_MEMBER => {
-				Ok(WindowEvents::Maximize(MaximizeEvent::try_from_message_unchecked(msg)?))
+				Ok(WindowEvents::Maximize(MaximizeEvent::try_from_validated_message(msg)?))
 			}
 			RestoreEvent::DBUS_MEMBER => {
-				Ok(WindowEvents::Restore(RestoreEvent::try_from_message_unchecked(msg)?))
+				Ok(WindowEvents::Restore(RestoreEvent::try_from_validated_message(msg)?))
 			}
-			"Close" => Ok(WindowEvents::Close(CloseEvent::try_from_message_unchecked(msg)?)),
+			"Close" => Ok(WindowEvents::Close(CloseEvent::try_from_validated_message(msg)?)),
 			CreateEvent::DBUS_MEMBER => {
-				Ok(WindowEvents::Create(CreateEvent::try_from_message_unchecked(msg)?))
+				Ok(WindowEvents::Create(CreateEvent::try_from_validated_message(msg)?))
 			}
 			ReparentEvent::DBUS_MEMBER => {
-				Ok(WindowEvents::Reparent(ReparentEvent::try_from_message_unchecked(msg)?))
+				Ok(WindowEvents::Reparent(ReparentEvent::try_from_validated_message(msg)?))
 			}
 			"DesktopCreate" => Ok(WindowEvents::DesktopCreate(
-				DesktopCreateEvent::try_from_message_unchecked(msg)?,
+				DesktopCreateEvent::try_from_validated_message(msg)?,
 			)),
 			"DesktopDestroy" => Ok(WindowEvents::DesktopDestroy(
-				DesktopDestroyEvent::try_from_message_unchecked(msg)?,
+				DesktopDestroyEvent::try_from_validated_message(msg)?,
 			)),
-			"Destroy" => Ok(WindowEvents::Destroy(DestroyEvent::try_from_message_unchecked(msg)?)),
+			"Destroy" => Ok(WindowEvents::Destroy(DestroyEvent::try_from_validated_message(msg)?)),
 			"Activate" => {
-				Ok(WindowEvents::Activate(ActivateEvent::try_from_message_unchecked(msg)?))
+				Ok(WindowEvents::Activate(ActivateEvent::try_from_validated_message(msg)?))
 			}
 			"Deactivate" => {
-				Ok(WindowEvents::Deactivate(DeactivateEvent::try_from_message_unchecked(msg)?))
+				Ok(WindowEvents::Deactivate(DeactivateEvent::try_from_validated_message(msg)?))
 			}
-			"Raise" => Ok(WindowEvents::Raise(RaiseEvent::try_from_message_unchecked(msg)?)),
-			"Lower" => Ok(WindowEvents::Lower(LowerEvent::try_from_message_unchecked(msg)?)),
-			"Move" => Ok(WindowEvents::Move(MoveEvent::try_from_message_unchecked(msg)?)),
-			"Resize" => Ok(WindowEvents::Resize(ResizeEvent::try_from_message_unchecked(msg)?)),
-			"Shade" => Ok(WindowEvents::Shade(ShadeEvent::try_from_message_unchecked(msg)?)),
-			"uUshade" => Ok(WindowEvents::UUshade(UUshadeEvent::try_from_message_unchecked(msg)?)),
-			"Restyle" => Ok(WindowEvents::Restyle(RestyleEvent::try_from_message_unchecked(msg)?)),
+			"Raise" => Ok(WindowEvents::Raise(RaiseEvent::try_from_validated_message(msg)?)),
+			"Lower" => Ok(WindowEvents::Lower(LowerEvent::try_from_validated_message(msg)?)),
+			"Move" => Ok(WindowEvents::Move(MoveEvent::try_from_validated_message(msg)?)),
+			"Resize" => Ok(WindowEvents::Resize(ResizeEvent::try_from_validated_message(msg)?)),
+			"Shade" => Ok(WindowEvents::Shade(ShadeEvent::try_from_validated_message(msg)?)),
+			"uUshade" => Ok(WindowEvents::UUshade(UUshadeEvent::try_from_validated_message(msg)?)),
+			"Restyle" => Ok(WindowEvents::Restyle(RestyleEvent::try_from_validated_message(msg)?)),
 			_ => Err(AtspiError::MemberMatch("No matching member for Window".into())),
 		}
 	}

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -4,7 +4,7 @@ use crate::{
 	error::AtspiError,
 	events::{
 		BusProperties, EventBodyOwned, EventWrapperMessageConversion, HasInterfaceName,
-		HasMatchRule, HasRegistryEventString,
+		HasMatchRule, HasRegistryEventString, TryFromMessage,
 	},
 	Event, EventProperties, EventTypeProperties,
 };
@@ -550,16 +550,7 @@ impl EventWrapperMessageConversion for WindowEvents {
 impl TryFrom<&zbus::Message> for WindowEvents {
 	type Error = AtspiError;
 	fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
-		let header = msg.header();
-		let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
-		if interface != WindowEvents::DBUS_INTERFACE {
-			return Err(AtspiError::InterfaceMatch(format!(
-				"Interface {} does not match require interface for event: {}",
-				interface,
-				WindowEvents::DBUS_INTERFACE
-			)));
-		}
-		Self::try_from_message_interface_checked(msg)
+		Self::try_from_message(msg)
 	}
 }
 

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "zbus")]
-use crate::events::{MessageConversion, ObjectRef};
+use crate::events::MessageConversion;
 use crate::{
 	error::AtspiError,
 	events::{BusProperties, EventBodyOwned, HasMatchRule, HasRegistryEventString},

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 #[cfg(feature = "zbus")]
 use crate::{
-	events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage},
+	events::{EventWrapperMessageConversion, MessageConversion, TryFromMessage, MessageConversionExt},
 	ObjectRef,
 };
 use zbus_names::UniqueName;

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -246,7 +246,7 @@ macro_rules! impl_to_dbus_message {
 ///         msg.header().member().unwrap(),
 ///         StateChangedEvent::DBUS_MEMBER)));
 ///     }
-///     StateChangedEvent::from_message_parts_unchecked(msg.try_into()?, msg.body().deserialize::<StateChangedEvent::Body>()?)
+///     StateChangedEvent::try_from_message_unchecked(msg.try_into()?, msg.body().deserialize::<StateChangedEvent::Body>()?)
 ///  }
 /// }
 /// ```
@@ -307,7 +307,7 @@ macro_rules! impl_from_dbus_message {
 						<$type as BusProperties>::DBUS_MEMBER
 					)));
 				}
-				<$type>::from_message_parts_unchecked(
+				<$type>::try_from_message_unchecked(
 					msg.try_into()?,
 					msg.body(), //.deserialize::<<$type as MessageConversion>::Body>()?,
 				)
@@ -320,13 +320,13 @@ macro_rules! impl_from_dbus_message {
 // This prevents Clippy from complaining about the macro not being used.
 // It is being used, but only in test mode.
 //
-/// Tests `Default` and `BusProperties::from_message_parts_unchecked` for a given event struct.
+/// Tests `Default` and `BusProperties::try_from_message_unchecked` for a given event struct.
 ///
 /// Obtains a default for the given event struct.
 /// Asserts that the path and sender are the default.
 ///
 /// Breaks the struct down into item (the associated object) and body.
-/// Then tests `BusProperties::from_message_parts_unchecked` with the item and body.
+/// Then tests `BusProperties::try_from_message_unchecked` with the item and body.
 #[cfg(test)]
 macro_rules! generic_event_test_case {
 	($type:ty) => {
@@ -342,7 +342,7 @@ macro_rules! generic_event_test_case {
 				.build(&(body,))
 				.expect("A message must be able to be built to run this test.")
 				.body();
-			let build_struct = <$type>::from_message_parts_unchecked(item, body2)
+			let build_struct = <$type>::try_from_message_unchecked(item, body2)
 				.expect("<$type as Default>'s parts should build a valid ObjectRef");
 			assert_eq!(struct_event, build_struct);
 		}

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -265,9 +265,6 @@ macro_rules! impl_to_dbus_message {
 ///     use zvariant::Type;
 ///     let header = msg.header();
 ///     let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
-///     let member = header.member().ok_or(AtspiError::MissingMember)?;
-///     let body = msg.body();
-///     let body_signature = body.signature().ok_or(AtspiError::MissingSignature)?;
 ///
 ///     if interface != <StateChangedEvent as BusProperties>::DBUS_INTERFACE {
 ///       return Err(AtspiError::InterfaceMatch(format!(
@@ -276,6 +273,7 @@ macro_rules! impl_to_dbus_message {
 ///         <StateChangedEvent as BusProperties>::DBUS_INTERFACE,
 ///       )));
 ///     }
+///     let member = header.member().ok_or(AtspiError::MissingMember)?;
 ///     if member != <StateChangedEvent>::DBUS_MEMBER {
 ///       return Err(AtspiError::MemberMatch(format!(
 ///         "The member {} does not match the signal's member: {}",
@@ -284,6 +282,8 @@ macro_rules! impl_to_dbus_message {
 ///         <StateChangedEvent as BusProperties>::DBUS_MEMBER,
 ///       )));
 ///     }
+///     let body = msg.body();
+///     let body_signature = body.signature().ok_or(AtspiError::MissingSignature)?;
 ///     if body_signature != <StateChangedEvent as MessageConversion>::Body::signature() {
 ///       return Err(AtspiError::SignatureMatch(format!(
 ///         "The message signature {} does not match the signal's body signature: {}",
@@ -337,9 +337,6 @@ macro_rules! impl_from_dbus_message {
 				use zvariant::Type;
 				let header = msg.header();
 				let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
-				let member = header.member().ok_or(AtspiError::MissingMember)?;
-				let body = msg.body();
-				let body_signature = body.signature().ok_or(AtspiError::MissingSignature)?;
 
 				if interface != <$type as BusProperties>::DBUS_INTERFACE {
 					return Err(AtspiError::InterfaceMatch(format!(
@@ -348,6 +345,7 @@ macro_rules! impl_from_dbus_message {
 						<$type as BusProperties>::DBUS_INTERFACE,
 					)));
 				}
+				let member = header.member().ok_or(AtspiError::MissingMember)?;
 				if member != <$type>::DBUS_MEMBER {
 					return Err(AtspiError::MemberMatch(format!(
 						"The member {} does not match the signal's member: {}",
@@ -356,6 +354,8 @@ macro_rules! impl_from_dbus_message {
 						<$type as BusProperties>::DBUS_MEMBER,
 					)));
 				}
+				let body = msg.body();
+				let body_signature = body.signature().ok_or(AtspiError::MissingSignature)?;
 				if body_signature != <$type as MessageConversion>::Body::signature() {
 					return Err(AtspiError::SignatureMatch(format!(
 						"The message signature {} does not match the signal's body signature: {}",

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -48,8 +48,8 @@ macro_rules! impl_event_properties {
 /// ```
 macro_rules! impl_from_object_ref {
 	($type:ty) => {
-		impl From<ObjectRef> for $type {
-			fn from(obj_ref: ObjectRef) -> Self {
+		impl From<crate::ObjectRef> for $type {
+			fn from(obj_ref: crate::ObjectRef) -> Self {
 				Self { item: obj_ref }
 			}
 		}

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -309,7 +309,7 @@ macro_rules! impl_from_dbus_message {
 		impl TryFrom<&zbus::Message> for $type {
 			type Error = AtspiError;
 			fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
-				<$type as MessageConversion>::try_from_message(msg)
+				<$type as MessageConversionExt<<$type as MessageConversion>::Body>>::try_from_message(msg)
 			}
 		}
 	};

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -1,5 +1,5 @@
 /// Expands to implement the required methods for the [`crate::EventProperties`] trait.
-/// This depends on the struct to have an `item` field of type `ObjectRef`.
+/// This depends on the struct to have an `item` field of type [`crate::ObjectRef`].
 ///
 /// ```ignore
 /// impl_from_interface_event_enum_for_event!(TextCaretMovedEvent);

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -706,8 +706,12 @@ macro_rules! event_wrapper_test_cases {
 				// This conversion in turn leans on the `impl_from_dbus_message` macro.
 				// In `MouseEvents::Abs(msg.try_into()?)`, it is the `msg.try_into()?` that should fail.
 				// The `msg.try_into()?` is provided through the `impl_from_dbus_message` macro.
+        // Additioanlly, we check against the same method in `Event`; the overarchive enum that
+        // contains all other events as variants.
 				let mod_type = <$type>::try_from(&fake_msg);
+				let event_type = Event::try_from(&fake_msg);
         assert_matches!(mod_type, Err(AtspiError::InterfaceMatch(_)), "Wrong kind of error");
+        assert_matches!(event_type, Err(AtspiError::InterfaceMatch(_)), "Wrong kind of error");
 			}
 			#[cfg(feature = "zbus")]
 			#[test]

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -445,6 +445,25 @@ macro_rules! zbus_message_qtspi_test_case {
           .unwrap();
           <$type>::try_from(&msg).expect("Should be able to use an EventBodyQT for any type whose BusProperties::Body = EventBodyOwned");
         }
+      #[cfg(feature = "zbus")]
+     #[test]
+    fn zbus_message_conversion_qtspi_event_enum() {
+      // in the case that the body type is EventBodyOwned, we need to also check successful
+      // conversion from a QSPI-style body.
+        let ev = <$type>::default();
+          let qt: crate::events::EventBodyQT = ev.body().into();
+          let msg = zbus::Message::signal(
+            ev.path(),
+            ev.interface(),
+            ev.member(),
+          )
+          .unwrap()
+          .sender(":0.0")
+          .unwrap()
+          .build(&(qt,))
+          .unwrap();
+          assert_matches!(Event::try_from(&msg), Ok(_));
+        }
     };
     ($type:ty, Explicit) => {};
 }

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -308,8 +308,8 @@ macro_rules! impl_from_dbus_message {
 					)));
 				}
 				<$type>::try_from_message_unchecked(
-					msg.try_into()?,
-					msg.body(), //.deserialize::<<$type as MessageConversion>::Body>()?,
+					msg, //msg.try_into()?,
+					    //msg.body(), //.deserialize::<<$type as MessageConversion>::Body>()?,
 				)
 			}
 		}
@@ -335,14 +335,12 @@ macro_rules! generic_event_test_case {
 			let struct_event = <$type>::default();
 			assert_eq!(struct_event.path().as_str(), "/org/a11y/atspi/accessible/null");
 			assert_eq!(struct_event.sender().as_str(), ":0.0");
-			let item = struct_event.item.clone();
 			let body = struct_event.body();
 			let body2 = Message::method("/my/fake/path", "my.fake.interface")
 				.expect("A message must be able to be built to run this test.")
 				.build(&(body,))
-				.expect("A message must be able to be built to run this test.")
-				.body();
-			let build_struct = <$type>::try_from_message_unchecked(item, body2)
+				.expect("A message must be able to be built to run this test.");
+			let build_struct = <$type>::try_from_message_unchecked(&body2)
 				.expect("<$type as Default>'s parts should build a valid ObjectRef");
 			assert_eq!(struct_event, build_struct);
 		}

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -252,6 +252,8 @@ macro_rules! impl_to_dbus_message {
 /// Implements the `TryFrom` trait for a given event type.
 /// Converts a `zbus::Message` into a user facing event type.
 ///
+/// See [`crate::events::MessageConversion`] for details on implementation.
+///
 /// # Example
 /// ```ignore
 /// impl_from_dbus_message!(StateChangedEvent);
@@ -262,36 +264,7 @@ macro_rules! impl_to_dbus_message {
 /// impl TryFrom<&zbus::Message> for StateChangedEvents {
 ///   type Error = AtspiError;
 ///   fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
-///     use zvariant::Type;
-///     let header = msg.header();
-///     let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
-///
-///     if interface != <StateChangedEvent as BusProperties>::DBUS_INTERFACE {
-///       return Err(AtspiError::InterfaceMatch(format!(
-///         "The interface {} does not match the signal's interface: {}",
-///         interface,
-///         <StateChangedEvent as BusProperties>::DBUS_INTERFACE,
-///       )));
-///     }
-///     let member = header.member().ok_or(AtspiError::MissingMember)?;
-///     if member != <StateChangedEvent>::DBUS_MEMBER {
-///       return Err(AtspiError::MemberMatch(format!(
-///         "The member {} does not match the signal's member: {}",
-///         // unwrap is safe here because of guard above
-///         member,
-///         <StateChangedEvent as BusProperties>::DBUS_MEMBER,
-///       )));
-///     }
-///     let body = msg.body();
-///     let body_signature = body.signature().ok_or(AtspiError::MissingSignature)?;
-///     if body_signature != <StateChangedEvent as MessageConversion>::Body::signature() {
-///       return Err(AtspiError::SignatureMatch(format!(
-///         "The message signature {} does not match the signal's body signature: {}",
-///         body_signature,
-///         <StateChangedEvent as MessageConversion>::Body::signature().as_str(),
-///       )));
-///     }
-///     <StateChangedEvent>::try_from_validated_message(msg)
+///     <$type as MessageConversion>::try_from_message(msg)
 ///   }
 /// }
 /// ```
@@ -334,36 +307,7 @@ macro_rules! impl_from_dbus_message {
 		impl TryFrom<&zbus::Message> for $type {
 			type Error = AtspiError;
 			fn try_from(msg: &zbus::Message) -> Result<Self, Self::Error> {
-				use zvariant::Type;
-				let header = msg.header();
-				let interface = header.interface().ok_or(AtspiError::MissingInterface)?;
-
-				if interface != <$type as BusProperties>::DBUS_INTERFACE {
-					return Err(AtspiError::InterfaceMatch(format!(
-						"The interface {} does not match the signal's interface: {}",
-						interface,
-						<$type as BusProperties>::DBUS_INTERFACE,
-					)));
-				}
-				let member = header.member().ok_or(AtspiError::MissingMember)?;
-				if member != <$type>::DBUS_MEMBER {
-					return Err(AtspiError::MemberMatch(format!(
-						"The member {} does not match the signal's member: {}",
-						// unwrap is safe here because of guard above
-						member,
-						<$type as BusProperties>::DBUS_MEMBER,
-					)));
-				}
-				let body = msg.body();
-				let body_signature = body.signature().ok_or(AtspiError::MissingSignature)?;
-				if body_signature != <$type as MessageConversion>::Body::signature() {
-					return Err(AtspiError::SignatureMatch(format!(
-						"The message signature {} does not match the signal's body signature: {}",
-						body_signature,
-						<$type as MessageConversion>::Body::signature().as_str(),
-					)));
-				}
-				<$type>::try_from_validated_message(msg)
+				<$type as MessageConversion>::try_from_message(msg)
 			}
 		}
 	};

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -291,7 +291,7 @@ macro_rules! impl_to_dbus_message {
 ///         <StateChangedEvent as MessageConversion>::Body::signature().as_str(),
 ///       )));
 ///     }
-///     <StateChangedEvent>::try_from_message_unchecked(msg)
+///     <StateChangedEvent>::try_from_validated_message(msg)
 ///   }
 /// }
 /// ```
@@ -363,7 +363,7 @@ macro_rules! impl_from_dbus_message {
 						<$type as MessageConversion>::Body::signature().as_str(),
 					)));
 				}
-				<$type>::try_from_message_unchecked(msg)
+				<$type>::try_from_validated_message(msg)
 			}
 		}
 	};
@@ -373,13 +373,13 @@ macro_rules! impl_from_dbus_message {
 // This prevents Clippy from complaining about the macro not being used.
 // It is being used, but only in test mode.
 //
-/// Tests `Default` and `BusProperties::try_from_message_unchecked` for a given event struct.
+/// Tests `Default` and `BusProperties::try_from_validated_message` for a given event struct.
 ///
 /// Obtains a default for the given event struct.
 /// Asserts that the path and sender are the default.
 ///
 /// Breaks the struct down into item (the associated object) and body.
-/// Then tests `BusProperties::try_from_message_unchecked` with the item and body.
+/// Then tests `BusProperties::try_from_validated_message` with the item and body.
 #[cfg(test)]
 macro_rules! generic_event_test_case {
 	($type:ty) => {
@@ -398,7 +398,7 @@ macro_rules! generic_event_test_case {
 			.unwrap()
 			.build(&(body,))
 			.unwrap();
-			let build_struct = <$type>::try_from_message_unchecked(&body2)
+			let build_struct = <$type>::try_from_validated_message(&body2)
 				.expect("<$type as Default>'s parts should build a valid ObjectRef");
 			assert_eq!(struct_event, build_struct);
 		}

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -246,7 +246,7 @@ macro_rules! impl_to_dbus_message {
 ///         msg.header().member().unwrap(),
 ///         StateChangedEvent::DBUS_MEMBER)));
 ///     }
-///     StateChangedEvent::from_message_parts(msg.try_into()?, msg.body().try_into()?)
+///     StateChangedEvent::from_message_parts_unchecked(msg.try_into()?, msg.body().deserialize::<StateChangedEvent::Body>()?)
 ///  }
 /// }
 /// ```
@@ -307,9 +307,9 @@ macro_rules! impl_from_dbus_message {
 						<$type as BusProperties>::DBUS_MEMBER
 					)));
 				}
-				<$type>::from_message_parts(
+				<$type>::from_message_parts_unchecked(
 					msg.try_into()?,
-					msg.body().deserialize::<<$type as BusProperties>::Body>()?,
+					msg.body().deserialize::<<$type as MessageConversion>::Body>()?,
 				)
 			}
 		}
@@ -320,13 +320,13 @@ macro_rules! impl_from_dbus_message {
 // This prevents Clippy from complaining about the macro not being used.
 // It is being used, but only in test mode.
 //
-/// Tests `Default` and `BusProperties::from_message_parts` for a given event struct.
+/// Tests `Default` and `BusProperties::from_message_parts_unchecked` for a given event struct.
 ///
 /// Obtains a default for the given event struct.
 /// Asserts that the path and sender are the default.
 ///
 /// Breaks the struct down into item (the associated object) and body.
-/// Then tests `BusProperties::from_message_parts` with the item and body.
+/// Then tests `BusProperties::from_message_parts_unchecked` with the item and body.
 #[cfg(test)]
 macro_rules! generic_event_test_case {
 	($type:ty) => {
@@ -337,7 +337,7 @@ macro_rules! generic_event_test_case {
 			assert_eq!(struct_event.sender().as_str(), ":0.0");
 			let item = struct_event.item.clone();
 			let body = struct_event.body();
-			let build_struct = <$type>::from_message_parts(item, body)
+			let build_struct = <$type>::from_message_parts_unchecked(item, body)
 				.expect("<$type as Default>'s parts should build a valid ObjectRef");
 			assert_eq!(struct_event, build_struct);
 		}

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -300,7 +300,7 @@ macro_rules! impl_from_dbus_message {
           )));
         };
         let item = msg.try_into()?;
-        Self::try_from_validated_message_parts(item, deser_body)
+        Self::from_message_unchecked_parts(item, deser_body)
       }
     }
 	};
@@ -319,13 +319,13 @@ macro_rules! impl_from_dbus_message {
 // This prevents Clippy from complaining about the macro not being used.
 // It is being used, but only in test mode.
 //
-/// Tests `Default` and `BusProperties::try_from_validated_message` for a given event struct.
+/// Tests `Default` and `BusProperties::from_message_unchecked` for a given event struct.
 ///
 /// Obtains a default for the given event struct.
 /// Asserts that the path and sender are the default.
 ///
 /// Breaks the struct down into item (the associated object) and body.
-/// Then tests `BusProperties::try_from_validated_message` with the item and body.
+/// Then tests `BusProperties::from_message_unchecked` with the item and body.
 #[cfg(test)]
 macro_rules! generic_event_test_case {
 	($type:ty) => {
@@ -344,7 +344,7 @@ macro_rules! generic_event_test_case {
 			.unwrap()
 			.build(&(body,))
 			.unwrap();
-			let build_struct = <$type>::try_from_validated_message(&body2)
+			let build_struct = <$type>::from_message_unchecked(&body2)
 				.expect("<$type as Default>'s parts should build a valid ObjectRef");
 			assert_eq!(struct_event, build_struct);
 		}
@@ -533,8 +533,8 @@ macro_rules! zbus_message_test_case {
 			.unwrap()
 			.build(&<$type>::default().body())
 			.unwrap();
-			let event = <$type>::try_from_validated_message(&fake_msg);
-      event.expect("The try_from_validated_message function should work, despite mismatching interface and member");
+			let event = <$type>::from_message_unchecked(&fake_msg);
+      event.expect("The from_message_unchecked function should work, despite mismatching interface and member");
 		}
 
 		#[cfg(feature = "zbus")]

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -501,6 +501,23 @@ macro_rules! zbus_message_test_case {
 
 		#[cfg(feature = "zbus")]
 		#[test]
+		fn zbus_msg_conversion_validated_message_with_body() -> () {
+			let fake_msg = zbus::Message::signal(
+				"/org/a11y/sixtynine/fourtwenty",
+				"org.a11y.atspi.technically.valid",
+				"MadeUpMember",
+			)
+			.unwrap()
+			.sender(":0.0")
+			.unwrap()
+			.build(&<$type>::default().body())
+			.unwrap();
+			let event = <$type>::try_from_validated_message(&fake_msg);
+      event.expect("The try_from_validated_message function should work, despite mismatching interface and member");
+		}
+
+		#[cfg(feature = "zbus")]
+		#[test]
 		fn zbus_msg_conversion_failure_correct_interface() -> () {
 			let fake_msg = zbus::Message::signal(
 				"/org/a11y/sixtynine/fourtwenty",

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -269,7 +269,7 @@ macro_rules! impl_to_dbus_message {
 /// }
 /// ```
 ///
-/// There is also a variant that can be used for events whose [`crate::events::BusProperties::Body`] is not
+/// There is also a variant that can be used for events whose [`crate::events::MessageConversion::Body`] is not
 /// [`crate::events::EventBodyOwned`]. You can call this by setting the second parameter to `Explicit`.
 macro_rules! impl_from_dbus_message {
 	($type:ty) => {

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -362,10 +362,15 @@ macro_rules! generic_event_test_case {
 			assert_eq!(struct_event.path().as_str(), "/org/a11y/atspi/accessible/null");
 			assert_eq!(struct_event.sender().as_str(), ":0.0");
 			let body = struct_event.body();
-			let body2 = Message::method("/my/fake/path", "my.fake.interface")
-				.expect("A message must be able to be built to run this test.")
-				.build(&(body,))
-				.expect("A message must be able to be built to run this test.");
+			let body2 = Message::method(
+				struct_event.path().as_str(),
+				<$type as BusProperties>::DBUS_MEMBER,
+			)
+			.unwrap()
+			.sender(struct_event.sender().as_str())
+			.unwrap()
+			.build(&(body,))
+			.unwrap();
 			let build_struct = <$type>::try_from_message_unchecked(&body2)
 				.expect("<$type as Default>'s parts should build a valid ObjectRef");
 			assert_eq!(struct_event, build_struct);

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -30,6 +30,32 @@ macro_rules! impl_event_properties {
 	};
 }
 
+/// Expands to implement From for [`crate::ObjectRef`].
+/// This depends on the struct to have an `item` field of type [`crate::ObjectRef`].
+///
+/// ```ignore
+/// impl_from_object_ref!(TextCaretMovedEvent);
+/// ```
+///
+/// Exapnds to:
+///
+/// ```ignore
+/// impl From<ObjectRef> for TextCaretMovedItem {
+///     fn from(obj_ref: ObjectRef) -> Self {
+///         Self { item: obj_ref }
+///     }
+/// }
+/// ```
+macro_rules! impl_from_object_ref {
+	($type:ty) => {
+		impl From<ObjectRef> for $type {
+			fn from(obj_ref: ObjectRef) -> Self {
+				Self { item: obj_ref }
+			}
+		}
+	};
+}
+
 /// Expands to a conversion given the enclosed event type and outer `Event` variant.
 ///
 /// eg

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -322,16 +322,16 @@ macro_rules! impl_from_dbus_message {
 				{
 					return Err(AtspiError::InterfaceMatch(format!(
 						"The interface {} does not match the signal's interface: {}",
-						header.interface().unwrap(),
-						<$type as BusProperties>::DBUS_INTERFACE
+						header.interface(),
+						Some(<$type as BusProperties>::DBUS_INTERFACE)
 					)));
 				}
 				if header.member().ok_or(AtspiError::MissingMember)? != <$type>::DBUS_MEMBER {
 					return Err(AtspiError::MemberMatch(format!(
 						"The member {} does not match the signal's member: {}",
 						// unwrap is safe here because of guard above
-						header.member().unwrap(),
-						<$type as BusProperties>::DBUS_MEMBER
+						header.member(),
+						Some(<$type as BusProperties>::DBUS_MEMBER)
 					)));
 				}
         if msg.body().signature() != Some(<$type as MessageConversion>::Body::signature()) {

--- a/atspi-common/tests/tests.rs
+++ b/atspi-common/tests/tests.rs
@@ -1,5 +1,5 @@
-use atspi_common::events::CacheEvents;
-use atspi_common::events::{AddAccessibleEvent, Event, RemoveAccessibleEvent};
+use atspi_common::events::cache::{AddAccessibleEvent, RemoveAccessibleEvent};
+use atspi_common::events::{CacheEvents, Event};
 use atspi_common::{CacheItem, ObjectRef};
 use atspi_connection::AccessibilityConnection;
 use std::time::Duration;

--- a/atspi-connection/src/lib.rs
+++ b/atspi-connection/src/lib.rs
@@ -14,7 +14,9 @@ use atspi_proxies::{
 	registry::RegistryProxy,
 };
 use common::error::AtspiError;
-use common::events::{BusProperties, Event, EventProperties, HasMatchRule, HasRegistryEventString};
+use common::events::{
+	BusProperties, Event, EventProperties, HasMatchRule, HasRegistryEventString, MessageConversion,
+};
 use futures_lite::stream::{Stream, StreamExt};
 use std::ops::Deref;
 use zbus::{fdo::DBusProxy, Address, MatchRule, MessageStream, MessageType};
@@ -294,7 +296,7 @@ impl AccessibilityConnection {
 	/// Both of these conditions should never happen as long as you have a valid event.
 	pub async fn send_event<T>(&self, event: T) -> Result<(), AtspiError>
 	where
-		T: BusProperties + EventProperties,
+		T: BusProperties + EventProperties + MessageConversion,
 	{
 		let conn = self.connection();
 		let new_message = zbus::Message::signal(

--- a/atspi-proxies/Cargo.toml
+++ b/atspi-proxies/Cargo.toml
@@ -19,14 +19,12 @@ publish = true
 [features]
 default = ["async-std"]
 async-std = ["zbus/async-io", "atspi-common/async-std"]
-gvariant = ["zvariant/gvariant"]
 tokio = ["zbus/tokio", "atspi-common/tokio"]
 
 [dependencies]
 atspi-common = { path = "../atspi-common", version = "0.8.0", default-features = false }
 serde = { version = "^1.0", default-features = false, features = ["derive"] }
 zbus = { workspace = true }
-zvariant = { version = "4.1", default-features = false }
 
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes"] }

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -63,7 +63,6 @@ required-features = ["connection-async-std"]
 async-std = { version = "1.12", default-features = false }
 atspi = { path = "." }
 criterion = "0.5"
-display_tree = "1.1"
 fastrand = "2.0"
 futures = { version = "0.3", default-features = false }
 futures-lite = { version = "2", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -91,7 +91,7 @@ ignore = [
 allow = [
     "MIT",
     "Apache-2.0",
-		"Unicode-DFS-2016",
+		"Unicode-3.0",
     #"Apache-2.0 WITH LLVM-exception",
 ]
 # The confidence threshold for detecting a license from license text.


### PR DESCRIPTION
## Summary

Split `BusProperties` into the `const &'static str`s (still called `BusProperties`), and message conversion: `MessageConversion` (TODO: name).

All trivial events (where they contain only the field `item`) now implement `From<ObjectRef>`.

All events that implement `From<ObjectRef>` get their `MessageConversion` implementation for free (blanket impl).

Rename:

- `from_message_parts(ObjectRef, Self::Body)`, to
- `try_from_message_unchecked(&zbus::Message)`

An additional check was added to all implementations of `From<&zbus::Message>` (the macro) requireing that the body signature match the event's body signature—this supplements the xisitng checks on the interface and member.

## Commits

- **Split BusProperties into two traits**
- **use new trait in sending event code**
- **Feature gate new MessageConversion trait behind 'zbus'**
- **Take zbus::Body instead of Self::Body in from_message_unchecked**
- **from_message_parts_unchecked -> try_from_message_unchecked**
- **Pass &Message to new try_from_message_unchecked**
- **Add macro to implement From<ObjectRef>**
- **Fix missing doc link**
- **Auto-implement MessageConversion for trivial case.**
- **Remove now unused From<UFET> for EventBodyOwned**
- **Use full message to check tests**
- **Make sure to check signature validity before calling *try_from_message_unchecked***

## TODO

- [x] Ensure `Event` and interface-grouped enums use `_unchecked` instead of `TryFrom<&Message>`
- [x] Add `_unchecked` variant deserialization for interface-grouped enums, which will not check the validity of the interface before continuing,