### PR TITLE
build(examples): Fixups for example builds

### DIFF
--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -47,17 +47,14 @@ path    = "./benches/event_parsing_100k.rs"
 [[example]]
 name              = "tree"
 path              = "./examples/bus-tree.rs"
-required-features = ["proxies-tokio", "zbus"]
 
 [[example]]
 name              = "focused-tokio"
 path              = "./examples/focused-tokio.rs"
-required-features = ["atspi_connection/wrappers", "connection-tokio"]
 
 [[example]]
 name              = "focused-async-std"
 path              = "./examples/focused-async-std.rs"
-required-features = ["atspi_connection/wrappers", "connection-async-std"]
 
 [dev-dependencies]
 async-std      = { version = "1.12", default-features = false }

--- a/atspi/examples/bus-tree.rs
+++ b/atspi/examples/bus-tree.rs
@@ -12,11 +12,11 @@
 use atspi::{
 	connection::set_session_accessibility,
 	proxy::accessible::{AccessibleProxy, ObjectRefExt},
-	zbus::{proxy::CacheProperties, Connection},
 	AccessibilityConnection, Role,
 };
 use futures::future::try_join_all;
 use std::fmt::{self, Display, Formatter};
+use zbus::{proxy::CacheProperties, Connection};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 

--- a/atspi/examples/focused-async-std.rs
+++ b/atspi/examples/focused-async-std.rs
@@ -1,4 +1,4 @@
-use atspi::events::object::StateChangedEvent;
+use atspi::{events::object::StateChangedEvent, ObjectEvents};
 use futures_lite::stream::StreamExt;
 use std::{error::Error, pin::pin};
 


### PR DESCRIPTION
Fixed minor import path changed.

Disabled `required-features = ["feat", "feat"]` on all three examples because it does not seem to matter - which is probalby indicative of failing gates. Needs attention.