### PR TITLE
doc: Use '\' instead of double spaces for hard line breaks in docs.

### DIFF
--- a/atspi-common/src/events/event_body.rs
+++ b/atspi-common/src/events/event_body.rs
@@ -41,10 +41,10 @@ impl Clone for EventBodyQtOwned {
 	/// 1. the `any_data` field contains an [`std::os::fd::OwnedFd`] type, and
 	/// 2. the maximum number of open files for the process is exceeded.
 	///
-	/// Then this function panic.  
+	/// Then this function panic.\
 	/// None of the types in [`crate::events`] use [`std::os::fd::OwnedFd`].
 	/// Events on the AT-SPI bus *could, theoretically* send a file descriptor, but nothing in the current
-	/// specification describes that.  
+	/// specification describes that.\
 	/// See [`zvariant::Value::try_clone`] for more information.
 	fn clone(&self) -> Self {
 		let cloned_any_data = self.any_data.try_clone().unwrap_or_else(|err| {
@@ -63,8 +63,8 @@ impl Clone for EventBodyQtOwned {
 
 /// Unit struct placeholder for `EventBodyQtOwned.properties`
 ///
-/// AT-SPI2 never reads or writes to `properties`.  
-/// `QtProperties` has the appropriate implementations for `Serialize` and `Deserialize`  
+/// AT-SPI2 never reads or writes to `properties`.\
+/// `QtProperties` has the appropriate implementations for `Serialize` and `Deserialize`\
 /// to make it serialize as an a valid tuple and valid bytes deserialize as placeholder.
 #[derive(Debug, Copy, Clone, Deserialize, Type, Default, PartialEq)]
 #[zvariant(signature = "(so)")]
@@ -96,8 +96,8 @@ impl Default for EventBodyQtOwned {
 
 /// Unit struct placeholder for `EventBody.properties`
 ///
-/// AT-SPI2 never reads or writes to `EventBody.properties`.  
-/// `Properties` has the appropriate implementations for `Serialize` and `Deserialize`  
+/// AT-SPI2 never reads or writes to `EventBody.properties`.\
+/// `Properties` has the appropriate implementations for `Serialize` and `Deserialize`\
 /// to make it serialize as an a valid dictionary and valid bytes deserialize as placeholder.
 #[derive(Debug, Copy, Clone, Type, Default, Deserialize, PartialEq)]
 #[zvariant(signature = "a{sv}")]
@@ -164,10 +164,10 @@ impl Clone for EventBodyOwned {
 	/// 1. the `any_data` field contains an [`std::os::fd::OwnedFd`] type, and
 	/// 2. the maximum number of open files for the process is exceeded.
 	///
-	/// Then this function panic.  
+	/// Then this function panic.\
 	/// None of the types in [`crate::events`] use [`std::os::fd::OwnedFd`].
 	/// Events on the AT-SPI bus *could, theoretically* send a file descriptor, but nothing in the current
-	/// specification describes that.  
+	/// specification describes that.\
 	/// See [`zvariant::Value::try_clone`] for more information.
 	fn clone(&self) -> Self {
 		let cloned_any_data = self.any_data.try_clone().unwrap_or_else(|err| {
@@ -230,7 +230,7 @@ impl EventBodyBorrowed<'_> {
 	/// 1. the `any_data` field contains an [`std::os::fd::OwnedFd`] type, and
 	/// 2. the maximum number of open files for the process is exceeded.
 	///
-	/// Chances are slim because none of the types in [`crate::events`] use [`std::os::fd::OwnedFd`].  
+	/// Chances are slim because none of the types in [`crate::events`] use [`std::os::fd::OwnedFd`].\
 	/// See [`zvariant::Value::try_clone`] for more information.
 	pub fn to_fully_owned(&self) -> Result<EventBodyOwned, AtspiError> {
 		let owned_any_data = self.any_data.try_to_owned()?;
@@ -254,10 +254,10 @@ impl Clone for EventBodyBorrowed<'_> {
 	/// 1. the `any_data` field contains an [`std::os::fd::OwnedFd`] type, and  
 	/// 2. the maximum number of open files for the process is exceeded.
 	///
-	/// Then this function panic.  
+	/// Then this function panic.\
 	/// None of the types in [`crate::events`] use [`std::os::fd::OwnedFd`].
 	/// Events on the AT-SPI bus *could, theoretically* send a file descriptor, but nothing in the current
-	/// specification describes that.  
+	/// specification describes that.\
 	/// See [`zvariant::Value::try_clone`] for more information.
 	fn clone(&self) -> Self {
 		let cloned_any_data = self.any_data.try_clone().unwrap_or_else(|err| {
@@ -319,10 +319,10 @@ impl Clone for EventBodyQtBorrowed<'_> {
 	/// 1. the `any_data` field contains an [`std::os::fd::OwnedFd`] type, and
 	/// 2. the maximum number of open files for the process is exceeded.
 	///
-	/// Then this function panics.  
+	/// Then this function panics.\
 	/// None of the types in [`crate::events`] use [`std::os::fd::OwnedFd`].
 	/// Events on the AT-SPI bus *could, theoretically* send a file descriptor, but nothing in the current
-	/// specification describes that.  
+	/// specification describes that.\
 	/// See [`zvariant::Value::try_clone`] for more information.
 	fn clone(&self) -> Self {
 		let cloned_any_data = self.any_data.try_clone().unwrap_or_else(|err| {
@@ -382,7 +382,7 @@ impl From<EventBodyQtOwned> for EventBodyOwned {
 
 /// Common event body that can be either owned or borrowed.
 ///
-/// This is useful for APIs that can return either owned or borrowed event bodies.  
+/// This is useful for APIs that can return either owned or borrowed event bodies.\
 /// Having this type allows to be generic over the event body type.
 #[derive(Debug, Clone, PartialEq)]
 pub enum EventBody<'a> {

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -658,7 +658,7 @@ macro_rules! zbus_message_test_case {
 /// ```ignore
 /// event_wrapper_test_cases!(MouseEvents, AbsEvent);
 /// ```
-/// In the macro, its first argument `$type` is the event enum type.  
+/// In the macro, its first argument `$type` is the event enum type.\
 /// The second argument `$any_subtype` is the event struct type.
 ///
 /// For each of the types, the macro will create a module with the name `events_tests_{foo}`

--- a/atspi-common/src/object_match.rs
+++ b/atspi-common/src/object_match.rs
@@ -81,7 +81,7 @@ impl ObjectMatchRule {
 	}
 }
 
-/// The 'builder' type for `MatchRule`.  
+/// The 'builder' type for `MatchRule`.\
 /// Use its methods to set match criteria.
 #[derive(Debug, Clone, Default)]
 pub struct ObjectMatchRuleBuilder {

--- a/atspi-common/src/relation_type.rs
+++ b/atspi-common/src/relation_type.rs
@@ -108,7 +108,7 @@ pub enum RelationType {
 	/// Indicates that this object has one or more errors, the nature of which is
 	/// described in the contents of the target object(s). Objects that have this
 	/// relation type should also contain [`crate::state::State::InvalidEntry`] when their
-	/// `GetState` method is called.  
+	/// `GetState` method is called.\
 	/// Included in upstream [AT-SPI2-CORE](https://gitlab.gnome.org/GNOME/at-spi2-core) since 2.26.
 	ErrorMessage,
 


### PR DESCRIPTION
In docs we have been using double spaces to indicate a hard line break. Clippy does not approve of this practice.
Clippy suggests using '\' instead.