### PR TITLE
fix (proxies): make `ProxyExt` convert into valid proxies #237

### DIFF
--- a/atspi-proxies/Cargo.toml
+++ b/atspi-proxies/Cargo.toml
@@ -30,6 +30,7 @@ zbus         = { workspace = true }
 [dev-dependencies]
 async-std    = { version = "1", features = ["attributes"] }
 atspi-common = { path = "../atspi-common", version = "0.9.0", features = ["async-std"] }
+atspi-connection = { path = "../atspi-connection", version = "0.9.0", features = ["tokio", "wrappers"] }
 byteorder    = "1.4"
 futures-lite = { version = "2", default-features = false }
 rename-item  = "0.1.0"

--- a/atspi-proxies/src/proxy_ext.rs
+++ b/atspi-proxies/src/proxy_ext.rs
@@ -7,17 +7,12 @@ use crate::{
 };
 use atspi_common::{Interface, InterfaceSet, Result};
 
-/// Easily acquire the other interface proxies an object may have.
+/// Acquire the other interface proxies an object may have implemented.
 ///
-/// Equip objects with conversions to proxies of the objects' further implemented interfaces
+/// Equip objects with conversions to proxies of the objects' implemented interfaces
 /// by extending `AccessibleProxy`.
 ///
-/// The `proxies` method returns a `Proxies` struct, which contains lazily loaded proxy accessors.
-///
-/// # Lazy initialization and cheap checks
-///
-/// Proxies are lazily initialized, so they are only created when requested.
-/// Interface availability is checked before creating the proxy and is a cheap bitop.
+/// The `proxies` method returns a `Proxies` struct.
 pub trait ProxyExt<'a> {
 	/// Get `Proxies` for the current object.
 	fn proxies(&self) -> impl std::future::Future<Output = Result<Proxies<'a>>>;
@@ -28,26 +23,6 @@ pub trait ProxyExt<'a> {
 pub struct Proxies<'a> {
 	interfaces: InterfaceSet,
 	proxy: zbus::Proxy<'a>,
-	inner: InnerProxies<'a>,
-}
-
-#[derive(Clone, Debug, Default)]
-struct InnerProxies<'a> {
-	action: Option<ActionProxy<'a>>,
-	application: Option<ApplicationProxy<'a>>,
-	cache: Option<CacheProxy<'a>>,
-	collection: Option<CollectionProxy<'a>>,
-	component: Option<ComponentProxy<'a>>,
-	document: Option<DocumentProxy<'a>>,
-	editable_text: Option<EditableTextProxy<'a>>,
-	hyperlink: Option<HyperlinkProxy<'a>>,
-	hypertext: Option<HypertextProxy<'a>>,
-	image: Option<ImageProxy<'a>>,
-	selection: Option<SelectionProxy<'a>>,
-	table: Option<TableProxy<'a>>,
-	table_cell: Option<TableCellProxy<'a>>,
-	text: Option<TextProxy<'a>>,
-	value: Option<ValueProxy<'a>>,
 }
 
 impl<'a> ProxyExt<'a> for AccessibleProxy<'a> {
@@ -55,7 +30,7 @@ impl<'a> ProxyExt<'a> for AccessibleProxy<'a> {
 		let iface_set: InterfaceSet = self.get_interfaces().await?;
 		let proxy = self.inner().clone();
 
-		Ok(Proxies { interfaces: iface_set, proxy, inner: InnerProxies::default() })
+		Ok(Proxies { interfaces: iface_set, proxy })
 	}
 }
 
@@ -65,13 +40,14 @@ impl<'a> Proxies<'a> {
 	/// # Errors
 	///
 	/// Returns an error if the interface is not available.
-	pub fn action(&mut self) -> Result<&mut ActionProxy<'a>> {
+	pub async fn action(&self) -> Result<ActionProxy<'a>> {
 		if self.interfaces.contains(Interface::Action) {
-			let proxy_ref = self
-				.inner
-				.action
-				.get_or_insert_with(|| ActionProxy::from(self.proxy.clone()));
-			Ok(proxy_ref)
+			Ok(ActionProxy::builder(self.proxy.connection())
+				.cache_properties(zbus::proxy::CacheProperties::No)
+				.destination(self.proxy.destination())?
+				.path(self.proxy.path())?
+				.build()
+				.await?)
 		} else {
 			Err(AtspiError::InterfaceNotAvailable("Action"))
 		}
@@ -82,13 +58,14 @@ impl<'a> Proxies<'a> {
 	/// # Errors
 	///
 	/// Returns an error if the interface is not available.
-	pub fn application(&mut self) -> Result<&mut ApplicationProxy<'a>> {
+	pub async fn application(&self) -> Result<ApplicationProxy<'a>> {
 		if self.interfaces.contains(Interface::Application) {
-			let proxy_ref = self
-				.inner
-				.application
-				.get_or_insert_with(|| ApplicationProxy::from(self.proxy.clone()));
-			Ok(proxy_ref)
+			Ok(ApplicationProxy::builder(self.proxy.connection())
+				.cache_properties(zbus::proxy::CacheProperties::No)
+				.destination(self.proxy.destination())?
+				.path(self.proxy.path())?
+				.build()
+				.await?)
 		} else {
 			Err(AtspiError::InterfaceNotAvailable("Application"))
 		}
@@ -99,13 +76,14 @@ impl<'a> Proxies<'a> {
 	/// # Errors
 	///
 	/// Returns an error if the interface is not available.
-	pub fn cache(&mut self) -> Result<&mut CacheProxy<'a>> {
+	pub async fn cache(&self) -> Result<CacheProxy<'a>> {
 		if self.interfaces.contains(Interface::Cache) {
-			let proxy_ref = self
-				.inner
-				.cache
-				.get_or_insert_with(|| CacheProxy::from(self.proxy.clone()));
-			Ok(proxy_ref)
+			Ok(CacheProxy::builder(self.proxy.connection())
+				.cache_properties(zbus::proxy::CacheProperties::No)
+				.destination(self.proxy.destination())?
+				.path(self.proxy.path())?
+				.build()
+				.await?)
 		} else {
 			Err(AtspiError::InterfaceNotAvailable("Cache"))
 		}
@@ -116,13 +94,14 @@ impl<'a> Proxies<'a> {
 	/// # Errors
 	///
 	/// Returns an error if the interface is not available.
-	pub fn collection(&mut self) -> Result<&mut CollectionProxy<'a>> {
+	pub async fn collection(&self) -> Result<CollectionProxy<'a>> {
 		if self.interfaces.contains(Interface::Collection) {
-			let proxy_ref = self
-				.inner
-				.collection
-				.get_or_insert_with(|| CollectionProxy::from(self.proxy.clone()));
-			Ok(proxy_ref)
+			Ok(CollectionProxy::builder(self.proxy.connection())
+				.cache_properties(zbus::proxy::CacheProperties::No)
+				.destination(self.proxy.destination())?
+				.path(self.proxy.path())?
+				.build()
+				.await?)
 		} else {
 			Err(AtspiError::InterfaceNotAvailable("Collection"))
 		}
@@ -133,13 +112,14 @@ impl<'a> Proxies<'a> {
 	/// # Errors
 	///
 	/// Returns an error if the interface is not available.
-	pub fn component(&mut self) -> Result<&mut ComponentProxy<'a>> {
+	pub async fn component(&self) -> Result<ComponentProxy<'a>> {
 		if self.interfaces.contains(Interface::Component) {
-			let proxy_ref = self
-				.inner
-				.component
-				.get_or_insert_with(|| ComponentProxy::from(self.proxy.clone()));
-			Ok(proxy_ref)
+			Ok(ComponentProxy::builder(self.proxy.connection())
+				.cache_properties(zbus::proxy::CacheProperties::No)
+				.destination(self.proxy.destination())?
+				.path(self.proxy.path())?
+				.build()
+				.await?)
 		} else {
 			Err(AtspiError::InterfaceNotAvailable("Component"))
 		}
@@ -150,13 +130,14 @@ impl<'a> Proxies<'a> {
 	/// # Errors
 	///
 	/// Returns an error if the interface is not available.
-	pub fn document(&mut self) -> Result<&mut DocumentProxy<'a>> {
+	pub async fn document(&self) -> Result<DocumentProxy<'a>> {
 		if self.interfaces.contains(Interface::Document) {
-			let proxy_ref = self
-				.inner
-				.document
-				.get_or_insert_with(|| DocumentProxy::from(self.proxy.clone()));
-			Ok(proxy_ref)
+			Ok(DocumentProxy::builder(self.proxy.connection())
+				.cache_properties(zbus::proxy::CacheProperties::No)
+				.destination(self.proxy.destination())?
+				.path(self.proxy.path())?
+				.build()
+				.await?)
 		} else {
 			Err(AtspiError::InterfaceNotAvailable("Document"))
 		}
@@ -167,13 +148,14 @@ impl<'a> Proxies<'a> {
 	/// # Errors
 	///
 	/// Returns an error if the interface is not available.
-	pub fn editable_text(&mut self) -> Result<&mut EditableTextProxy<'a>> {
+	pub async fn editable_text(&self) -> Result<EditableTextProxy<'a>> {
 		if self.interfaces.contains(Interface::EditableText) {
-			let proxy_ref = self
-				.inner
-				.editable_text
-				.get_or_insert_with(|| EditableTextProxy::from(self.proxy.clone()));
-			Ok(proxy_ref)
+			Ok(EditableTextProxy::builder(self.proxy.connection())
+				.cache_properties(zbus::proxy::CacheProperties::No)
+				.destination(self.proxy.destination())?
+				.path(self.proxy.path())?
+				.build()
+				.await?)
 		} else {
 			Err(AtspiError::InterfaceNotAvailable("EditableText"))
 		}
@@ -184,13 +166,14 @@ impl<'a> Proxies<'a> {
 	/// # Errors
 	///
 	/// Returns an error if the interface is not available.
-	pub fn hyperlink(&mut self) -> Result<&mut HyperlinkProxy<'a>> {
+	pub async fn hyperlink(&self) -> Result<HyperlinkProxy<'a>> {
 		if self.interfaces.contains(Interface::Hyperlink) {
-			let proxy_ref = self
-				.inner
-				.hyperlink
-				.get_or_insert_with(|| HyperlinkProxy::from(self.proxy.clone()));
-			Ok(proxy_ref)
+			Ok(HyperlinkProxy::builder(self.proxy.connection())
+				.cache_properties(zbus::proxy::CacheProperties::No)
+				.destination(self.proxy.destination())?
+				.path(self.proxy.path())?
+				.build()
+				.await?)
 		} else {
 			Err(AtspiError::InterfaceNotAvailable("Hyperlink"))
 		}
@@ -201,13 +184,14 @@ impl<'a> Proxies<'a> {
 	/// # Errors
 	///
 	/// Returns an error if the interface is not available.
-	pub fn hypertext(&mut self) -> Result<&mut HypertextProxy<'a>> {
+	pub async fn hypertext(&self) -> Result<HypertextProxy<'a>> {
 		if self.interfaces.contains(Interface::Hypertext) {
-			let proxy_ref = self
-				.inner
-				.hypertext
-				.get_or_insert_with(|| HypertextProxy::from(self.proxy.clone()));
-			Ok(proxy_ref)
+			Ok(HypertextProxy::builder(self.proxy.connection())
+				.cache_properties(zbus::proxy::CacheProperties::No)
+				.destination(self.proxy.destination())?
+				.path(self.proxy.path())?
+				.build()
+				.await?)
 		} else {
 			Err(AtspiError::InterfaceNotAvailable("Hypertext"))
 		}
@@ -218,13 +202,14 @@ impl<'a> Proxies<'a> {
 	/// # Errors
 	///
 	/// Returns an error if the interface is not available.
-	pub fn image(&mut self) -> Result<&mut ImageProxy<'a>> {
+	pub async fn image(&self) -> Result<ImageProxy<'a>> {
 		if self.interfaces.contains(Interface::Image) {
-			let proxy_ref = self
-				.inner
-				.image
-				.get_or_insert_with(|| ImageProxy::from(self.proxy.clone()));
-			Ok(proxy_ref)
+			Ok(ImageProxy::builder(self.proxy.connection())
+				.cache_properties(zbus::proxy::CacheProperties::No)
+				.destination(self.proxy.destination())?
+				.path(self.proxy.path())?
+				.build()
+				.await?)
 		} else {
 			Err(AtspiError::InterfaceNotAvailable("Image"))
 		}
@@ -235,13 +220,14 @@ impl<'a> Proxies<'a> {
 	/// # Errors
 	///
 	/// Returns an error if the interface is not available.
-	pub fn selection(&mut self) -> Result<&mut SelectionProxy<'a>> {
+	pub async fn selection(&self) -> Result<SelectionProxy<'a>> {
 		if self.interfaces.contains(Interface::Selection) {
-			let proxy_ref = self
-				.inner
-				.selection
-				.get_or_insert_with(|| SelectionProxy::from(self.proxy.clone()));
-			Ok(proxy_ref)
+			Ok(SelectionProxy::builder(self.proxy.connection())
+				.cache_properties(zbus::proxy::CacheProperties::No)
+				.destination(self.proxy.destination())?
+				.path(self.proxy.path())?
+				.build()
+				.await?)
 		} else {
 			Err(AtspiError::InterfaceNotAvailable("Selection"))
 		}
@@ -252,13 +238,14 @@ impl<'a> Proxies<'a> {
 	/// # Errors
 	///
 	/// Returns an error if the interface is not available.
-	pub fn table(&mut self) -> Result<&mut TableProxy<'a>> {
+	pub async fn table(&self) -> Result<TableProxy<'a>> {
 		if self.interfaces.contains(Interface::Table) {
-			let proxy_ref = self
-				.inner
-				.table
-				.get_or_insert_with(|| TableProxy::from(self.proxy.clone()));
-			Ok(proxy_ref)
+			Ok(TableProxy::builder(self.proxy.connection())
+				.cache_properties(zbus::proxy::CacheProperties::No)
+				.destination(self.proxy.destination())?
+				.path(self.proxy.path())?
+				.build()
+				.await?)
 		} else {
 			Err(AtspiError::InterfaceNotAvailable("Table"))
 		}
@@ -269,13 +256,14 @@ impl<'a> Proxies<'a> {
 	/// # Errors
 	///
 	/// Returns an error if the interface is not available.
-	pub fn table_cell(&mut self) -> Result<&mut TableCellProxy<'a>> {
+	pub async fn table_cell(&self) -> Result<TableCellProxy<'a>> {
 		if self.interfaces.contains(Interface::TableCell) {
-			let proxy_ref = self
-				.inner
-				.table_cell
-				.get_or_insert_with(|| TableCellProxy::from(self.proxy.clone()));
-			Ok(proxy_ref)
+			Ok(TableCellProxy::builder(self.proxy.connection())
+				.cache_properties(zbus::proxy::CacheProperties::No)
+				.destination(self.proxy.destination())?
+				.path(self.proxy.path())?
+				.build()
+				.await?)
 		} else {
 			Err(AtspiError::InterfaceNotAvailable("TableCell"))
 		}
@@ -286,13 +274,14 @@ impl<'a> Proxies<'a> {
 	/// # Errors
 	///
 	/// Returns an error if the interface is not available.
-	pub fn text(&mut self) -> Result<&mut TextProxy<'a>> {
+	pub async fn text(&self) -> Result<TextProxy<'a>> {
 		if self.interfaces.contains(Interface::Text) {
-			let proxy_ref = self
-				.inner
-				.text
-				.get_or_insert_with(|| TextProxy::from(self.proxy.clone()));
-			Ok(proxy_ref)
+			Ok(TextProxy::builder(self.proxy.connection())
+				.cache_properties(zbus::proxy::CacheProperties::No)
+				.destination(self.proxy.destination())?
+				.path(self.proxy.path())?
+				.build()
+				.await?)
 		} else {
 			Err(AtspiError::InterfaceNotAvailable("Text"))
 		}
@@ -303,13 +292,14 @@ impl<'a> Proxies<'a> {
 	/// # Errors
 	///
 	/// Returns an error if the interface is not available.
-	pub fn value(&mut self) -> Result<&mut ValueProxy<'a>> {
+	pub async fn value(&self) -> Result<ValueProxy<'a>> {
 		if self.interfaces.contains(Interface::Value) {
-			let proxy_ref = self
-				.inner
-				.value
-				.get_or_insert_with(|| ValueProxy::from(self.proxy.clone()));
-			Ok(proxy_ref)
+			Ok(ValueProxy::builder(self.proxy.connection())
+				.cache_properties(zbus::proxy::CacheProperties::No)
+				.destination(self.proxy.destination())?
+				.path(self.proxy.path())?
+				.build()
+				.await?)
 		} else {
 			Err(AtspiError::InterfaceNotAvailable("Value"))
 		}


### PR DESCRIPTION
See #237 for description of the problem.

We can not rely on `ThisInterfaceProxy::from` to do a meaningful conversion. The builder is `async`, so the current solution also became `async` even if the builder without caching is actually sync - makeing the async wrapping just a noop wrapping.

The solution in this fix no longer stores proxies for later use.

`Option::get_or_insert` required an `FnOnce` closure which, with our MSRV, cannot be `async`.