### PR TITLE
feat: introduces borrowed bodies

### DIFF
--- a/atspi-common/Cargo.toml
+++ b/atspi-common/Cargo.toml
@@ -1,42 +1,42 @@
 [package]
-name = "atspi-common"
-version = "0.9.0"
-edition = "2021"
-readme = "README.md"
-categories = ["accessibility", "api-bindings"]
-keywords = ["Macros", "Accessibility"]
-repository = "https://github.com/odilia-app/atspi"
-description = "Primitive types used for sending and receiving Linux accessibility events."
-license = "Apache-2.0 OR MIT"
-include = ["src/**/*", "LICENSE-*", "README.md", "xml/*"]
-rust-version.workspace = true
+  categories             = [ "accessibility", "api-bindings" ]
+  description            = "Primitive types used for sending and receiving Linux accessibility events."
+  edition                = "2021"
+  include                = [ "LICENSE-*", "README.md", "src/**/*", "xml/*" ]
+  keywords               = [ "Accessibility", "Macros" ]
+  license                = "Apache-2.0 OR MIT"
+  name                   = "atspi-common"
+  readme                 = "README.md"
+  repository             = "https://github.com/odilia-app/atspi"
+  rust-version.workspace = true
+  version                = "0.9.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+  # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["async-std", "wrappers"]
-async-std = ["zbus/async-io"]
-tokio = ["zbus/tokio"]
-wrappers = []
+  async-std = [ "zbus/async-io" ]
+  default   = [ "async-std", "wrappers" ]
+  tokio     = [ "zbus/tokio" ]
+  wrappers  = [  ]
 
 [dependencies]
-enumflags2 = "0.7.7"
-serde = "1.0"
-static_assertions = "1.1.0"
-zbus-lockstep = { version = "0.5.0" }
-zbus-lockstep-macros = { version = "0.5.0" }
-zbus_names = "4.0"
-zvariant = { version = "5.1", default-features = false }
-zbus = { workspace = true, optional = true, default-features = false }
+  enumflags2           = "0.7.7"
+  serde                = "1.0"
+  static_assertions    = "1.1.0"
+  zbus                 = { workspace = true, optional = true, default-features = false }
+  zbus-lockstep        = { version = "0.5.0" }
+  zbus-lockstep-macros = { version = "0.5.0" }
+  zbus_names           = "4.0"
+  zvariant             = { version = "5.1", default-features = false }
 
 [dev-dependencies]
-atspi-connection = { path = "../atspi-connection" }
-atspi-proxies = { path = "../atspi-proxies" }
-rename-item = "0.1.0"
-serde_plain = "1.0.1"
-static_assertions = "1.1.0"
-tokio-stream = { version = "0.1", default-features = false, features = ["time"] }
-tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
-tokio-test = "0.4.2"
-zbus = { workspace = true }
-assert_matches = "1.5.0"
+  assert_matches    = "1.5.0"
+  atspi-connection  = { path = "../atspi-connection" }
+  atspi-proxies     = { path = "../atspi-proxies" }
+  rename-item       = "0.1.0"
+  serde_plain       = "1.0.1"
+  static_assertions = "1.1.0"
+  tokio             = { version = "1", default-features = false, features = [ "macros", "rt-multi-thread" ] }
+  tokio-stream      = { version = "0.1", default-features = false, features = [ "time" ] }
+  tokio-test        = "0.4.2"
+  zbus              = { workspace = true }

--- a/atspi-common/src/events/event_body.rs
+++ b/atspi-common/src/events/event_body.rs
@@ -1,0 +1,986 @@
+use crate::AtspiError;
+use serde::{
+	ser::{SerializeMap, SerializeStruct},
+	Deserialize, Serialize,
+};
+use zbus_lockstep_macros::validate;
+use zvariant::{ObjectPath, OwnedValue, Type, Value};
+
+/// Event body as used exclusively by 'Qt' toolkit.
+///
+/// Signature:  "siiv(so)"
+#[derive(Debug, Serialize, Deserialize, PartialEq, Type)]
+pub struct EventBodyQT {
+	/// kind variant, used for specifying an event triple "object:state-changed:focused",
+	/// the "focus" part of this event is what is contained within the kind.
+	// #[serde(rename = "type")]
+	pub kind: String,
+
+	/// Generic detail1 value described by AT-SPI.
+	pub detail1: i32,
+
+	/// Generic detail2 value described by AT-SPI.
+	pub detail2: i32,
+
+	/// Generic `any_data` value described by AT-SPI.
+	/// This can be any type.
+	pub any_data: OwnedValue,
+
+	/// Not in use.
+	/// See: [`QtProperties`].
+	#[serde(skip_deserializing)]
+	pub(crate) properties: QtProperties,
+}
+
+impl Clone for EventBodyQT {
+	/// # Safety  
+	///
+	/// This implementation of [`Clone`] *can panic!* although chances are slim.
+	///
+	/// If the following conditions are met:
+	/// 1. the `any_data` or `properties` field contain an [`std::os::fd::OwnedFd`] type, and
+	/// 2. the maximum number of open files for the process is exceeded.
+	///
+	/// Then this function panic.  
+	/// None of the types in [`crate::events`] use [`std::os::fd::OwnedFd`].
+	/// Events on the AT-SPI bus *could, theoretically* send a file descriptor, but nothing in the current
+	/// specification describes that.  
+	/// See [`zvariant::Value::try_clone`] for more information.
+	fn clone(&self) -> Self {
+		let cloned_any_data = self.any_data.try_clone().unwrap_or_else(|err| {
+			panic!("Failure cloning 'any_data' field: {err:?}");
+		});
+
+		Self {
+			kind: self.kind.clone(),
+			detail1: self.detail1,
+			detail2: self.detail2,
+			any_data: cloned_any_data,
+			properties: QtProperties,
+		}
+	}
+}
+
+/// Unit struct placeholder for `EventBodyQT.properties`
+///
+/// AT-SPI2 never reads or writes to `EventBodyQT.properties`.  
+/// `QtProperties` has the appropriate implementations for `Serialize` and `Deserialize`  
+/// to make it serialize as an a valid tuple and valid bytes deserialize as placeholder.
+#[derive(Debug, Copy, Clone, Deserialize, Type, Default, PartialEq)]
+#[zvariant(signature = "(so)")]
+pub(crate) struct QtProperties;
+
+impl Serialize for QtProperties {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::ser::Serializer,
+	{
+		let mut structure = serializer.serialize_struct("ObjectRef", 2)?;
+		structure.serialize_field("name", ":0.0")?;
+		structure.serialize_field("path", &ObjectPath::from_static_str_unchecked("/"))?;
+		structure.end()
+	}
+}
+
+impl Default for EventBodyQT {
+	fn default() -> Self {
+		Self {
+			kind: String::new(),
+			detail1: 0,
+			detail2: 0,
+			any_data: 0_u32.into(),
+			properties: QtProperties,
+		}
+	}
+}
+
+/// Unit struct placeholder for `EventBody.properties`
+///
+/// AT-SPI2 never reads or writes to `EventBody.properties`.  
+/// `Properties` has the appropriate implementations for `Serialize` and `Deserialize`  
+/// to make it serialize as an a valid dictionary and valid bytes deserialize as placeholder.
+#[derive(Debug, Copy, Clone, Type, Default, Deserialize, PartialEq)]
+#[zvariant(signature = "a{sv}")]
+pub(crate) struct Properties;
+
+impl Serialize for Properties {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::ser::Serializer,
+	{
+		serializer.serialize_map(Some(0))?.end()
+	}
+}
+
+/// AT-SPI2 protocol native event body type.
+///
+/// All of the various signals in the AT-SPI2 protocol share this shape.
+/// Most toolkits and implementors emit this type, except for `Qt`, which has has its
+/// own type: [`EventBodyQT`].
+///
+/// Signature `(siiva{sv})`,
+#[validate(signal: "PropertyChange")]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Type)]
+pub struct EventBodyOwned {
+	/// kind variant, used for specifying an event triple "object:state-changed:focused",
+	/// the "focus" part of this event is what is contained within the kind.
+	#[serde(rename = "type")]
+	pub kind: String,
+
+	/// Generic detail1 value described by AT-SPI.
+	pub detail1: i32,
+
+	/// Generic detail2 value described by AT-SPI.
+	pub detail2: i32,
+
+	/// Generic `any_data` value described by AT-SPI.
+	/// This can be any type.
+	///
+	pub any_data: OwnedValue,
+
+	/// Not in use.
+	/// See: [`Properties`].
+	pub(crate) properties: Properties,
+}
+
+impl Default for EventBodyOwned {
+	fn default() -> Self {
+		Self {
+			kind: String::new(),
+			detail1: 0,
+			detail2: 0,
+			any_data: 0_u32.into(),
+			properties: Properties,
+		}
+	}
+}
+
+impl Clone for EventBodyOwned {
+	/// # Safety  
+	///
+	/// This implementation of [`Clone`] *can panic!* although chances are slim.
+	///
+	/// If the following conditions are met:
+	/// 1. the `any_data` or `properties` field contain an [`std::os::fd::OwnedFd`] type, and
+	/// 2. the maximum number of open files for the process is exceeded.
+	///
+	/// Then this function panic.  
+	/// None of the types in [`crate::events`] use [`std::os::fd::OwnedFd`].
+	/// Events on the AT-SPI bus *could, theoretically* send a file descriptor, but nothing in the current
+	/// specification describes that.  
+	/// See [`zvariant::Value::try_clone`] for more information.
+	fn clone(&self) -> Self {
+		let cloned_any_data = self.any_data.try_clone().unwrap_or_else(|err| {
+			panic!("Failure cloning 'any_data' field: {err:?}");
+		});
+
+		Self {
+			kind: self.kind.clone(),
+			detail1: self.detail1,
+			detail2: self.detail2,
+			any_data: cloned_any_data,
+			properties: Properties,
+		}
+	}
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Type)]
+pub struct EventBodyBorrow<'a> {
+	/// kind variant, used for specifying an event triple "object:state-changed:focused",
+	/// the "focus" part of this event is what is contained within the kind.
+	#[serde(rename = "type")]
+	#[serde(borrow)]
+	pub kind: &'a str,
+
+	/// Generic detail1 value described by AT-SPI.
+	pub detail1: i32,
+
+	/// Generic detail2 value described by AT-SPI.
+	pub detail2: i32,
+
+	/// Generic `any_data` value described by AT-SPI.
+	/// This can be any type.
+	#[serde(borrow)]
+	pub any_data: Value<'a>,
+
+	/// Not in use.
+	/// See: [`Properties`].
+	#[serde(skip_deserializing)]
+	pub(crate) properties: Properties,
+}
+
+impl Default for EventBodyBorrow<'_> {
+	fn default() -> Self {
+		Self {
+			kind: "",
+			detail1: 0,
+			detail2: 0,
+			any_data: Value::new(0_u32),
+			properties: Properties,
+		}
+	}
+}
+
+impl EventBodyBorrow<'_> {
+	/// Convert this borrowed event body to an owned event body.
+	///
+	/// # Errors
+	///
+	/// This will error if the following conditions are met:
+	/// 1. the `any_data` field contains an [`std::os::fd::OwnedFd`] type, and
+	/// 2. the maximum number of open files for the process is exceeded.
+	///
+	/// Chances are slim because none of the types in [`crate::events`] use [`std::os::fd::OwnedFd`].  
+	/// See [`zvariant::Value::try_clone`] for more information.
+	pub fn to_fully_owned(&self) -> Result<EventBodyOwned, AtspiError> {
+		let owned_any_data = self.any_data.try_to_owned()?;
+
+		Ok(EventBodyOwned {
+			kind: self.kind.into(),
+			detail1: self.detail1,
+			detail2: self.detail2,
+			any_data: owned_any_data,
+			properties: Properties,
+		})
+	}
+}
+
+impl Clone for EventBodyBorrow<'_> {
+	/// # Safety  
+	///
+	/// This implementation of [`Clone`] *can panic!* although chances are slim.
+	///
+	/// If the following conditions are met:
+	/// 1. the `any_data` or `properties` field contain an [`std::os::fd::OwnedFd`] type, and
+	/// 2. the maximum number of open files for the process is exceeded.
+	///
+	/// Then this function panic.  
+	/// None of the types in [`crate::events`] use [`std::os::fd::OwnedFd`].
+	/// Events on the AT-SPI bus *could, theoretically* send a file descriptor, but nothing in the current
+	/// specification describes that.  
+	/// See [`zvariant::Value::try_clone`] for more information.
+	fn clone(&self) -> Self {
+		let cloned_any_data = self.any_data.try_clone().unwrap_or_else(|err| {
+			panic!("Failure cloning 'any_data' field: {err:?}");
+		});
+
+		Self {
+			kind: self.kind,
+			detail1: self.detail1,
+			detail2: self.detail2,
+			any_data: cloned_any_data,
+			properties: Properties,
+		}
+	}
+}
+
+#[derive(Debug, Type, Deserialize, PartialEq)]
+pub struct EventBodyQTBorrow<'m> {
+	/// kind variant, used for specifying an event triple "object:state-changed:focused",
+	/// the "focus" part of this event is what is contained within the kind.
+	#[serde(rename = "type")]
+	pub kind: &'m str,
+
+	/// Generic detail1 value described by AT-SPI.
+	pub detail1: i32,
+
+	/// Generic detail2 value described by AT-SPI.
+	pub detail2: i32,
+
+	/// Generic `any_data` value described by AT-SPI.
+	/// This can be any type.
+	#[serde(borrow)]
+	pub any_data: Value<'m>,
+
+	/// Not in use.
+	/// See: [`QtProperties`].
+	#[serde(skip_deserializing)]
+	pub(crate) properties: QtProperties,
+}
+
+impl Default for EventBodyQTBorrow<'_> {
+	fn default() -> Self {
+		Self {
+			kind: "",
+			detail1: 0,
+			detail2: 0,
+			any_data: Value::new(0_u32),
+			properties: QtProperties,
+		}
+	}
+}
+
+impl Clone for EventBodyQTBorrow<'_> {
+	/// # Safety  
+	///
+	/// This implementation of [`Clone`] *can panic!* although chances are slim.
+	///
+	/// If the following conditions are met:
+	/// 1. the `any_data` or `properties` field contain an [`std::os::fd::OwnedFd`] type, and
+	/// 2. the maximum number of open files for the process is exceeded.
+	///
+	/// Then this function panic.  
+	/// None of the types in [`crate::events`] use [`std::os::fd::OwnedFd`].
+	/// Events on the AT-SPI bus *could, theoretically* send a file descriptor, but nothing in the current
+	/// specification describes that.  
+	/// See [`zvariant::Value::try_clone`] for more information.
+	fn clone(&self) -> Self {
+		let cloned_any_data = self.any_data.try_clone().unwrap_or_else(|err| {
+			panic!("Failure cloning 'any_data' field: {err:?}");
+		});
+
+		Self {
+			kind: self.kind,
+			detail1: self.detail1,
+			detail2: self.detail2,
+			any_data: cloned_any_data,
+			properties: QtProperties,
+		}
+	}
+}
+
+impl EventBodyQTBorrow<'_> {
+	/// Convert partially borrowed Qt event body to an owned event body.
+	///
+	/// # Errors
+	///
+	/// This will error if the following conditions are met:
+	/// 1. the `any_data` field contains an [`std::os::fd::OwnedFd`] type, and
+	/// 2. the maximum number of open files for the process is exceeded.
+	pub fn try_to_owned(&self) -> Result<EventBodyQT, AtspiError> {
+		let any_data = self.any_data.try_to_owned()?;
+
+		Ok(EventBodyQT {
+			kind: self.kind.to_owned(),
+			detail1: self.detail1,
+			detail2: self.detail2,
+			any_data,
+			properties: self.properties,
+		})
+	}
+}
+
+impl<'de> From<EventBodyQTBorrow<'de>> for EventBodyBorrow<'de> {
+	fn from(borrow: EventBodyQTBorrow<'de>) -> Self {
+		let EventBodyQTBorrow { kind, detail1, detail2, any_data, properties: _ } = borrow;
+
+		Self { kind, detail1, detail2, any_data, properties: Properties }
+	}
+}
+
+impl From<EventBodyQT> for EventBodyOwned {
+	fn from(body: EventBodyQT) -> Self {
+		Self {
+			kind: body.kind,
+			detail1: body.detail1,
+			detail2: body.detail2,
+			any_data: body.any_data,
+			properties: Properties,
+		}
+	}
+}
+
+/// Common event body that can be either owned or borrowed.
+///
+/// This is useful for APIs that can return either owned or borrowed event bodies.  
+/// Having this type allows to be generic over the event body type.
+#[derive(Debug, Clone, PartialEq)]
+pub enum EventBody<'a> {
+	Owned(EventBodyOwned),
+	Borrowed(EventBodyBorrow<'a>),
+}
+
+impl Default for EventBody<'_> {
+	fn default() -> Self {
+		Self::Borrowed(EventBodyBorrow::default())
+	}
+}
+
+impl<'a> EventBody<'_> {
+	/// Non-consuming conversion to an owned event body.
+	///
+	/// Does cloning.
+	///
+	/// # Errors
+	/// The borrowed variant will error if the following conditions are met:  
+	/// 1. the `any_data` field contains an [`std::os::fd::OwnedFd`] type, and  
+	/// 2. the maximum number of open files for the process is exceeded.
+	pub fn as_owned(&self) -> Result<EventBodyOwned, AtspiError> {
+		match self {
+			Self::Owned(owned) => Ok(owned.clone()),
+			Self::Borrowed(borrowed) => borrowed.to_fully_owned(),
+		}
+	}
+
+	/// Consuming conversion to an owned event body.
+	///
+	/// Does cloning.
+	///
+	/// # Errors
+	/// The borrowed variant will error if the following conditions are met:  
+	/// 1. the `any_data` field contains an [`std::os::fd::OwnedFd`] type, and  
+	/// 2. the maximum number of open files for the process is exceeded.
+	pub fn into_owned(self) -> Result<EventBodyOwned, AtspiError> {
+		match self {
+			Self::Owned(owned) => Ok(owned),
+			Self::Borrowed(borrowed) => borrowed.to_fully_owned(),
+		}
+	}
+
+	/// The `kind` field as `&str`.
+	///
+	/// With both variants, this method returns a reference to the `kind` field.
+	#[must_use]
+	pub fn kind(&'a self) -> &'a str {
+		match self {
+			Self::Owned(owned) => owned.kind.as_str(),
+			Self::Borrowed(borrowed) => borrowed.kind,
+		}
+	}
+
+	/// Take or convert the `kind` field as `String`.
+	///
+	/// With the owned variant, this method takes the `kind` field and replaces it with an empty string.
+	/// With the borrowed variant, this method clones and allocates the `kind` field.
+	pub fn take_kind(&mut self) -> String {
+		match self {
+			Self::Owned(owned) => std::mem::take(&mut owned.kind),
+			Self::Borrowed(borrowed) => borrowed.kind.to_owned(),
+		}
+	}
+
+	#[must_use]
+	pub fn detail1(&self) -> i32 {
+		match self {
+			Self::Owned(owned) => owned.detail1,
+			Self::Borrowed(borrowed) => borrowed.detail1,
+		}
+	}
+
+	#[must_use]
+	pub fn detail2(&self) -> i32 {
+		match self {
+			Self::Owned(owned) => owned.detail2,
+			Self::Borrowed(borrowed) => borrowed.detail2,
+		}
+	}
+
+	/// The `any_data` field as `&Value`.
+	/// With both variants, this method returns a reference to the `any_data` field.
+	#[must_use]
+	pub fn any_data(&'a self) -> &'a Value<'a> {
+		match self {
+			Self::Owned(owned) => &owned.any_data,
+			Self::Borrowed(borrowed) => &borrowed.any_data,
+		}
+	}
+
+	/// Take or convert the `any_data` field as `OwnedValue`.
+	/// With the owned variant, this method takes the `any_data` field and replaces it with a default value.
+	/// As `Value` does not have a default value, we will replace with `0_u32`, a nbon-allocating value.
+	///
+	/// With the borrowed variant, this method clones and allocates the `any_data` field.
+	///
+	/// # Panics
+	/// This method will panic if the `any_data` field contains an [`std::os::fd::OwnedFd`] type, and
+	/// the maximum number of open files for the process is exceeded.
+	///
+	/// None of the types in [`crate::events`] use [`std::os::fd::OwnedFd`].
+	/// Events on the AT-SPI bus *could, theoretically* send a file descriptor, but nothing in the current
+	/// specification describes that.
+	pub fn take_any_data(&mut self) -> OwnedValue {
+		match self {
+			Self::Owned(owned) => std::mem::replace(&mut owned.any_data, 0_u32.into()),
+			Self::Borrowed(borrowed) => borrowed.any_data.try_to_owned().expect("cloning 'any_data' field should not fail because we do not expect it to hold an fd"),
+		}
+	}
+}
+
+impl Type for EventBody<'_> {
+	const SIGNATURE: &'static zvariant::Signature = EventBodyOwned::SIGNATURE;
+}
+
+impl<'de> Deserialize<'de> for EventBody<'de> {
+	fn deserialize<D>(deserializer: D) -> Result<EventBody<'de>, D::Error>
+	where
+		D: serde::de::Deserializer<'de>,
+	{
+		let borrowed = EventBodyBorrow::deserialize(deserializer)?;
+		Ok(borrowed.into())
+	}
+}
+
+impl Serialize for EventBody<'_> {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::ser::Serializer,
+	{
+		match self {
+			EventBody::Owned(owned) => owned.serialize(serializer),
+			EventBody::Borrowed(borrowed) => borrowed.serialize(serializer),
+		}
+	}
+}
+
+impl From<EventBodyOwned> for EventBody<'_> {
+	fn from(owned: EventBodyOwned) -> Self {
+		EventBody::Owned(owned)
+	}
+}
+
+impl<'b> From<EventBodyBorrow<'b>> for EventBody<'b> {
+	fn from(borrowed: EventBodyBorrow<'b>) -> Self {
+		EventBody::Borrowed(borrowed)
+	}
+}
+
+impl From<EventBodyQT> for EventBody<'_> {
+	fn from(qt_owned: EventBodyQT) -> Self {
+		EventBody::Owned(qt_owned.into())
+	}
+}
+
+impl<'a> From<EventBodyQTBorrow<'a>> for EventBody<'a> {
+	fn from(qt_borrowed: EventBodyQTBorrow<'a>) -> Self {
+		EventBody::Borrowed(qt_borrowed.into())
+	}
+}
+
+impl From<EventBodyOwned> for EventBodyQT {
+	fn from(owned: EventBodyOwned) -> Self {
+		Self {
+			kind: owned.kind,
+			detail1: owned.detail1,
+			detail2: owned.detail2,
+			any_data: owned.any_data,
+			properties: QtProperties,
+		}
+	}
+}
+
+impl<'a> From<EventBodyBorrow<'a>> for EventBodyQT {
+	fn from(borrowed: EventBodyBorrow<'a>) -> Self {
+		Self {
+			kind: borrowed.kind.to_owned(),
+			detail1: borrowed.detail1,
+			detail2: borrowed.detail2,
+			any_data: borrowed
+				.any_data
+				.try_to_owned()
+				.expect("converting borrowed to owned should not fail"),
+			properties: QtProperties,
+		}
+	}
+}
+
+impl From<EventBody<'_>> for EventBodyQT {
+	fn from(event: EventBody) -> Self {
+		match event {
+			EventBody::Owned(owned) => owned.into(),
+			EventBody::Borrowed(borrowed) => borrowed.into(),
+		}
+	}
+}
+
+impl PartialEq<EventBodyOwned> for EventBodyQT {
+	fn eq(&self, other: &EventBodyOwned) -> bool {
+		self.kind == other.kind
+			&& self.detail1 == other.detail1
+			&& self.detail2 == other.detail2
+			&& self.any_data == other.any_data
+	}
+}
+
+impl PartialEq<EventBodyQT> for EventBodyOwned {
+	fn eq(&self, other: &EventBodyQT) -> bool {
+		self.kind == other.kind
+			&& self.detail1 == other.detail1
+			&& self.detail2 == other.detail2
+			&& self.any_data == other.any_data
+	}
+}
+
+impl PartialEq<EventBodyBorrow<'_>> for EventBodyQTBorrow<'_> {
+	fn eq(&self, other: &EventBodyBorrow<'_>) -> bool {
+		self.kind == other.kind
+			&& self.detail1 == other.detail1
+			&& self.detail2 == other.detail2
+			&& self.any_data == other.any_data
+	}
+}
+
+impl PartialEq<EventBodyQTBorrow<'_>> for EventBodyBorrow<'_> {
+	fn eq(&self, other: &EventBodyQTBorrow<'_>) -> bool {
+		self.kind == other.kind
+			&& self.detail1 == other.detail1
+			&& self.detail2 == other.detail2
+			&& self.any_data == other.any_data
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::ObjectRef;
+	use std::collections::HashMap;
+	use zvariant::{serialized::Context, LE};
+	use zvariant::{Array, ObjectPath, Value};
+
+	#[test]
+	fn owned_event_body_clone() {
+		let event = EventBodyOwned::default();
+		let cloned = event.clone();
+
+		assert_eq!(event, cloned);
+	}
+
+	#[test]
+	fn event_body_qt_clone() {
+		let event = EventBodyQT::default();
+		let cloned = event.clone();
+
+		assert_eq!(event, cloned);
+	}
+
+	#[test]
+	fn event_body_borrowed_clone() {
+		let event = EventBodyBorrow::default();
+		let cloned = event.clone();
+
+		assert_eq!(event, cloned);
+	}
+
+	#[test]
+	fn event_body_qt_borrowed_clone() {
+		let event = EventBodyQTBorrow::default();
+		let cloned = event.clone();
+
+		assert_eq!(event, cloned);
+	}
+
+	#[test]
+	fn owned_event_body_default() {
+		let event = EventBodyOwned::default();
+
+		assert_eq!(event.kind, "");
+		assert_eq!(event.detail1, 0);
+		assert_eq!(event.detail2, 0);
+		assert_eq!(event.any_data, 0_u32.into());
+	}
+
+	#[test]
+	fn qt_event_body_default() {
+		let event = EventBodyQT::default();
+
+		assert_eq!(event.kind, "");
+		assert_eq!(event.detail1, 0);
+		assert_eq!(event.detail2, 0);
+		assert_eq!(event.any_data, 0_u32.into());
+		assert_eq!(event.properties, QtProperties);
+	}
+
+	#[test]
+	fn event_body_borrowed_default() {
+		let event = EventBodyBorrow::default();
+
+		assert_eq!(event.kind, "");
+		assert_eq!(event.detail1, 0);
+		assert_eq!(event.detail2, 0);
+		assert_eq!(event.any_data, Value::new(0_u32));
+	}
+
+	#[test]
+	fn qt_event_body_borrowed_default() {
+		let event = EventBodyQTBorrow::default();
+
+		assert_eq!(event.kind, "");
+		assert_eq!(event.detail1, 0);
+		assert_eq!(event.detail2, 0);
+		assert_eq!(event.any_data, Value::new(0_u32));
+		assert_eq!(event.properties, QtProperties);
+	}
+
+	#[test]
+	fn event_body_default() {
+		let event = EventBody::default();
+
+		assert_eq!(event, EventBody::Borrowed(EventBodyBorrow::default()));
+	}
+
+	#[test]
+	fn qt_to_owned() {
+		let qt = EventBodyQT::default();
+		let owned: EventBodyOwned = EventBodyQT::default().into();
+
+		assert_eq!(owned, qt);
+	}
+
+	#[test]
+	fn borrowed_to_qt() {
+		let borrowed: EventBodyBorrow = EventBodyQTBorrow::default().into();
+
+		assert_eq!(borrowed, EventBodyBorrow::default());
+	}
+
+	#[test]
+	fn event_body_deserialize_as_owned() {
+		let event = EventBodyOwned::default();
+
+		let ctxt = Context::new_dbus(LE, 0);
+		let bytes = zvariant::to_bytes::<EventBodyOwned>(ctxt, &event).unwrap();
+
+		let (deserialized, _) = bytes.deserialize::<EventBodyOwned>().unwrap();
+
+		assert_eq!(deserialized, event);
+	}
+
+	#[test]
+	fn owned_event_body_deserialize_as_borrowed() {
+		let event = EventBodyOwned::default();
+
+		let ctxt = Context::new_dbus(LE, 0);
+		let bytes = zvariant::to_bytes::<EventBodyOwned>(ctxt, &event).unwrap();
+
+		let (deserialized, _) = bytes.deserialize::<EventBodyBorrow>().unwrap();
+
+		assert_eq!(deserialized, EventBodyBorrow::default());
+		assert_eq!(deserialized.kind, event.kind.as_str());
+		assert_eq!(deserialized.detail1, event.detail1);
+		assert_eq!(deserialized.detail2, event.detail2);
+		assert_eq!(deserialized.any_data, *event.any_data);
+	}
+
+	#[test]
+	fn qt_owned_event_body_deserialize_as_borrowed() {
+		let event = EventBodyQT::default();
+
+		let ctxt = Context::new_dbus(LE, 0);
+		let bytes = zvariant::to_bytes::<EventBodyQT>(ctxt, &event).unwrap();
+
+		let (deserialized, _) = bytes.deserialize::<EventBodyBorrow>().unwrap();
+
+		assert_eq!(deserialized, EventBodyBorrow::default());
+		assert_eq!(deserialized.kind, event.kind.as_str());
+		assert_eq!(deserialized.detail1, event.detail1);
+		assert_eq!(deserialized.detail2, event.detail2);
+		assert_eq!(deserialized.any_data, *event.any_data);
+	}
+
+	#[test]
+	fn event_body_default_deserialize_as_event_body() {
+		let event = EventBody::default();
+
+		let ctxt = Context::new_dbus(LE, 0);
+		let bytes = zvariant::to_bytes::<EventBody>(ctxt, &event).unwrap();
+
+		let (deserialized, _) = bytes.deserialize::<EventBody>().unwrap();
+
+		assert_eq!(deserialized, event);
+	}
+
+	#[test]
+	fn event_body_owned_default_deserialize_as_event_body() {
+		let event = EventBodyOwned::default();
+
+		let ctxt = Context::new_dbus(LE, 0);
+		let bytes = zvariant::to_bytes::<EventBodyOwned>(ctxt, &event).unwrap();
+
+		let (deserialized, _) = bytes.deserialize::<EventBody>().unwrap();
+
+		assert_eq!(deserialized.kind(), event.kind.as_str());
+		assert_eq!(deserialized.detail1(), event.detail1);
+		assert_eq!(deserialized.detail2(), event.detail2);
+		assert_eq!(*deserialized.any_data(), *event.any_data);
+	}
+
+	#[test]
+	fn complex_body_deserialize_as_event_body() {
+		let boots = Array::from(vec!["these", "boots", "are", "made", "for", "walking"]);
+		let boots = Value::from(boots);
+		let event = (
+			"object:state-changed:focused",
+			1,
+			2,
+			boots.clone(),
+			HashMap::from([("key", Value::from(55_u32)), ("key2", Value::from(56_u32))]),
+		);
+
+		let ctxt = Context::new_dbus(LE, 0);
+		let bytes =
+			zvariant::to_bytes::<(&str, i32, i32, Value, HashMap<&str, Value>)>(ctxt, &event)
+				.unwrap();
+
+		let (deserialized, _) = bytes.deserialize::<EventBody>().unwrap();
+
+		assert_eq!(deserialized.kind(), "object:state-changed:focused");
+		assert_eq!(deserialized.detail1(), 1);
+		assert_eq!(deserialized.detail2(), 2);
+		assert_eq!(*deserialized.any_data(), boots);
+	}
+
+	#[test]
+	fn complex_body_deserialize_as_owned_event_body() {
+		let boots = Array::from(vec!["these", "boots", "are", "made", "for", "walking"]);
+		let boots = Value::from(boots);
+		let event = (
+			"object:state-changed:focused",
+			1,
+			2,
+			boots.clone(),
+			HashMap::from([("key", Value::from(55_u32)), ("key2", Value::from(56_u32))]),
+		);
+
+		let ctxt = Context::new_dbus(LE, 0);
+		let bytes =
+			zvariant::to_bytes::<(&str, i32, i32, Value, HashMap<&str, Value>)>(ctxt, &event)
+				.unwrap();
+
+		let (deserialized, _) = bytes.deserialize::<EventBodyOwned>().unwrap();
+
+		assert_eq!(deserialized.kind, "object:state-changed:focused");
+		assert_eq!(deserialized.detail1, 1);
+		assert_eq!(deserialized.detail2, 2);
+		assert_eq!(*deserialized.any_data, boots);
+	}
+
+	#[test]
+	fn complex_body_deserialize_as_borrowed_event_body() {
+		let boots = Array::from(vec!["these", "boots", "are", "made", "for", "walking"]);
+		let boots = Value::from(boots);
+		let event = (
+			"object:state-changed:focused",
+			1,
+			2,
+			boots.clone(),
+			HashMap::from([("key", Value::from(55_u32)), ("key2", Value::from(56_u32))]),
+		);
+
+		let ctxt = Context::new_dbus(LE, 0);
+		let bytes =
+			zvariant::to_bytes::<(&str, i32, i32, Value, HashMap<&str, Value>)>(ctxt, &event)
+				.unwrap();
+
+		let (deserialized, _) = bytes.deserialize::<EventBodyBorrow>().unwrap();
+
+		assert_eq!(deserialized.kind, "object:state-changed:focused");
+		assert_eq!(deserialized.detail1, 1);
+		assert_eq!(deserialized.detail2, 2);
+		assert_eq!(deserialized.any_data, boots);
+	}
+
+	#[test]
+	fn deserialize_message_from_complex_message_data() {
+		let boots = Array::from(vec!["these", "boots", "are", "made", "for", "walking"]);
+		let boots = Value::from(boots);
+		let body = (
+			"object:state-changed:focused",
+			1,
+			2,
+			boots.clone(),
+			HashMap::from([("key", Value::from(55_u32)), ("key2", Value::from(56_u32))]),
+		);
+
+		let message = zbus::Message::signal("/", "org.a11y.atspi.Object", "StateChange")
+			.unwrap()
+			.build(&body)
+			.unwrap();
+
+		let msg_body = message.body();
+
+		let deserialized = msg_body.deserialize::<EventBodyOwned>().unwrap();
+
+		assert_eq!(deserialized.kind, "object:state-changed:focused");
+		assert_eq!(deserialized.detail1, 1);
+		assert_eq!(deserialized.detail2, 2);
+		assert_eq!(*deserialized.any_data, boots);
+	}
+
+	#[test]
+	fn simple_data_deserialization() {
+		let body = "hello";
+
+		let message = zbus::Message::signal("/bus/driver/zeenix", "org.Zbus", "TicketCheck")
+			.unwrap()
+			.build(&body)
+			.unwrap();
+
+		let msg_body = message.body();
+		let deserialized = msg_body.deserialize::<&str>().unwrap();
+
+		assert_eq!(deserialized, body);
+	}
+
+	#[test]
+	fn test_valid_hashmap_of_string_value_deserializes_as_properties() {
+		let val = Value::from(0_u32);
+		let key = "test";
+		let map = HashMap::from([(key, val)]);
+
+		let ctxt = Context::new_dbus(LE, 0);
+		let bytes = zvariant::to_bytes::<HashMap<&str, Value>>(ctxt, &map).unwrap();
+
+		let (properties, _) = bytes.deserialize::<Properties>().unwrap();
+
+		assert_eq!(properties, Properties);
+	}
+
+	#[test]
+	fn test_object_ref_deserializes_as_qt_properties() {
+		let object_ref = ObjectRef::default();
+
+		let ctxt = Context::new_dbus(LE, 0);
+		let bytes = zvariant::to_bytes::<ObjectRef>(ctxt, &object_ref).unwrap();
+
+		let (qt_props, _) = bytes.deserialize::<QtProperties>().unwrap();
+
+		assert_eq!(qt_props, QtProperties);
+	}
+
+	#[test]
+	fn test_properties_serializes_as_valid_hashmap() {
+		let properties = Properties;
+		let ctxt = Context::new_dbus(LE, 0);
+		let bytes = zvariant::to_bytes::<Properties>(ctxt, &properties).unwrap();
+
+		let (map, _) = bytes.deserialize::<HashMap<&str, Value>>().unwrap();
+
+		assert_eq!(map, HashMap::new());
+	}
+
+	#[test]
+	fn test_qt_properties_serializes_as_valid_string_objpath_tuple() {
+		let qt_properties = QtProperties;
+		let ctxt = Context::new_dbus(LE, 0);
+		let bytes = zvariant::to_bytes::<QtProperties>(ctxt, &qt_properties).unwrap();
+
+		let (tuple, _) = bytes.deserialize::<(&str, ObjectPath)>().unwrap();
+
+		assert_eq!(tuple, (":0.0", ObjectPath::from_static_str_unchecked("/")));
+	}
+
+	#[test]
+	fn test_qt_properties_serializes_as_valid_object_ref() {
+		let qt_properties = QtProperties;
+		let ctxt = Context::new_dbus(LE, 0);
+		let bytes = zvariant::to_bytes::<QtProperties>(ctxt, &qt_properties).unwrap();
+
+		let (objectref, _) = bytes.deserialize::<ObjectRef>().unwrap();
+
+		assert_eq!(objectref.name, ":0.0");
+		assert_eq!(objectref.path, ObjectPath::from_static_str_unchecked("/").into());
+	}
+
+	#[cfg(test)]
+	mod signatures {
+		#[test]
+		fn test_event_body_signature_equals_borrowed_event_body_signature() {
+			use super::*;
+			use zvariant::Type;
+
+			let borrowed = EventBodyBorrow::SIGNATURE;
+			let owned = EventBodyOwned::SIGNATURE;
+
+			assert_eq!(borrowed, owned);
+		}
+	}
+}

--- a/atspi-common/src/events/event_body.rs
+++ b/atspi-common/src/events/event_body.rs
@@ -10,10 +10,10 @@ use zvariant::{ObjectPath, OwnedValue, Type, Value};
 ///
 /// Signature:  "siiv(so)"
 #[derive(Debug, Serialize, Deserialize, PartialEq, Type)]
-pub struct EventBodyQT {
+pub struct EventBodyQtOwned {
 	/// kind variant, used for specifying an event triple "object:state-changed:focused",
 	/// the "focus" part of this event is what is contained within the kind.
-	// #[serde(rename = "type")]
+	#[serde(rename = "type")]
 	pub kind: String,
 
 	/// Generic detail1 value described by AT-SPI.
@@ -32,7 +32,7 @@ pub struct EventBodyQT {
 	pub(crate) properties: QtProperties,
 }
 
-impl Clone for EventBodyQT {
+impl Clone for EventBodyQtOwned {
 	/// # Safety  
 	///
 	/// This implementation of [`Clone`] *can panic!* although chances are slim.
@@ -61,9 +61,9 @@ impl Clone for EventBodyQT {
 	}
 }
 
-/// Unit struct placeholder for `EventBodyQT.properties`
+/// Unit struct placeholder for `EventBodyQtOwned.properties`
 ///
-/// AT-SPI2 never reads or writes to `EventBodyQT.properties`.  
+/// AT-SPI2 never reads or writes to `properties`.  
 /// `QtProperties` has the appropriate implementations for `Serialize` and `Deserialize`  
 /// to make it serialize as an a valid tuple and valid bytes deserialize as placeholder.
 #[derive(Debug, Copy, Clone, Deserialize, Type, Default, PartialEq)]
@@ -82,7 +82,7 @@ impl Serialize for QtProperties {
 	}
 }
 
-impl Default for EventBodyQT {
+impl Default for EventBodyQtOwned {
 	fn default() -> Self {
 		Self {
 			kind: String::new(),
@@ -116,7 +116,7 @@ impl Serialize for Properties {
 ///
 /// All of the various signals in the AT-SPI2 protocol share this shape.
 /// Most toolkits and implementors emit this type, except for `Qt`, which has has its
-/// own type: [`EventBodyQT`].
+/// own type: [`EventBodyQtOwned`].
 ///
 /// Signature `(siiva{sv})`,
 #[validate(signal: "PropertyChange")]
@@ -161,7 +161,7 @@ impl Clone for EventBodyOwned {
 	/// This implementation of [`Clone`] *can panic!* although chances are slim.
 	///
 	/// If the following conditions are met:
-	/// 1. the `any_data` or `properties` field contain an [`std::os::fd::OwnedFd`] type, and
+	/// 1. the `any_data` field contains an [`std::os::fd::OwnedFd`] type, and
 	/// 2. the maximum number of open files for the process is exceeded.
 	///
 	/// Then this function panic.  
@@ -185,7 +185,7 @@ impl Clone for EventBodyOwned {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Type)]
-pub struct EventBodyBorrow<'a> {
+pub struct EventBodyBorrowed<'a> {
 	/// kind variant, used for specifying an event triple "object:state-changed:focused",
 	/// the "focus" part of this event is what is contained within the kind.
 	#[serde(rename = "type")]
@@ -209,7 +209,7 @@ pub struct EventBodyBorrow<'a> {
 	pub(crate) properties: Properties,
 }
 
-impl Default for EventBodyBorrow<'_> {
+impl Default for EventBodyBorrowed<'_> {
 	fn default() -> Self {
 		Self {
 			kind: "",
@@ -221,7 +221,7 @@ impl Default for EventBodyBorrow<'_> {
 	}
 }
 
-impl EventBodyBorrow<'_> {
+impl EventBodyBorrowed<'_> {
 	/// Convert this borrowed event body to an owned event body.
 	///
 	/// # Errors
@@ -245,13 +245,13 @@ impl EventBodyBorrow<'_> {
 	}
 }
 
-impl Clone for EventBodyBorrow<'_> {
+impl Clone for EventBodyBorrowed<'_> {
 	/// # Safety  
 	///
 	/// This implementation of [`Clone`] *can panic!* although chances are slim.
 	///
 	/// If the following conditions are met:
-	/// 1. the `any_data` or `properties` field contain an [`std::os::fd::OwnedFd`] type, and
+	/// 1. the `any_data` field contains an [`std::os::fd::OwnedFd`] type, and  
 	/// 2. the maximum number of open files for the process is exceeded.
 	///
 	/// Then this function panic.  
@@ -275,7 +275,7 @@ impl Clone for EventBodyBorrow<'_> {
 }
 
 #[derive(Debug, Type, Deserialize, PartialEq)]
-pub struct EventBodyQTBorrow<'m> {
+pub struct EventBodyQtBorrowed<'m> {
 	/// kind variant, used for specifying an event triple "object:state-changed:focused",
 	/// the "focus" part of this event is what is contained within the kind.
 	#[serde(rename = "type")]
@@ -298,7 +298,7 @@ pub struct EventBodyQTBorrow<'m> {
 	pub(crate) properties: QtProperties,
 }
 
-impl Default for EventBodyQTBorrow<'_> {
+impl Default for EventBodyQtBorrowed<'_> {
 	fn default() -> Self {
 		Self {
 			kind: "",
@@ -310,16 +310,16 @@ impl Default for EventBodyQTBorrow<'_> {
 	}
 }
 
-impl Clone for EventBodyQTBorrow<'_> {
+impl Clone for EventBodyQtBorrowed<'_> {
 	/// # Safety  
 	///
 	/// This implementation of [`Clone`] *can panic!* although chances are slim.
 	///
 	/// If the following conditions are met:
-	/// 1. the `any_data` or `properties` field contain an [`std::os::fd::OwnedFd`] type, and
+	/// 1. the `any_data` field contains an [`std::os::fd::OwnedFd`] type, and
 	/// 2. the maximum number of open files for the process is exceeded.
 	///
-	/// Then this function panic.  
+	/// Then this function panics.  
 	/// None of the types in [`crate::events`] use [`std::os::fd::OwnedFd`].
 	/// Events on the AT-SPI bus *could, theoretically* send a file descriptor, but nothing in the current
 	/// specification describes that.  
@@ -339,7 +339,7 @@ impl Clone for EventBodyQTBorrow<'_> {
 	}
 }
 
-impl EventBodyQTBorrow<'_> {
+impl EventBodyQtBorrowed<'_> {
 	/// Convert partially borrowed Qt event body to an owned event body.
 	///
 	/// # Errors
@@ -347,10 +347,10 @@ impl EventBodyQTBorrow<'_> {
 	/// This will error if the following conditions are met:
 	/// 1. the `any_data` field contains an [`std::os::fd::OwnedFd`] type, and
 	/// 2. the maximum number of open files for the process is exceeded.
-	pub fn try_to_owned(&self) -> Result<EventBodyQT, AtspiError> {
+	pub fn try_to_owned(&self) -> Result<EventBodyQtOwned, AtspiError> {
 		let any_data = self.any_data.try_to_owned()?;
 
-		Ok(EventBodyQT {
+		Ok(EventBodyQtOwned {
 			kind: self.kind.to_owned(),
 			detail1: self.detail1,
 			detail2: self.detail2,
@@ -360,16 +360,16 @@ impl EventBodyQTBorrow<'_> {
 	}
 }
 
-impl<'de> From<EventBodyQTBorrow<'de>> for EventBodyBorrow<'de> {
-	fn from(borrow: EventBodyQTBorrow<'de>) -> Self {
-		let EventBodyQTBorrow { kind, detail1, detail2, any_data, properties: _ } = borrow;
+impl<'de> From<EventBodyQtBorrowed<'de>> for EventBodyBorrowed<'de> {
+	fn from(borrow: EventBodyQtBorrowed<'de>) -> Self {
+		let EventBodyQtBorrowed { kind, detail1, detail2, any_data, properties: _ } = borrow;
 
 		Self { kind, detail1, detail2, any_data, properties: Properties }
 	}
 }
 
-impl From<EventBodyQT> for EventBodyOwned {
-	fn from(body: EventBodyQT) -> Self {
+impl From<EventBodyQtOwned> for EventBodyOwned {
+	fn from(body: EventBodyQtOwned) -> Self {
 		Self {
 			kind: body.kind,
 			detail1: body.detail1,
@@ -387,12 +387,12 @@ impl From<EventBodyQT> for EventBodyOwned {
 #[derive(Debug, Clone, PartialEq)]
 pub enum EventBody<'a> {
 	Owned(EventBodyOwned),
-	Borrowed(EventBodyBorrow<'a>),
+	Borrowed(EventBodyBorrowed<'a>),
 }
 
 impl Default for EventBody<'_> {
 	fn default() -> Self {
-		Self::Borrowed(EventBodyBorrow::default())
+		Self::Borrowed(EventBodyBorrowed::default())
 	}
 }
 
@@ -505,7 +505,7 @@ impl<'de> Deserialize<'de> for EventBody<'de> {
 	where
 		D: serde::de::Deserializer<'de>,
 	{
-		let borrowed = EventBodyBorrow::deserialize(deserializer)?;
+		let borrowed = EventBodyBorrowed::deserialize(deserializer)?;
 		Ok(borrowed.into())
 	}
 }
@@ -528,25 +528,25 @@ impl From<EventBodyOwned> for EventBody<'_> {
 	}
 }
 
-impl<'b> From<EventBodyBorrow<'b>> for EventBody<'b> {
-	fn from(borrowed: EventBodyBorrow<'b>) -> Self {
+impl<'b> From<EventBodyBorrowed<'b>> for EventBody<'b> {
+	fn from(borrowed: EventBodyBorrowed<'b>) -> Self {
 		EventBody::Borrowed(borrowed)
 	}
 }
 
-impl From<EventBodyQT> for EventBody<'_> {
-	fn from(qt_owned: EventBodyQT) -> Self {
+impl From<EventBodyQtOwned> for EventBody<'_> {
+	fn from(qt_owned: EventBodyQtOwned) -> Self {
 		EventBody::Owned(qt_owned.into())
 	}
 }
 
-impl<'a> From<EventBodyQTBorrow<'a>> for EventBody<'a> {
-	fn from(qt_borrowed: EventBodyQTBorrow<'a>) -> Self {
+impl<'a> From<EventBodyQtBorrowed<'a>> for EventBody<'a> {
+	fn from(qt_borrowed: EventBodyQtBorrowed<'a>) -> Self {
 		EventBody::Borrowed(qt_borrowed.into())
 	}
 }
 
-impl From<EventBodyOwned> for EventBodyQT {
+impl From<EventBodyOwned> for EventBodyQtOwned {
 	fn from(owned: EventBodyOwned) -> Self {
 		Self {
 			kind: owned.kind,
@@ -558,8 +558,8 @@ impl From<EventBodyOwned> for EventBodyQT {
 	}
 }
 
-impl<'a> From<EventBodyBorrow<'a>> for EventBodyQT {
-	fn from(borrowed: EventBodyBorrow<'a>) -> Self {
+impl<'a> From<EventBodyBorrowed<'a>> for EventBodyQtOwned {
+	fn from(borrowed: EventBodyBorrowed<'a>) -> Self {
 		Self {
 			kind: borrowed.kind.to_owned(),
 			detail1: borrowed.detail1,
@@ -573,7 +573,7 @@ impl<'a> From<EventBodyBorrow<'a>> for EventBodyQT {
 	}
 }
 
-impl From<EventBody<'_>> for EventBodyQT {
+impl From<EventBody<'_>> for EventBodyQtOwned {
 	fn from(event: EventBody) -> Self {
 		match event {
 			EventBody::Owned(owned) => owned.into(),
@@ -582,7 +582,7 @@ impl From<EventBody<'_>> for EventBodyQT {
 	}
 }
 
-impl PartialEq<EventBodyOwned> for EventBodyQT {
+impl PartialEq<EventBodyOwned> for EventBodyQtOwned {
 	fn eq(&self, other: &EventBodyOwned) -> bool {
 		self.kind == other.kind
 			&& self.detail1 == other.detail1
@@ -591,8 +591,8 @@ impl PartialEq<EventBodyOwned> for EventBodyQT {
 	}
 }
 
-impl PartialEq<EventBodyQT> for EventBodyOwned {
-	fn eq(&self, other: &EventBodyQT) -> bool {
+impl PartialEq<EventBodyQtOwned> for EventBodyOwned {
+	fn eq(&self, other: &EventBodyQtOwned) -> bool {
 		self.kind == other.kind
 			&& self.detail1 == other.detail1
 			&& self.detail2 == other.detail2
@@ -600,8 +600,8 @@ impl PartialEq<EventBodyQT> for EventBodyOwned {
 	}
 }
 
-impl PartialEq<EventBodyBorrow<'_>> for EventBodyQTBorrow<'_> {
-	fn eq(&self, other: &EventBodyBorrow<'_>) -> bool {
+impl PartialEq<EventBodyBorrowed<'_>> for EventBodyQtBorrowed<'_> {
+	fn eq(&self, other: &EventBodyBorrowed<'_>) -> bool {
 		self.kind == other.kind
 			&& self.detail1 == other.detail1
 			&& self.detail2 == other.detail2
@@ -609,8 +609,8 @@ impl PartialEq<EventBodyBorrow<'_>> for EventBodyQTBorrow<'_> {
 	}
 }
 
-impl PartialEq<EventBodyQTBorrow<'_>> for EventBodyBorrow<'_> {
-	fn eq(&self, other: &EventBodyQTBorrow<'_>) -> bool {
+impl PartialEq<EventBodyQtBorrowed<'_>> for EventBodyBorrowed<'_> {
+	fn eq(&self, other: &EventBodyQtBorrowed<'_>) -> bool {
 		self.kind == other.kind
 			&& self.detail1 == other.detail1
 			&& self.detail2 == other.detail2
@@ -636,7 +636,7 @@ mod test {
 
 	#[test]
 	fn event_body_qt_clone() {
-		let event = EventBodyQT::default();
+		let event = EventBodyQtOwned::default();
 		let cloned = event.clone();
 
 		assert_eq!(event, cloned);
@@ -644,7 +644,7 @@ mod test {
 
 	#[test]
 	fn event_body_borrowed_clone() {
-		let event = EventBodyBorrow::default();
+		let event = EventBodyBorrowed::default();
 		let cloned = event.clone();
 
 		assert_eq!(event, cloned);
@@ -652,7 +652,7 @@ mod test {
 
 	#[test]
 	fn event_body_qt_borrowed_clone() {
-		let event = EventBodyQTBorrow::default();
+		let event = EventBodyQtBorrowed::default();
 		let cloned = event.clone();
 
 		assert_eq!(event, cloned);
@@ -670,7 +670,7 @@ mod test {
 
 	#[test]
 	fn qt_event_body_default() {
-		let event = EventBodyQT::default();
+		let event = EventBodyQtOwned::default();
 
 		assert_eq!(event.kind, "");
 		assert_eq!(event.detail1, 0);
@@ -681,7 +681,7 @@ mod test {
 
 	#[test]
 	fn event_body_borrowed_default() {
-		let event = EventBodyBorrow::default();
+		let event = EventBodyBorrowed::default();
 
 		assert_eq!(event.kind, "");
 		assert_eq!(event.detail1, 0);
@@ -691,7 +691,7 @@ mod test {
 
 	#[test]
 	fn qt_event_body_borrowed_default() {
-		let event = EventBodyQTBorrow::default();
+		let event = EventBodyQtBorrowed::default();
 
 		assert_eq!(event.kind, "");
 		assert_eq!(event.detail1, 0);
@@ -704,22 +704,22 @@ mod test {
 	fn event_body_default() {
 		let event = EventBody::default();
 
-		assert_eq!(event, EventBody::Borrowed(EventBodyBorrow::default()));
+		assert_eq!(event, EventBody::Borrowed(EventBodyBorrowed::default()));
 	}
 
 	#[test]
 	fn qt_to_owned() {
-		let qt = EventBodyQT::default();
-		let owned: EventBodyOwned = EventBodyQT::default().into();
+		let qt = EventBodyQtOwned::default();
+		let owned: EventBodyOwned = EventBodyQtOwned::default().into();
 
 		assert_eq!(owned, qt);
 	}
 
 	#[test]
 	fn borrowed_to_qt() {
-		let borrowed: EventBodyBorrow = EventBodyQTBorrow::default().into();
+		let borrowed: EventBodyBorrowed = EventBodyQtBorrowed::default().into();
 
-		assert_eq!(borrowed, EventBodyBorrow::default());
+		assert_eq!(borrowed, EventBodyBorrowed::default());
 	}
 
 	#[test]
@@ -741,9 +741,9 @@ mod test {
 		let ctxt = Context::new_dbus(LE, 0);
 		let bytes = zvariant::to_bytes::<EventBodyOwned>(ctxt, &event).unwrap();
 
-		let (deserialized, _) = bytes.deserialize::<EventBodyBorrow>().unwrap();
+		let (deserialized, _) = bytes.deserialize::<EventBodyBorrowed>().unwrap();
 
-		assert_eq!(deserialized, EventBodyBorrow::default());
+		assert_eq!(deserialized, EventBodyBorrowed::default());
 		assert_eq!(deserialized.kind, event.kind.as_str());
 		assert_eq!(deserialized.detail1, event.detail1);
 		assert_eq!(deserialized.detail2, event.detail2);
@@ -752,14 +752,14 @@ mod test {
 
 	#[test]
 	fn qt_owned_event_body_deserialize_as_borrowed() {
-		let event = EventBodyQT::default();
+		let event = EventBodyQtOwned::default();
 
 		let ctxt = Context::new_dbus(LE, 0);
-		let bytes = zvariant::to_bytes::<EventBodyQT>(ctxt, &event).unwrap();
+		let bytes = zvariant::to_bytes::<EventBodyQtOwned>(ctxt, &event).unwrap();
 
-		let (deserialized, _) = bytes.deserialize::<EventBodyBorrow>().unwrap();
+		let (deserialized, _) = bytes.deserialize::<EventBodyBorrowed>().unwrap();
 
-		assert_eq!(deserialized, EventBodyBorrow::default());
+		assert_eq!(deserialized, EventBodyBorrowed::default());
 		assert_eq!(deserialized.kind, event.kind.as_str());
 		assert_eq!(deserialized.detail1, event.detail1);
 		assert_eq!(deserialized.detail2, event.detail2);
@@ -860,7 +860,7 @@ mod test {
 			zvariant::to_bytes::<(&str, i32, i32, Value, HashMap<&str, Value>)>(ctxt, &event)
 				.unwrap();
 
-		let (deserialized, _) = bytes.deserialize::<EventBodyBorrow>().unwrap();
+		let (deserialized, _) = bytes.deserialize::<EventBodyBorrowed>().unwrap();
 
 		assert_eq!(deserialized.kind, "object:state-changed:focused");
 		assert_eq!(deserialized.detail1, 1);
@@ -977,7 +977,7 @@ mod test {
 			use super::*;
 			use zvariant::Type;
 
-			let borrowed = EventBodyBorrow::SIGNATURE;
+			let borrowed = EventBodyBorrowed::SIGNATURE;
 			let owned = EventBodyOwned::SIGNATURE;
 
 			assert_eq!(borrowed, owned);

--- a/atspi-common/src/events/keyboard.rs
+++ b/atspi-common/src/events/keyboard.rs
@@ -4,12 +4,11 @@ use crate::{
 	events::{MessageConversion, MessageConversionExt},
 	ObjectRef,
 };
-use crate::{
-	events::{BusProperties, EventBodyOwned},
-	EventProperties,
-};
+use crate::{events::event_body::EventBodyOwned, EventProperties};
 use zbus_names::UniqueName;
 use zvariant::{ObjectPath, OwnedValue};
+
+use super::{event_body::Properties, BusProperties};
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct ModifiersEvent {
@@ -53,7 +52,7 @@ impl_event_properties!(ModifiersEvent);
 impl From<ModifiersEvent> for EventBodyOwned {
 	fn from(event: ModifiersEvent) -> Self {
 		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
+			properties: Properties,
 			kind: String::default(),
 			detail1: event.previous_modifiers,
 			detail2: event.current_modifiers,

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -3,7 +3,7 @@ pub mod document;
 #[cfg(feature = "wrappers")]
 pub mod event_wrappers;
 
-pub use event_body::{EventBodyBorrow, EventBodyOwned, EventBodyQT, EventBodyQTBorrow};
+pub use event_body::{EventBodyBorrowed, EventBodyOwned, EventBodyQtBorrowed, EventBodyQtOwned};
 #[cfg(feature = "wrappers")]
 pub use event_wrappers::{
 	CacheEvents, DocumentEvents, Event, FocusEvents, KeyboardEvents, MouseEvents, ObjectEvents,
@@ -538,14 +538,14 @@ where
 		let data_body: EventBodyOwned = if body_sig == EventBodyOwned::SIGNATURE {
 			body.deserialize_unchecked()?
 		} else if body_sig == QSPI_EVENT_SIGNATURE {
-			let qtbody: EventBodyQT = body.deserialize_unchecked()?;
+			let qtbody: EventBodyQtOwned = body.deserialize_unchecked()?;
 			qtbody.into()
 		} else {
 			return Err(AtspiError::SignatureMatch(format!(
 				"The message signature {} does not match the signal's body signature: {} or {}",
 				body_sig,
 				EventBodyOwned::SIGNATURE,
-				EventBodyQT::SIGNATURE,
+				EventBodyQtOwned::SIGNATURE,
 			)));
 		};
 		let item = msg.try_into()?;

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -3,7 +3,7 @@ pub mod document;
 #[cfg(feature = "wrappers")]
 pub mod event_wrappers;
 
-use event_body::{EventBodyOwned, EventBodyQT};
+pub use event_body::{EventBodyBorrow, EventBodyOwned, EventBodyQT, EventBodyQTBorrow};
 #[cfg(feature = "wrappers")]
 pub use event_wrappers::{
 	CacheEvents, DocumentEvents, Event, FocusEvents, KeyboardEvents, MouseEvents, ObjectEvents,

--- a/atspi-common/src/events/mod.rs
+++ b/atspi-common/src/events/mod.rs
@@ -2,11 +2,13 @@ pub mod cache;
 pub mod document;
 #[cfg(feature = "wrappers")]
 pub mod event_wrappers;
+use event_body::{EventBodyOwned, EventBodyQT};
 #[cfg(feature = "wrappers")]
 pub use event_wrappers::{
 	CacheEvents, DocumentEvents, Event, FocusEvents, KeyboardEvents, MouseEvents, ObjectEvents,
 	TerminalEvents, WindowEvents,
 };
+pub mod event_body;
 pub mod focus;
 pub mod keyboard;
 pub mod mouse;
@@ -65,8 +67,6 @@ pub const CACHE_ADD_SIGNATURE: &Signature = &Signature::static_structure(&[
 	&Signature::Array(Child::Static { child: &Signature::U32 }),
 ]);
 
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 use zbus_lockstep_macros::validate;
 use zbus_names::{OwnedUniqueName, UniqueName};
@@ -74,153 +74,12 @@ use zbus_names::{OwnedUniqueName, UniqueName};
 use zvariant::OwnedObjectPath;
 use zvariant::{
 	signature::{Child, Fields},
-	ObjectPath, OwnedValue, Signature, Type, Value,
+	ObjectPath, Signature, Type,
 };
 
 #[cfg(feature = "zbus")]
 use crate::AtspiError;
 use crate::ObjectRef;
-
-/// Qt event body, which is not the same as other GUI frameworks.
-/// Signature:  "siiv(so)"
-#[derive(Debug, Serialize, Deserialize, Type, PartialEq)]
-pub struct EventBodyQT {
-	/// kind variant, used for specifying an event triple "object:state-changed:focused",
-	/// the "focus" part of this event is what is contained within the kind.
-	// #[serde(rename = "type")]
-	pub kind: String,
-	/// Generic detail1 value described by AT-SPI.
-	pub detail1: i32,
-	/// Generic detail2 value described by AT-SPI.
-	pub detail2: i32,
-	/// Generic `any_data` value described by AT-SPI.
-	/// This can be any type.
-	pub any_data: OwnedValue,
-	/// A tuple of properties.
-	/// Not in use.
-	pub properties: ObjectRef,
-}
-impl From<EventBodyOwned> for EventBodyQT {
-	fn from(ev: EventBodyOwned) -> Self {
-		EventBodyQT {
-			kind: ev.kind,
-			detail1: ev.detail1,
-			detail2: ev.detail2,
-			any_data: ev.any_data,
-			properties: ObjectRef::default(),
-		}
-	}
-}
-
-impl Default for EventBodyQT {
-	fn default() -> Self {
-		Self {
-			kind: String::new(),
-			detail1: 0,
-			detail2: 0,
-			any_data: 0u8.into(),
-			properties: ObjectRef::default(),
-		}
-	}
-}
-
-/// Standard event body (GTK, `egui`, etc.)
-/// NOTE: Qt has its own signature: [`EventBodyQT`].
-/// Signature `(siiva{sv})`,
-#[validate(signal: "PropertyChange")]
-#[derive(Debug, Serialize, Deserialize, Type, PartialEq)]
-pub struct EventBodyOwned {
-	/// kind variant, used for specifying an event triple "object:state-changed:focused",
-	/// the "focus" part of this event is what is contained within the kind.
-	#[serde(rename = "type")]
-	pub kind: String,
-	/// Generic detail1 value described by AT-SPI.
-	pub detail1: i32,
-	/// Generic detail2 value described by AT-SPI.
-	pub detail2: i32,
-	/// Generic `any_data` value described by AT-SPI.
-	/// This can be any type.
-	pub any_data: OwnedValue,
-	/// A map of properties.
-	/// Not in use.
-	pub properties: HashMap<OwnedUniqueName, OwnedValue>,
-}
-
-impl From<EventBodyQT> for EventBodyOwned {
-	fn from(body: EventBodyQT) -> Self {
-		let mut props = HashMap::new();
-
-		let name = body.properties.name;
-		let path = body.properties.path;
-
-		// We know `path` is a `OwnedObjectPath`, so the conversion to
-		// `OwnedValue` is infallible at present.
-		// Should this ever change, we need to know.
-		let value = Value::ObjectPath(path.into()).try_to_owned().unwrap_or_else(|err| {
-			panic!("Error occurred: {err:?}");
-		});
-
-		props.insert(name, value);
-		Self {
-			kind: body.kind,
-			detail1: body.detail1,
-			detail2: body.detail2,
-			any_data: body.any_data,
-			properties: props,
-		}
-	}
-}
-
-impl Default for EventBodyOwned {
-	fn default() -> Self {
-		Self {
-			kind: String::new(),
-			detail1: 0,
-			detail2: 0,
-			any_data: 0u8.into(),
-			properties: HashMap::new(),
-		}
-	}
-}
-
-/// Safety: This implementation of [`Clone`] *can panic!* Although the chance is extremely remote.
-///
-/// If:
-/// 1. the `any_data` or `properties` field contain an [`std::os::fd::OwnedFd`] type, and
-/// 2. the maximum number of open files for the process is exceeded.
-///
-/// Then, and only then, will this function panic.
-/// None of the types in [`crate::events`] use [`std::os::fd::OwnedFd`].
-/// Events on the AT-SPI bus *could, theoretically* send a file descriptor, but nothing in the
-/// specification allows that.
-///
-/// See [`zvariant::Value::try_clone`] for more information.
-impl Clone for EventBodyOwned {
-	fn clone(&self) -> Self {
-		let cloned_any_data = self.any_data.try_clone().unwrap_or_else(|err| {
-			panic!("Failure cloning 'any_data' field: {err:?}");
-		});
-
-		let cloned_properties = {
-			let mut map = HashMap::new();
-			for (key, value) in &self.properties {
-				let cloned_value = value.try_clone().unwrap_or_else(|err| {
-					panic!("Failure cloning 'props' field: {err:?}");
-				});
-				map.insert(key.clone(), cloned_value);
-			}
-			map
-		};
-
-		Self {
-			kind: self.kind.clone(),
-			detail1: self.detail1,
-			detail2: self.detail2,
-			any_data: cloned_any_data,
-			properties: cloned_properties,
-		}
-	}
-}
 
 impl HasInterfaceName for EventListenerEvents {
 	const DBUS_INTERFACE: &'static str = "org.a11y.atspi.Registry";
@@ -748,28 +607,5 @@ impl<T: EventWrapperMessageConversion + HasInterfaceName> TryFromMessage for T {
 			)));
 		}
 		<T as EventWrapperMessageConversion>::try_from_message_interface_checked(msg)
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use super::{EventBodyOwned, EventBodyQT, QSPI_EVENT_SIGNATURE};
-	use std::collections::HashMap;
-	use zvariant::{ObjectPath, Type};
-
-	#[test]
-	fn check_event_body_qt_signature() {
-		assert_eq!(<EventBodyQT as Type>::SIGNATURE, QSPI_EVENT_SIGNATURE);
-	}
-
-	#[test]
-	fn test_event_body_qt_to_event_body_owned_conversion() {
-		let event_body: EventBodyOwned = EventBodyQT::default().into();
-
-		let accessible = crate::ObjectRef::default();
-		let name = accessible.name;
-		let path = accessible.path;
-		let props = HashMap::from([(name, ObjectPath::from(path).into())]);
-		assert_eq!(event_body.properties, props);
 	}
 }

--- a/atspi-common/src/events/mouse.rs
+++ b/atspi-common/src/events/mouse.rs
@@ -123,13 +123,7 @@ impl_from_dbus_message!(AbsEvent);
 impl_event_properties!(AbsEvent);
 impl From<AbsEvent> for EventBodyOwned {
 	fn from(event: AbsEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: event.x,
-			detail2: event.y,
-			any_data: u8::default().into(),
-		}
+		EventBodyOwned { detail1: event.x, detail2: event.y, ..Default::default() }
 	}
 }
 
@@ -139,13 +133,7 @@ impl_from_dbus_message!(RelEvent);
 impl_event_properties!(RelEvent);
 impl From<RelEvent> for EventBodyOwned {
 	fn from(event: RelEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: event.x,
-			detail2: event.y,
-			any_data: u8::default().into(),
-		}
+		EventBodyOwned { detail1: event.x, detail2: event.y, ..Default::default() }
 	}
 }
 
@@ -156,11 +144,10 @@ impl_event_properties!(ButtonEvent);
 impl From<ButtonEvent> for EventBodyOwned {
 	fn from(event: ButtonEvent) -> Self {
 		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
 			kind: event.detail,
 			detail1: event.mouse_x,
 			detail2: event.mouse_y,
-			any_data: u8::default().into(),
+			..Default::default()
 		}
 	}
 }

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -10,6 +10,8 @@ use crate::{
 use zbus_names::UniqueName;
 use zvariant::{ObjectPath, OwnedValue, Value};
 
+use super::event_body::Properties;
+
 /// The `org.a11y.atspi.Event.Object:PropertyChange` event.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PropertyChangeEvent {
@@ -727,13 +729,7 @@ impl_event_properties!(PropertyChangeEvent);
 
 impl From<PropertyChangeEvent> for EventBodyOwned {
 	fn from(event: PropertyChangeEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: event.property,
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: event.value.into(),
-		}
+		EventBodyOwned { kind: event.property, any_data: event.value.into(), ..Default::default() }
 	}
 }
 
@@ -756,11 +752,9 @@ impl_event_properties!(StateChangedEvent);
 impl From<StateChangedEvent> for EventBodyOwned {
 	fn from(event: StateChangedEvent) -> Self {
 		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
 			kind: event.state.to_string(),
 			detail1: event.enabled.into(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
+			..Default::default()
 		}
 	}
 }
@@ -772,16 +766,16 @@ impl_event_properties!(ChildrenChangedEvent);
 impl From<ChildrenChangedEvent> for EventBodyOwned {
 	fn from(event: ChildrenChangedEvent) -> Self {
 		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
 			kind: event.operation.to_string(),
 			detail1: event.index_in_parent,
-			detail2: i32::default(),
+
 			// `OwnedValue` is constructed from the `crate::ObjectRef`
 			// Only path to fail is to convert a Fd into an `OwnedValue`.
 			// Therefore, this is safe.
 			any_data: Value::from(event.child)
 				.try_into()
 				.expect("Failed to convert child to OwnedValue"),
+			..Default::default()
 		}
 	}
 }
@@ -811,16 +805,13 @@ impl_event_properties!(ActiveDescendantChangedEvent);
 impl From<ActiveDescendantChangedEvent> for EventBodyOwned {
 	fn from(event: ActiveDescendantChangedEvent) -> Self {
 		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: i32::default(),
-			detail2: i32::default(),
 			// `OwnedValue` is constructed from the `crate::ObjectRef`
 			// Only path to fail is to convert a Fd into an `OwnedValue`.
 			// Therefore, this is safe.
 			any_data: Value::from(event.child)
 				.try_to_owned()
 				.expect("Failed to convert child to OwnedValue"),
+			..Default::default()
 		}
 	}
 }
@@ -904,7 +895,6 @@ impl_event_properties!(TextChangedEvent);
 impl From<TextChangedEvent> for EventBodyOwned {
 	fn from(event: TextChangedEvent) -> Self {
 		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
 			kind: event.operation.to_string(),
 			detail1: event.start_pos,
 			detail2: event.length,
@@ -914,6 +904,7 @@ impl From<TextChangedEvent> for EventBodyOwned {
 			any_data: Value::from(event.text)
 				.try_to_owned()
 				.expect("Failed to convert child to OwnedValue"),
+			properties: Properties,
 		}
 	}
 }
@@ -930,12 +921,6 @@ impl_from_dbus_message!(TextCaretMovedEvent);
 impl_event_properties!(TextCaretMovedEvent);
 impl From<TextCaretMovedEvent> for EventBodyOwned {
 	fn from(event: TextCaretMovedEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: String::default(),
-			detail1: event.position,
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
+		EventBodyOwned { detail1: event.position, ..Default::default() }
 	}
 }

--- a/atspi-common/src/events/object.rs
+++ b/atspi-common/src/events/object.rs
@@ -10,7 +10,7 @@ use crate::{
 use zbus_names::UniqueName;
 use zvariant::{ObjectPath, OwnedValue, Value};
 
-use super::event_body::Properties;
+use super::{event_body::Properties, EventBodyQtOwned};
 
 /// The `org.a11y.atspi.Event.Object:PropertyChange` event.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -394,8 +394,9 @@ impl MessageConversion for PropertyChangeEvent {
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
+		// TODO: Check the likely thing first _and_ body.deserialize already checks the signature
 		let body = if msg.body().signature() == crate::events::QSPI_EVENT_SIGNATURE {
-			msg.body().deserialize::<crate::events::EventBodyQT>()?.into()
+			msg.body().deserialize::<crate::events::EventBodyQtOwned>()?.into()
 		} else {
 			msg.body().deserialize()?
 		};
@@ -440,8 +441,9 @@ impl MessageConversion for StateChangedEvent {
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
+		// TODO: Check the likely thing first _and_ body.deserialize already checks the signature
 		let body = if msg.body().signature() == crate::events::QSPI_EVENT_SIGNATURE {
-			msg.body().deserialize::<crate::events::EventBodyQT>()?.into()
+			msg.body().deserialize::<crate::events::EventBodyQtOwned>()?.into()
 		} else {
 			msg.body().deserialize()?
 		};
@@ -476,7 +478,7 @@ impl MessageConversion for ChildrenChangedEvent {
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
 		let body = if msg.body().signature() == crate::events::QSPI_EVENT_SIGNATURE {
-			msg.body().deserialize::<crate::events::EventBodyQT>()?.into()
+			msg.body().deserialize::<crate::events::EventBodyQtOwned>()?.into()
 		} else {
 			msg.body().deserialize()?
 		};
@@ -529,8 +531,9 @@ impl MessageConversion for ActiveDescendantChangedEvent {
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
+		// TODO: Check the likely thing first _and_ body.deserialize already checks the signature
 		let body = if msg.body().signature() == crate::events::QSPI_EVENT_SIGNATURE {
-			msg.body().deserialize::<crate::events::EventBodyQT>()?.into()
+			msg.body().deserialize::<crate::events::EventBodyQtOwned>()?.into()
 		} else {
 			msg.body().deserialize()?
 		};
@@ -563,8 +566,9 @@ impl MessageConversion for AnnouncementEvent {
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
+		// TODO: Check the likely thing first _and_ body.deserialize already checks the signature
 		let body = if msg.body().signature() == crate::events::QSPI_EVENT_SIGNATURE {
-			msg.body().deserialize::<crate::events::EventBodyQT>()?.into()
+			msg.body().deserialize::<crate::events::EventBodyQtOwned>()?.into()
 		} else {
 			msg.body().deserialize()?
 		};
@@ -671,8 +675,9 @@ impl MessageConversion for TextChangedEvent {
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
+		// TODO: Check the likely thing first _and_ body.deserialize already checks the signature
 		let body = if msg.body().signature() == crate::events::QSPI_EVENT_SIGNATURE {
-			msg.body().deserialize::<crate::events::EventBodyQT>()?.into()
+			msg.body().deserialize::<EventBodyQtOwned>()?.into()
 		} else {
 			msg.body().deserialize()?
 		};
@@ -709,8 +714,9 @@ impl MessageConversion for TextCaretMovedEvent {
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
+		// TODO: Check the likely thing first _and_ body.deserialize already checks the signature
 		let body = if msg.body().signature() == crate::events::QSPI_EVENT_SIGNATURE {
-			msg.body().deserialize::<crate::events::EventBodyQT>()?.into()
+			msg.body().deserialize::<EventBodyQtOwned>()?.into()
 		} else {
 			msg.body().deserialize()?
 		};

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -11,6 +11,8 @@ use crate::{
 use zbus_names::UniqueName;
 use zvariant::ObjectPath;
 
+use super::EventBodyQtOwned;
+
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize, Eq, Hash, Default)]
 pub struct PropertyChangeEvent {
 	/// The [`crate::ObjectRef`] which the event applies to.
@@ -150,8 +152,9 @@ impl MessageConversion for PropertyChangeEvent {
 	}
 	fn from_message_unchecked(msg: &zbus::Message) -> Result<Self, AtspiError> {
 		let item = msg.try_into()?;
+		// TODO: Check the likely path first. also, deserialize already checks the signature
 		let body = if msg.body().signature() == crate::events::QSPI_EVENT_SIGNATURE {
-			msg.body().deserialize::<crate::events::EventBodyQT>()?.into()
+			msg.body().deserialize::<EventBodyQtOwned>()?.into()
 		} else {
 			msg.body().deserialize()?
 		};

--- a/atspi-common/src/events/window.rs
+++ b/atspi-common/src/events/window.rs
@@ -313,13 +313,7 @@ impl_from_dbus_message!(PropertyChangeEvent);
 impl_event_properties!(PropertyChangeEvent);
 impl From<PropertyChangeEvent> for EventBodyOwned {
 	fn from(event: PropertyChangeEvent) -> Self {
-		EventBodyOwned {
-			properties: std::collections::HashMap::new(),
-			kind: event.property,
-			detail1: i32::default(),
-			detail2: i32::default(),
-			any_data: u8::default().into(),
-		}
+		EventBodyOwned { kind: event.property, ..Default::default() }
 	}
 }
 

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -292,8 +292,8 @@ macro_rules! impl_from_dbus_message {
         let body_signature = body.signature();
         let deser_body: <Self as MessageConversion>::Body = if body_signature == crate::events::EventBodyOwned::SIGNATURE {
             body.deserialize_unchecked()?
-        } else if body_signature == crate::events::EventBodyQT::SIGNATURE {
-			let qtbody: crate::events::EventBodyQT = body.deserialize_unchecked()?;
+        } else if body_signature == crate::events::EventBodyQtOwned::SIGNATURE {
+			let qtbody: crate::events::EventBodyQtOwned = body.deserialize_unchecked()?;
             qtbody.into()
         } else {
           return Err(AtspiError::SignatureMatch(format!(
@@ -435,7 +435,7 @@ macro_rules! zbus_message_qtspi_test_case {
       // in the case that the body type is EventBodyOwned, we need to also check successful
       // conversion from a QSPI-style body.
         let ev = <$type>::default();
-          let qt: crate::events::EventBodyQT = ev.body().into();
+          let qt: crate::events::EventBodyQtOwned = ev.body().into();
           let msg = zbus::Message::signal(
             ev.path(),
             ev.interface(),
@@ -446,7 +446,7 @@ macro_rules! zbus_message_qtspi_test_case {
           .unwrap()
           .build(&(qt,))
           .unwrap();
-          <$type>::try_from(&msg).expect("Should be able to use an EventBodyQT for any type whose BusProperties::Body = EventBodyOwned");
+          <$type>::try_from(&msg).expect("Should be able to use an EventBodyQtOwned for any type whose BusProperties::Body = EventBodyOwned");
         }
       #[cfg(feature = "zbus")]
      #[test]
@@ -454,7 +454,7 @@ macro_rules! zbus_message_qtspi_test_case {
       // in the case that the body type is EventBodyOwned, we need to also check successful
       // conversion from a QSPI-style body.
         let ev = <$type>::default();
-          let qt: crate::events::EventBodyQT = ev.body().into();
+          let qt: crate::events::EventBodyQtOwned = ev.body().into();
           let msg = zbus::Message::signal(
             ev.path(),
             ev.interface(),

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -273,7 +273,7 @@ macro_rules! impl_to_dbus_message {
 /// ```
 ///
 /// There is also a variant that can be used for events whose [`crate::events::MessageConversion::Body`] is not
-/// [`crate::events::EventBodyOwned`]. You can call this by setting the second parameter to `Explicit`.
+/// [`crate::events::event_body::EventBodyOwned`]. You can call this by setting the second parameter to `Explicit`.
 macro_rules! impl_from_dbus_message {
 	($type:ty) => {
 		impl_from_dbus_message!($type, Auto);

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -290,11 +290,11 @@ macro_rules! impl_from_dbus_message {
 
         let body = msg.body();
         let body_signature = body.signature();
-        let deser_body: <Self as MessageConversion>::Body = if body_signature == crate::events::QSPI_EVENT_SIGNATURE {
-            let qtbody: crate::events::EventBodyQT = body.deserialize_unchecked()?;
-            qtbody.into()
-        } else if body_signature == crate::events::ATSPI_EVENT_SIGNATURE {
+        let deser_body: <Self as MessageConversion>::Body = if body_signature == crate::events::EventBodyOwned::SIGNATURE {
             body.deserialize_unchecked()?
+        } else if body_signature == crate::events::EventBodyQT::SIGNATURE {
+			let qtbody: crate::events::EventBodyQT = body.deserialize_unchecked()?;
+            qtbody.into()
         } else {
           return Err(AtspiError::SignatureMatch(format!(
             "The message signature {} does not match the signal's body signature: {}",

--- a/atspi-connection/Cargo.toml
+++ b/atspi-connection/Cargo.toml
@@ -1,31 +1,31 @@
 [package]
-name = "atspi-connection"
-version = "0.9.0"
-edition = "2021"
-description = "A method of connecting, querying, sending and receiving over AT-SPI."
-license = "Apache-2.0 OR MIT" 
-keywords = ["screen-reader", "accessibility", "a11y", "linux"]
-categories = ["accessibility"]
-rust-version.workspace = true
-repository = "https://github.com/odilia-app/atspi/"
-readme = "README.md"
-include = ["src/**/*", "LICENSE-*", "README.md"]
+  categories             = [ "accessibility" ]
+  description            = "A method of connecting, querying, sending and receiving over AT-SPI."
+  edition                = "2021"
+  include                = [ "LICENSE-*", "README.md", "src/**/*" ]
+  keywords               = [ "a11y", "accessibility", "linux", "screen-reader" ]
+  license                = "Apache-2.0 OR MIT"
+  name                   = "atspi-connection"
+  readme                 = "README.md"
+  repository             = "https://github.com/odilia-app/atspi/"
+  rust-version.workspace = true
+  version                = "0.9.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+  # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["async-std"]
-tracing = ["dep:tracing"]
-async-std = ["zbus/async-io", "atspi-proxies/async-std", "atspi-common/async-std"]
-tokio = ["zbus/tokio", "atspi-proxies/tokio", "atspi-common/tokio"]
+  async-std = [ "atspi-common/async-std", "atspi-proxies/async-std", "zbus/async-io" ]
+  default   = [ "async-std" ]
+  tokio     = [ "atspi-common/tokio", "atspi-proxies/tokio", "zbus/tokio" ]
+  tracing   = [ "dep:tracing" ]
 
 [dependencies]
-atspi-common = { path = "../atspi-common/", version = "0.9.0", default-features = false, features = ["wrappers"] }
-atspi-proxies = { path = "../atspi-proxies/", version = "0.9.0", default-features = false }
-futures-lite = { version = "2", default-features = false }
-tracing = { optional = true, workspace = true }
-zbus.workspace = true
+  atspi-common   = { path = "../atspi-common/", version = "0.9.0", default-features = false, features = [ "wrappers" ] }
+  atspi-proxies  = { path = "../atspi-proxies/", version = "0.9.0", default-features = false }
+  futures-lite   = { version = "2", default-features = false }
+  tracing        = { optional = true, workspace = true }
+  zbus.workspace = true
 
 [dev-dependencies]
-tokio-test = "0.4.2"
-enumflags2.workspace = true
+  enumflags2.workspace = true
+  tokio-test           = "0.4.2"

--- a/atspi-proxies/Cargo.toml
+++ b/atspi-proxies/Cargo.toml
@@ -1,40 +1,40 @@
 [package]
-name = "atspi-proxies"
-version = "0.9.0"
-description = "AT-SPI2 proxies to query or manipulate UI objects"
-license = "Apache-2.0 OR MIT"
-readme = "README.md"
-repository = "https://github.com/odilia-app/atspi"
-homepage = "https://github.com/odilia-app/atspi"
-keywords = ["screen-reader", "accessibility", "a11y", "tts", "linux"]
-categories = ["accessibility", "api-bindings"]
-edition = "2021"
-rust-version.workspace = true
-include = ["src/**/*", "README.md"]
+  categories             = [ "accessibility", "api-bindings" ]
+  description            = "AT-SPI2 proxies to query or manipulate UI objects"
+  edition                = "2021"
+  homepage               = "https://github.com/odilia-app/atspi"
+  include                = [ "README.md", "src/**/*" ]
+  keywords               = [ "a11y", "accessibility", "linux", "screen-reader", "tts" ]
+  license                = "Apache-2.0 OR MIT"
+  name                   = "atspi-proxies"
+  readme                 = "README.md"
+  repository             = "https://github.com/odilia-app/atspi"
+  rust-version.workspace = true
+  version                = "0.9.0"
 
-[package.metadata.release]
-release = true
-publish = true
+  [package.metadata.release]
+    publish = true
+    release = true
 
 [features]
-default = ["async-std"]
-async-std = ["zbus/async-io", "atspi-common/async-std"]
-tokio = ["zbus/tokio", "atspi-common/tokio"]
+  async-std = [ "atspi-common/async-std", "zbus/async-io" ]
+  default   = [ "async-std" ]
+  tokio     = [ "atspi-common/tokio", "zbus/tokio" ]
 
 [dependencies]
-atspi-common = { path = "../atspi-common", version = "0.9.0", default-features = false }
-serde = { version = "^1.0", default-features = false, features = ["derive"] }
-zbus = { workspace = true }
+  atspi-common = { path = "../atspi-common", version = "0.9.0", default-features = false }
+  serde        = { version = "^1.0", default-features = false, features = [ "derive" ] }
+  zbus         = { workspace = true }
 
 [dev-dependencies]
-async-std = { version = "1", features = ["attributes"] }
-atspi-common = { path = "../atspi-common", version = "0.9.0", features = ["async-std"] }
-byteorder = "1.4"
-futures-lite = { version = "2", default-features = false }
-rename-item = "0.1.0"
-serde_json = "1.0.96"
-serde_plain = "1.0.1"
-tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
-tokio-stream = "0.1"
-tokio-test = "0.4.2"
-tracing = "0.1.37"
+  async-std    = { version = "1", features = [ "attributes" ] }
+  atspi-common = { path = "../atspi-common", version = "0.9.0", features = [ "async-std" ] }
+  byteorder    = "1.4"
+  futures-lite = { version = "2", default-features = false }
+  rename-item  = "0.1.0"
+  serde_json   = "1.0.96"
+  serde_plain  = "1.0.1"
+  tokio        = { version = "1", default-features = false, features = [ "macros", "rt-multi-thread" ] }
+  tokio-stream = "0.1"
+  tokio-test   = "0.4.2"
+  tracing      = "0.1.37"

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -1,71 +1,71 @@
 [package]
-name = "atspi"
-version = "0.25.0"
-authors.workspace = true
-edition = "2021"
-description = "Pure-Rust, zbus-based AT-SPI2 protocol implementation."
-license = "Apache-2.0 OR MIT"
-readme = "../README.md"
-repository = "https://github.com/odilia-app/atspi"
-homepage = "https://github.com/odilia-app/atspi"
-keywords = ["screen-reader", "accessibility", "a11y", "tts", "linux"]
-categories = ["accessibility", "api-bindings"]
-rust-version.workspace = true
-include = ["src/**/*", "LICENSE-*", "README.md"]
+  authors.workspace      = true
+  categories             = [ "accessibility", "api-bindings" ]
+  description            = "Pure-Rust, zbus-based AT-SPI2 protocol implementation."
+  edition                = "2021"
+  homepage               = "https://github.com/odilia-app/atspi"
+  include                = [ "LICENSE-*", "README.md", "src/**/*" ]
+  keywords               = [ "a11y", "accessibility", "linux", "screen-reader", "tts" ]
+  license                = "Apache-2.0 OR MIT"
+  name                   = "atspi"
+  readme                 = "../README.md"
+  repository             = "https://github.com/odilia-app/atspi"
+  rust-version.workspace = true
+  version                = "0.25.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+  # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["async-std"]
-async-std = ["proxies-async-std", "connection-async-std"]
-tokio = ["proxies-tokio", "connection-tokio"]
+  async-std = [ "connection-async-std", "proxies-async-std" ]
+  default   = [ "async-std" ]
+  tokio     = [ "connection-tokio", "proxies-tokio" ]
 
-proxies = []
-proxies-async-std = ["atspi-proxies/async-std", "proxies"]
-proxies-tokio = ["atspi-proxies/tokio", "proxies"]
-connection = []
-connection-async-std = ["atspi-connection/async-std", "connection"]
-connection-tokio = ["atspi-connection/tokio", "connection"]
-tracing = ["atspi-connection/tracing"]
+  connection           = [  ]
+  connection-async-std = [ "atspi-connection/async-std", "connection" ]
+  connection-tokio     = [ "atspi-connection/tokio", "connection" ]
+  proxies              = [  ]
+  proxies-async-std    = [ "atspi-proxies/async-std", "proxies" ]
+  proxies-tokio        = [ "atspi-proxies/tokio", "proxies" ]
+  tracing              = [ "atspi-connection/tracing" ]
 
 [dependencies]
-atspi-common = { path = "../atspi-common", version = "0.9.0", default-features = false }
-atspi-connection = { path = "../atspi-connection", version = "0.9.0", default-features = false, optional = true }
-atspi-proxies = { path = "../atspi-proxies", version = "0.9.0", default-features = false, optional = true }
-zbus = { workspace = true, default-features = false, optional = true }
+  atspi-common     = { path = "../atspi-common", version = "0.9.0", default-features = false }
+  atspi-connection = { path = "../atspi-connection", version = "0.9.0", default-features = false, optional = true }
+  atspi-proxies    = { path = "../atspi-proxies", version = "0.9.0", default-features = false, optional = true }
+  zbus             = { workspace = true, default-features = false, optional = true }
 
 [[bench]]
-name = "event_parsing"
-path = "./benches/event_parsing.rs"
-harness = false
+  harness = false
+  name    = "event_parsing"
+  path    = "./benches/event_parsing.rs"
 
 [[bench]]
-name = "event_parsing_100k"
-path = "./benches/event_parsing_100k.rs"
-harness = false
+  harness = false
+  name    = "event_parsing_100k"
+  path    = "./benches/event_parsing_100k.rs"
 
 [[example]]
-name = "tree"
-path = "./examples/bus-tree.rs"
-required-features = ["proxies-tokio", "zbus"]
+  name              = "tree"
+  path              = "./examples/bus-tree.rs"
+  required-features = [ "proxies-tokio", "zbus" ]
 
 [[example]]
-name = "focused-tokio"
-path = "./examples/focused-tokio.rs"
-required-features = ["connection-tokio"]
+  name              = "focused-tokio"
+  path              = "./examples/focused-tokio.rs"
+  required-features = [ "connection-tokio" ]
 
 [[example]]
-name = "focused-async-std"
-path = "./examples/focused-async-std.rs"
-required-features = ["connection-async-std"]
+  name              = "focused-async-std"
+  path              = "./examples/focused-async-std.rs"
+  required-features = [ "connection-async-std" ]
 
 [dev-dependencies]
-async-std = { version = "1.12", default-features = false }
-atspi = { path = "." }
-criterion = "0.5"
-fastrand = "2.0"
-futures = { version = "0.3", default-features = false, features = ["alloc"] }
-futures-lite = { version = "2", default-features = false }
-tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
-tokio-stream = "0.1"
-zbus.workspace = true
+  async-std      = { version = "1.12", default-features = false }
+  atspi          = { path = "." }
+  criterion      = "0.5"
+  fastrand       = "2.0"
+  futures        = { version = "0.3", default-features = false, features = [ "alloc" ] }
+  futures-lite   = { version = "2", default-features = false }
+  tokio          = { version = "1", default-features = false, features = [ "macros", "rt-multi-thread" ] }
+  tokio-stream   = "0.1"
+  zbus.workspace = true


### PR DESCRIPTION
This 'backports' the `event_body` module from our development branch.

- Adds borrowed bodies for qt and common bodies.
- Adds sane defaults and conversions
- Adds `QtProperties` and `Properties` to replace unused types in field 'properties' (HashMaps / ObjectRef types)
- Minimal serialization for `QtProperties` and `Properties`
- Uphold `Type::Signature` requirements for `QtProperties` and `Properties`
- Shrink `EventBody` and `EventBodyQT` from 144 bytes to 96 bytes
- Adds many tests.

In need of eyeballs! ;)