### PR TITLE
`State` gains ` to_static_str()` method

### DIFF
--- a/atspi-common/src/events/event_body.rs
+++ b/atspi-common/src/events/event_body.rs
@@ -38,7 +38,7 @@ impl Clone for EventBodyQtOwned {
 	/// This implementation of [`Clone`] *can panic!* although chances are slim.
 	///
 	/// If the following conditions are met:
-	/// 1. the `any_data` or `properties` field contain an [`std::os::fd::OwnedFd`] type, and
+	/// 1. the `any_data` field contains an [`std::os::fd::OwnedFd`] type, and
 	/// 2. the maximum number of open files for the process is exceeded.
 	///
 	/// Then this function panic.  

--- a/atspi-common/src/state.rs
+++ b/atspi-common/src/state.rs
@@ -221,9 +221,14 @@ pub enum State {
 	ReadOnly,
 }
 
-impl fmt::Display for State {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		let state_str = match self {
+impl State {
+	// "Matches on enums with undeclared discriminants (such that the compiler can choose sequential values)
+	// are optimized down to a jump table"
+	// https://users.rust-lang.org/t/match-statement-efficiency/4488/2
+
+	/// Returns the state as a static string.
+	pub fn to_static_str(&self) -> &'static str {
+		match self {
 			State::Invalid => "invalid",
 			State::Active => "active",
 			State::Armed => "armed",
@@ -268,8 +273,13 @@ impl fmt::Display for State {
 			State::Checkable => "checkable",
 			State::HasPopup => "has-popup",
 			State::ReadOnly => "read-only",
-		};
-		f.write_str(state_str)
+		}
+	}
+}
+
+impl fmt::Display for State {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		f.write_str(self.to_static_str())
 	}
 }
 

--- a/atspi-common/src/state.rs
+++ b/atspi-common/src/state.rs
@@ -227,6 +227,7 @@ impl State {
 	// https://users.rust-lang.org/t/match-statement-efficiency/4488/2
 
 	/// Returns the state as a static string.
+	#[must_use]
 	pub fn to_static_str(&self) -> &'static str {
 		match self {
 			State::Invalid => "invalid",


### PR DESCRIPTION
This introduces `to_static_str` for `State`.

This addresses the need for fast, non-allocating strings from a `State`,
without the risk of method implementation and enum drifting out of sync without
anyone noticing.

On efficiency of match statements on enums:  rustc is smart and (under these circumstances) compiles a jump table.

"Matches on enums with undeclared discriminants (such that the compiler can choose sequential values) are optimized down to a jump table ..."

[match statement efficiency](https://users.rust-lang.org/t/match-statement-efficiency/4488/2)