### PR TITLE
dev(toml): Make `Cargo.toml` format pretty independent of editor.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,12 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt
-      - name: Run formatter
+      - name: Install Taplo
+        uses: taiki-e/install-action@taplo
+      - name: Run formatter (Rust)
         run: cargo fmt --all --check
+      - name: Run formatter (TOML)
+        run: taplo fmt --config taplo.toml --check
   rustdoc:
     runs-on: ubuntu-latest
     needs: [clippy,no-unused-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,24 +1,24 @@
 [workspace]
-  members  = [ "atspi", "atspi-common", "atspi-connection", "atspi-proxies" ]
-  resolver = "2"
+members  = ["atspi", "atspi-common", "atspi-connection", "atspi-proxies"]
+resolver = "2"
 
 
-  [workspace.package]
-    authors = [
-      "Alberto Tirla <albertotirla@gmail.com>",
-      "DataTriny <datatriny@gmail.com>",
-      "Luuk van der Duim <luukvanderduim@gmail.com>",
-      "Michael Connor Buchan <mikey@blindcomputing.org>",
-      "Tait Hoyem <tait@tait.tech>"
-    ]
-    description = "AT-SPI2 protocol implementation in Rust"
-    rust-version = "1.77.2"
+[workspace.package]
+authors = [
+  "Alberto Tirla <albertotirla@gmail.com>",
+  "DataTriny <datatriny@gmail.com>",
+  "Luuk van der Duim <luukvanderduim@gmail.com>",
+  "Michael Connor Buchan <mikey@blindcomputing.org>",
+  "Tait Hoyem <tait@tait.tech>",
+]
+description = "AT-SPI2 protocol implementation in Rust"
+rust-version = "1.77.2"
 
-  [workspace.dependencies]
-    enumflags2 = "0.7.7"
-    tracing    = "0.1.37"
-    zbus       = { version = "5.5", default-features = false }
+[workspace.dependencies]
+enumflags2 = "0.7.7"
+tracing    = "0.1.37"
+zbus       = { version = "5.5", default-features = false }
 
 [profile.bench]
-  codegen-units = 1
-  lto           = true
+codegen-units = 1
+lto           = true

--- a/atspi-common/Cargo.toml
+++ b/atspi-common/Cargo.toml
@@ -1,42 +1,47 @@
 [package]
-  categories             = [ "accessibility", "api-bindings" ]
-  description            = "Primitive types used for sending and receiving Linux accessibility events."
-  edition                = "2021"
-  include                = [ "LICENSE-*", "README.md", "src/**/*", "xml/*" ]
-  keywords               = [ "Accessibility", "Macros" ]
-  license                = "Apache-2.0 OR MIT"
-  name                   = "atspi-common"
-  readme                 = "README.md"
-  repository             = "https://github.com/odilia-app/atspi"
-  rust-version.workspace = true
-  version                = "0.9.0"
+categories             = ["accessibility", "api-bindings"]
+description            = "Primitive types used for sending and receiving Linux accessibility events."
+edition                = "2021"
+include                = ["LICENSE-*", "README.md", "src/**/*", "xml/*"]
+keywords               = ["Accessibility", "Macros"]
+license                = "Apache-2.0 OR MIT"
+name                   = "atspi-common"
+readme                 = "README.md"
+repository             = "https://github.com/odilia-app/atspi"
+rust-version.workspace = true
+version                = "0.9.0"
 
-  # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-  async-std = [ "zbus/async-io" ]
-  default   = [ "async-std", "wrappers" ]
-  tokio     = [ "zbus/tokio" ]
-  wrappers  = [  ]
+async-std = ["zbus/async-io"]
+default   = ["async-std", "wrappers"]
+tokio     = ["zbus/tokio"]
+wrappers  = []
 
 [dependencies]
-  enumflags2           = "0.7.7"
-  serde                = "1.0"
-  static_assertions    = "1.1.0"
-  zbus                 = { workspace = true, optional = true, default-features = false }
-  zbus-lockstep        = { version = "0.5.0" }
-  zbus-lockstep-macros = { version = "0.5.0" }
-  zbus_names           = "4.0"
-  zvariant             = { version = "5.1", default-features = false }
+enumflags2           = "0.7.7"
+serde                = "1.0"
+static_assertions    = "1.1.0"
+zbus                 = { workspace = true, optional = true, default-features = false }
+zbus-lockstep        = { version = "0.5.0" }
+zbus-lockstep-macros = { version = "0.5.0" }
+zbus_names           = "4.0"
+zvariant             = { version = "5.1", default-features = false }
 
 [dev-dependencies]
-  assert_matches    = "1.5.0"
-  atspi-connection  = { path = "../atspi-connection" }
-  atspi-proxies     = { path = "../atspi-proxies" }
-  rename-item       = "0.1.0"
-  serde_plain       = "1.0.1"
-  static_assertions = "1.1.0"
-  tokio             = { version = "1", default-features = false, features = [ "macros", "rt-multi-thread" ] }
-  tokio-stream      = { version = "0.1", default-features = false, features = [ "time" ] }
-  tokio-test        = "0.4.2"
-  zbus              = { workspace = true }
+assert_matches = "1.5.0"
+atspi-connection = { path = "../atspi-connection" }
+atspi-proxies = { path = "../atspi-proxies" }
+rename-item = "0.1.0"
+serde_plain = "1.0.1"
+static_assertions = "1.1.0"
+tokio = { version = "1", default-features = false, features = [
+  "macros",
+  "rt-multi-thread",
+] }
+tokio-stream = { version = "0.1", default-features = false, features = [
+  "time",
+] }
+tokio-test = "0.4.2"
+zbus = { workspace = true }

--- a/atspi-connection/Cargo.toml
+++ b/atspi-connection/Cargo.toml
@@ -1,31 +1,37 @@
 [package]
-  categories             = [ "accessibility" ]
-  description            = "A method of connecting, querying, sending and receiving over AT-SPI."
-  edition                = "2021"
-  include                = [ "LICENSE-*", "README.md", "src/**/*" ]
-  keywords               = [ "a11y", "accessibility", "linux", "screen-reader" ]
-  license                = "Apache-2.0 OR MIT"
-  name                   = "atspi-connection"
-  readme                 = "README.md"
-  repository             = "https://github.com/odilia-app/atspi/"
-  rust-version.workspace = true
-  version                = "0.9.0"
+categories             = ["accessibility"]
+description            = "A method of connecting, querying, sending and receiving over AT-SPI."
+edition                = "2021"
+include                = ["LICENSE-*", "README.md", "src/**/*"]
+keywords               = ["a11y", "accessibility", "linux", "screen-reader"]
+license                = "Apache-2.0 OR MIT"
+name                   = "atspi-connection"
+readme                 = "README.md"
+repository             = "https://github.com/odilia-app/atspi/"
+rust-version.workspace = true
+version                = "0.9.0"
 
-  # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-  async-std = [ "atspi-common/async-std", "atspi-proxies/async-std", "zbus/async-io" ]
-  default   = [ "async-std" ]
-  tokio     = [ "atspi-common/tokio", "atspi-proxies/tokio", "zbus/tokio" ]
-  tracing   = [ "dep:tracing" ]
+async-std = [
+  "atspi-common/async-std",
+  "atspi-proxies/async-std",
+  "zbus/async-io",
+]
+default = ["async-std"]
+tokio = ["atspi-common/tokio", "atspi-proxies/tokio", "zbus/tokio"]
+tracing = ["dep:tracing"]
 
 [dependencies]
-  atspi-common   = { path = "../atspi-common/", version = "0.9.0", default-features = false, features = [ "wrappers" ] }
-  atspi-proxies  = { path = "../atspi-proxies/", version = "0.9.0", default-features = false }
-  futures-lite   = { version = "2", default-features = false }
-  tracing        = { optional = true, workspace = true }
-  zbus.workspace = true
+atspi-common = { path = "../atspi-common/", version = "0.9.0", default-features = false, features = [
+  "wrappers",
+] }
+atspi-proxies = { path = "../atspi-proxies/", version = "0.9.0", default-features = false }
+futures-lite = { version = "2", default-features = false }
+tracing = { optional = true, workspace = true }
+zbus.workspace = true
 
 [dev-dependencies]
-  enumflags2.workspace = true
-  tokio-test           = "0.4.2"
+enumflags2.workspace = true
+tokio-test           = "0.4.2"

--- a/atspi-proxies/Cargo.toml
+++ b/atspi-proxies/Cargo.toml
@@ -1,40 +1,45 @@
 [package]
-  categories             = [ "accessibility", "api-bindings" ]
-  description            = "AT-SPI2 proxies to query or manipulate UI objects"
-  edition                = "2021"
-  homepage               = "https://github.com/odilia-app/atspi"
-  include                = [ "README.md", "src/**/*" ]
-  keywords               = [ "a11y", "accessibility", "linux", "screen-reader", "tts" ]
-  license                = "Apache-2.0 OR MIT"
-  name                   = "atspi-proxies"
-  readme                 = "README.md"
-  repository             = "https://github.com/odilia-app/atspi"
-  rust-version.workspace = true
-  version                = "0.9.0"
+categories             = ["accessibility", "api-bindings"]
+description            = "AT-SPI2 proxies to query or manipulate UI objects"
+edition                = "2021"
+homepage               = "https://github.com/odilia-app/atspi"
+include                = ["README.md", "src/**/*"]
+keywords               = ["a11y", "accessibility", "linux", "screen-reader", "tts"]
+license                = "Apache-2.0 OR MIT"
+name                   = "atspi-proxies"
+readme                 = "README.md"
+repository             = "https://github.com/odilia-app/atspi"
+rust-version.workspace = true
+version                = "0.9.0"
 
-  [package.metadata.release]
-    publish = true
-    release = true
+[package.metadata.release]
+publish = true
+release = true
 
 [features]
-  async-std = [ "atspi-common/async-std", "zbus/async-io" ]
-  default   = [ "async-std" ]
-  tokio     = [ "atspi-common/tokio", "zbus/tokio" ]
+async-std = ["atspi-common/async-std", "zbus/async-io"]
+default   = ["async-std"]
+tokio     = ["atspi-common/tokio", "zbus/tokio"]
 
 [dependencies]
-  atspi-common = { path = "../atspi-common", version = "0.9.0", default-features = false }
-  serde        = { version = "^1.0", default-features = false, features = [ "derive" ] }
-  zbus         = { workspace = true }
+atspi-common = { path = "../atspi-common", version = "0.9.0", default-features = false }
+serde        = { version = "^1.0", default-features = false, features = ["derive"] }
+zbus         = { workspace = true }
 
 [dev-dependencies]
-  async-std    = { version = "1", features = [ "attributes" ] }
-  atspi-common = { path = "../atspi-common", version = "0.9.0", features = [ "async-std" ] }
-  byteorder    = "1.4"
-  futures-lite = { version = "2", default-features = false }
-  rename-item  = "0.1.0"
-  serde_json   = "1.0.96"
-  serde_plain  = "1.0.1"
-  tokio        = { version = "1", default-features = false, features = [ "macros", "rt-multi-thread" ] }
-  tokio-stream = "0.1"
-  tokio-test   = "0.4.2"
-  tracing      = "0.1.37"
+async-std = { version = "1", features = ["attributes"] }
+atspi-common = { path = "../atspi-common", version = "0.9.0", features = [
+  "async-std",
+] }
+byteorder = "1.4"
+futures-lite = { version = "2", default-features = false }
+rename-item = "0.1.0"
+serde_json = "1.0.96"
+serde_plain = "1.0.1"
+tokio = { version = "1", default-features = false, features = [
+  "macros",
+  "rt-multi-thread",
+] }
+tokio-stream = "0.1"
+tokio-test = "0.4.2"
+tracing = "0.1.37"

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -1,71 +1,74 @@
 [package]
-  authors.workspace      = true
-  categories             = [ "accessibility", "api-bindings" ]
-  description            = "Pure-Rust, zbus-based AT-SPI2 protocol implementation."
-  edition                = "2021"
-  homepage               = "https://github.com/odilia-app/atspi"
-  include                = [ "LICENSE-*", "README.md", "src/**/*" ]
-  keywords               = [ "a11y", "accessibility", "linux", "screen-reader", "tts" ]
-  license                = "Apache-2.0 OR MIT"
-  name                   = "atspi"
-  readme                 = "../README.md"
-  repository             = "https://github.com/odilia-app/atspi"
-  rust-version.workspace = true
-  version                = "0.25.0"
+authors.workspace      = true
+categories             = ["accessibility", "api-bindings"]
+description            = "Pure-Rust, zbus-based AT-SPI2 protocol implementation."
+edition                = "2021"
+homepage               = "https://github.com/odilia-app/atspi"
+include                = ["LICENSE-*", "README.md", "src/**/*"]
+keywords               = ["a11y", "accessibility", "linux", "screen-reader", "tts"]
+license                = "Apache-2.0 OR MIT"
+name                   = "atspi"
+readme                 = "../README.md"
+repository             = "https://github.com/odilia-app/atspi"
+rust-version.workspace = true
+version                = "0.25.0"
 
-  # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-  async-std = [ "connection-async-std", "proxies-async-std" ]
-  default   = [ "async-std" ]
-  tokio     = [ "connection-tokio", "proxies-tokio" ]
+async-std = ["connection-async-std", "proxies-async-std"]
+default   = ["async-std"]
+tokio     = ["connection-tokio", "proxies-tokio"]
 
-  connection           = [  ]
-  connection-async-std = [ "atspi-connection/async-std", "connection" ]
-  connection-tokio     = [ "atspi-connection/tokio", "connection" ]
-  proxies              = [  ]
-  proxies-async-std    = [ "atspi-proxies/async-std", "proxies" ]
-  proxies-tokio        = [ "atspi-proxies/tokio", "proxies" ]
-  tracing              = [ "atspi-connection/tracing" ]
+connection           = []
+connection-async-std = ["atspi-connection/async-std", "connection"]
+connection-tokio     = ["atspi-connection/tokio", "connection"]
+proxies              = []
+proxies-async-std    = ["atspi-proxies/async-std", "proxies"]
+proxies-tokio        = ["atspi-proxies/tokio", "proxies"]
+tracing              = ["atspi-connection/tracing"]
 
 [dependencies]
-  atspi-common     = { path = "../atspi-common", version = "0.9.0", default-features = false }
-  atspi-connection = { path = "../atspi-connection", version = "0.9.0", default-features = false, optional = true }
-  atspi-proxies    = { path = "../atspi-proxies", version = "0.9.0", default-features = false, optional = true }
-  zbus             = { workspace = true, default-features = false, optional = true }
+atspi-common     = { path = "../atspi-common", version = "0.9.0", default-features = false }
+atspi-connection = { path = "../atspi-connection", version = "0.9.0", default-features = false, optional = true }
+atspi-proxies    = { path = "../atspi-proxies", version = "0.9.0", default-features = false, optional = true }
+zbus             = { workspace = true, default-features = false, optional = true }
 
 [[bench]]
-  harness = false
-  name    = "event_parsing"
-  path    = "./benches/event_parsing.rs"
+harness = false
+name    = "event_parsing"
+path    = "./benches/event_parsing.rs"
 
 [[bench]]
-  harness = false
-  name    = "event_parsing_100k"
-  path    = "./benches/event_parsing_100k.rs"
+harness = false
+name    = "event_parsing_100k"
+path    = "./benches/event_parsing_100k.rs"
 
 [[example]]
-  name              = "tree"
-  path              = "./examples/bus-tree.rs"
-  required-features = [ "proxies-tokio", "zbus" ]
+name              = "tree"
+path              = "./examples/bus-tree.rs"
+required-features = ["proxies-tokio", "zbus"]
 
 [[example]]
-  name              = "focused-tokio"
-  path              = "./examples/focused-tokio.rs"
-  required-features = [ "connection-tokio" ]
+name              = "focused-tokio"
+path              = "./examples/focused-tokio.rs"
+required-features = ["connection-tokio"]
 
 [[example]]
-  name              = "focused-async-std"
-  path              = "./examples/focused-async-std.rs"
-  required-features = [ "connection-async-std" ]
+name              = "focused-async-std"
+path              = "./examples/focused-async-std.rs"
+required-features = ["connection-async-std"]
 
 [dev-dependencies]
-  async-std      = { version = "1.12", default-features = false }
-  atspi          = { path = "." }
-  criterion      = "0.5"
-  fastrand       = "2.0"
-  futures        = { version = "0.3", default-features = false, features = [ "alloc" ] }
-  futures-lite   = { version = "2", default-features = false }
-  tokio          = { version = "1", default-features = false, features = [ "macros", "rt-multi-thread" ] }
-  tokio-stream   = "0.1"
-  zbus.workspace = true
+async-std = { version = "1.12", default-features = false }
+atspi = { path = "." }
+criterion = "0.5"
+fastrand = "2.0"
+futures = { version = "0.3", default-features = false, features = ["alloc"] }
+futures-lite = { version = "2", default-features = false }
+tokio = { version = "1", default-features = false, features = [
+  "macros",
+  "rt-multi-thread",
+] }
+tokio-stream = "0.1"
+zbus.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -23,13 +23,13 @@
 # dependencies not shared by any other crates, would be ignored, as the target
 # list here is effectively saying which targets you are building for.
 targets = [
-    # The triple can be any string, but only the target triples built in to
-    # rustc (as of 1.40) can be checked against actual config expressions
-    #"x86_64-unknown-linux-musl",
-    # You can also specify which target_features you promise are enabled for a
-    # particular target. target_features are currently not validated against
-    # the actual valid features supported by the target architecture.
-    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+  # The triple can be any string, but only the target triples built in to
+  # rustc (as of 1.40) can be checked against actual config expressions
+  #"x86_64-unknown-linux-musl",
+  # You can also specify which target_features you promise are enabled for a
+  # particular target. target_features are currently not validated against
+  # the actual valid features supported by the target architecture.
+  #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
 ]
 # When creating the dependency graph used as the source of truth when checks are
 # executed, this field can be used to prune crates from the graph, removing them
@@ -70,10 +70,10 @@ feature-depth = 1
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    #"RUSTSEC-0000-0000",
-    #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
-    #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
-    #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
+  #"RUSTSEC-0000-0000",
+  #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
+  #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
+  #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
@@ -89,10 +89,10 @@ ignore = [
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
-    "MIT",
-    "Apache-2.0",
-		"Unicode-3.0",
-    #"Apache-2.0 WITH LLVM-exception",
+  "Apache-2.0",
+  "MIT",
+  "Unicode-3.0",
+  #"Apache-2.0 WITH LLVM-exception",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
@@ -102,9 +102,9 @@ confidence-threshold = 0.95
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-    # Each entry is the crate and version constraint, and its specific allow
-    # list
-    #{ allow = ["Zlib"], crate = "adler32" },
+  # Each entry is the crate and version constraint, and its specific allow
+  # list
+  #{ allow = ["Zlib"], crate = "adler32" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,
@@ -135,7 +135,7 @@ ignore = false
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked
 registries = [
-    #"https://sekretz.com/registry
+  #"https://sekretz.com/registry
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -162,16 +162,16 @@ workspace-default-features = "allow"
 external-default-features = "allow"
 # List of crates that are allowed. Use with care!
 allow = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
+  #"ansi_term@0.11.0",
+  #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
 ]
 # List of crates to deny
 deny = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
-    # Wrapper crates can optionally be specified to allow the crate when it
-    # is a direct dependency of the otherwise banned crate
-    #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
+  #"ansi_term@0.11.0",
+  #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
+  # Wrapper crates can optionally be specified to allow the crate when it
+  # is a direct dependency of the otherwise banned crate
+  #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
 ]
 
 # List of features to allow/deny
@@ -199,16 +199,16 @@ deny = [
 
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
+  #"ansi_term@0.11.0",
+  #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite.
 skip-tree = [
-    #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
-    #{ crate = "ansi_term@0.11.0", depth = 20 },
+  #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
+  #{ crate = "ansi_term@0.11.0", depth = 20 },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,12 +2,12 @@
 # https://rust-lang.github.io/rustfmt/?version=v1.5.1&search=
 
 # This crate is 'unix' only.
-newline_style = "Unix"
+newline_style   = "Unix"
 reorder_imports = true
 
 # chain_width; a percentage of maximum width
 # precedes what is implied by `use_small_heuristics"
-chain_width = 70
+chain_width          = 70
 use_small_heuristics = "Max"
 
 # force the use of tabs, not spaces

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,16 @@
+[formatting]
+align_entries  = true
+reorder_arrays = true
+
+# Taplo formatting: https://taplo.tamasfe.dev/configuration/formatter-options.html
+# This rule makes sure that the dependencies section of Cargo.toml are sorted and formatted.
+# Other sections are to be left as they are.
+
+[[rule]]
+include = ["**/Cargo.toml", "Cargo.toml"]
+keys    = ["dependencies"]
+
+[rule.formatting]
+align_entries  = true
+reorder_arrays = true
+reorder_keys   = true


### PR DESCRIPTION
Make `Cargo.toml` format the same regardless of editor in use.

VSCode uses the 'Better TOML' plugin to highlight and format Cargo.toml files.

Getting the same results from eg. 'zed' requires the configuration to be independant from a local extension's settings.

This `taplo.toml` alphabetically orders entries in any 'dependencies' section, but leaves other sections 'as is'.
Also does indentation and alignment.

See [Taplo](https://taplo.tamasfe.dev/)
See [Taplo configuration](https://taplo.tamasfe.dev/configuration/file.html)

Support in editors:

zed, through 'TOML' extension (\*)
vscode: through 'Better TOML' extension (\*)
NeoVim / Vim: [taplo](https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/configs/taplo.lua)

*: confirmed