### PR TITLE
fix(proxies): disable property caching by default

### DIFF
--- a/atspi-proxies/src/accessible.rs
+++ b/atspi-proxies/src/accessible.rs
@@ -162,11 +162,11 @@ pub trait Accessible {
 	/// a test program may have to recursively get the children to find a specific id.
 	/// This is because accessible objects can be created dynamically, and they do not always
 	/// correspond to a static view of an application's data.
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn accessible_id(&self) -> zbus::Result<String>;
 
 	/// Number of accessible children for the current object.
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn child_count(&self) -> zbus::Result<i32>;
 
 	/// Human-readable, localized description of `self` in more detail.
@@ -180,7 +180,7 @@ pub trait Accessible {
 	/// more detail.
 	///
 	/// [name]: #method.name
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn description(&self) -> zbus::Result<String>;
 
 	/// Unix locale for the current object.
@@ -197,7 +197,7 @@ pub trait Accessible {
 	/// display a document in Spanish ("es").
 	/// In the latter case, a screen reader will want to know that it should switch to
 	/// Spanish while reading the document.
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn locale(&self) -> zbus::Result<String>;
 
 	/// Human-readable, localized, short name for the object.
@@ -212,7 +212,7 @@ pub trait Accessible {
 	/// interface.
 	///
 	/// [`RelationType::LabelledBy`]: crate::common::RelationType::LabelledBy
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn name(&self) -> zbus::Result<String>;
 
 	/// ObjectRef parent object of the current object.
@@ -225,11 +225,11 @@ pub trait Accessible {
 	/// Root object:
 	/// An application must have a single root object, called "/org/a11y/atspi/accessible/root".
 	/// All other objects should have that one as their highest-level ancestor.
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn parent(&self) -> zbus::Result<ObjectRef>;
 
 	/// Help text for the current object.
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn help_text(&self) -> zbus::Result<String>;
 }
 

--- a/atspi-proxies/src/action.rs
+++ b/atspi-proxies/src/action.rs
@@ -126,6 +126,6 @@ pub trait Action {
 	///
 	///	By convention, if there is more than one action available,
 	/// the first one is considered the "default" action of the object.
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn nactions(&self) -> zbus::Result<i32>;
 }

--- a/atspi-proxies/src/application.rs
+++ b/atspi-proxies/src/application.rs
@@ -86,7 +86,7 @@ pub trait Application {
 	/// using versioned interface names instead.
 	///
 	/// member: "AtspiVersion", type: property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn atspi_version(&self) -> zbus::Result<String>;
 
 	/// Retrieve numerical id of the application.
@@ -117,7 +117,7 @@ pub trait Application {
 	///
 	/// [`embed`]: crate::socket::SocketProxy#method.embed
 	/// [`org.a11y.atspi.Socket`]: crate::socket::SocketProxy
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn id(&self) -> zbus::Result<i32>;
 
 	/// Set ID of the application.
@@ -134,20 +134,20 @@ pub trait Application {
 	/// member: "Id", type: property
 	///
 	/// [`id`]: crate::application::ApplicationProxy#method.id
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn set_id(&self, value: i32) -> zbus::Result<()>;
 
 	/// Retrieves the name of the toolkit used to implement the application's
 	/// user interface.
 	///
 	/// member: "ToolkitName", type: property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn toolkit_name(&self) -> zbus::Result<String>;
 
 	/// Returns the version of the toolkit used to implement the
 	/// application's user interface.
 	///
 	/// member: "Version", type: property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn version(&self) -> zbus::Result<String>;
 }

--- a/atspi-proxies/src/bus.rs
+++ b/atspi-proxies/src/bus.rs
@@ -26,15 +26,15 @@
 )]
 pub trait Status {
 	/// IsEnabled property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn is_enabled(&self) -> zbus::Result<bool>;
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn set_is_enabled(&self, value: bool) -> zbus::Result<()>;
 
 	/// ScreenReaderEnabled property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn screen_reader_enabled(&self) -> zbus::Result<bool>;
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn set_screen_reader_enabled(&self, value: bool) -> zbus::Result<()>;
 }
 

--- a/atspi-proxies/src/document.rs
+++ b/atspi-proxies/src/document.rs
@@ -30,10 +30,10 @@ pub trait Document {
 	fn get_locale(&self) -> zbus::Result<String>;
 
 	/// CurrentPageNumber property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn current_page_number(&self) -> zbus::Result<i32>;
 
 	/// PageCount property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn page_count(&self) -> zbus::Result<i32>;
 }

--- a/atspi-proxies/src/hyperlink.rs
+++ b/atspi-proxies/src/hyperlink.rs
@@ -24,14 +24,14 @@ pub trait Hyperlink {
 	fn is_valid(&self) -> zbus::Result<bool>;
 
 	/// EndIndex property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn end_index(&self) -> zbus::Result<i32>;
 
 	/// NAnchors property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn nanchors(&self) -> zbus::Result<i16>;
 
 	/// StartIndex property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn start_index(&self) -> zbus::Result<i32>;
 }

--- a/atspi-proxies/src/image.rs
+++ b/atspi-proxies/src/image.rs
@@ -24,10 +24,10 @@ pub trait Image {
 	fn get_image_size(&self) -> zbus::Result<(i32, i32)>;
 
 	/// ImageDescription property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn image_description(&self) -> zbus::Result<String>;
 
 	/// ImageLocale property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn image_locale(&self) -> zbus::Result<String>;
 }

--- a/atspi-proxies/src/selection.rs
+++ b/atspi-proxies/src/selection.rs
@@ -36,6 +36,6 @@ pub trait Selection {
 	fn select_child(&self, child_index: i32) -> zbus::Result<bool>;
 
 	/// NSelectedChildren property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn nselected_children(&self) -> zbus::Result<i32>;
 }

--- a/atspi-proxies/src/table.rs
+++ b/atspi-proxies/src/table.rs
@@ -78,26 +78,26 @@ pub trait Table {
 	fn remove_row_selection(&self, row: i32) -> zbus::Result<bool>;
 
 	/// Caption property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn caption(&self) -> zbus::Result<ObjectRef>;
 
 	/// NColumns property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn ncolumns(&self) -> zbus::Result<i32>;
 
 	/// NRows property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn nrows(&self) -> zbus::Result<i32>;
 
 	/// NSelectedColumns property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn nselected_columns(&self) -> zbus::Result<i32>;
 
 	/// NSelectedRows property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn nselected_rows(&self) -> zbus::Result<i32>;
 
 	/// Summary property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn summary(&self) -> zbus::Result<ObjectRef>;
 }

--- a/atspi-proxies/src/table_cell.rs
+++ b/atspi-proxies/src/table_cell.rs
@@ -24,18 +24,18 @@ pub trait TableCell {
 	fn get_row_header_cells(&self) -> zbus::Result<Vec<ObjectRef>>;
 
 	/// ColumnSpan property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn column_span(&self) -> zbus::Result<i32>;
 
 	/// Position property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn position(&self) -> zbus::Result<(i32, i32)>;
 
 	/// RowSpan property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn row_span(&self) -> zbus::Result<i32>;
 
 	/// Table property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn table(&self) -> zbus::Result<ObjectRef>;
 }

--- a/atspi-proxies/src/text.rs
+++ b/atspi-proxies/src/text.rs
@@ -132,10 +132,10 @@ pub trait Text {
 	) -> zbus::Result<bool>;
 
 	/// CaretOffset property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn caret_offset(&self) -> zbus::Result<i32>;
 
 	/// CharacterCount property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn character_count(&self) -> zbus::Result<i32>;
 }

--- a/atspi-proxies/src/value.rs
+++ b/atspi-proxies/src/value.rs
@@ -13,22 +13,22 @@
 #[zbus::proxy(interface = "org.a11y.atspi.Value", assume_defaults = true)]
 pub trait Value {
 	/// CurrentValue property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn current_value(&self) -> zbus::Result<f64>;
 
 	/// Set CurrentValue property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn set_current_value(&self, value: f64) -> zbus::Result<()>;
 
 	/// MaximumValue property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn maximum_value(&self) -> zbus::Result<f64>;
 
 	/// MinimumIncrement property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn minimum_increment(&self) -> zbus::Result<f64>;
 
 	/// MinimumValue property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn minimum_value(&self) -> zbus::Result<f64>;
 }


### PR DESCRIPTION
By annotating property methods in proxy 'trait's with:

```rust
#[zbus(property(emits_changed_signal = "false"))]
fn property_getter()
```

disables the property cache because zbus assumes caching properties is only safe if it can listen for updates on properties. If property changes are not  (guaranteed) to be transmitted, zbus cannot know whether the data it has in cache has gone stale.

[zbus v5.5.0 docs on `emits_changed_signal` arguments:](https://docs.rs/zbus/latest/zbus/attr.proxy.html)
```text
"false" - change signal is not (guaranteed to be) emitted if the property changes. 
This disables property value caching, and does not generate a listener method for the change signal.
```