### PR TITLE
fix(proxies): Disable caching on recently added `Value::text` property

### DIFF
--- a/atspi-proxies/src/value.rs
+++ b/atspi-proxies/src/value.rs
@@ -33,6 +33,6 @@ pub trait Value {
 	fn minimum_value(&self) -> zbus::Result<f64>;
 
 	/// Text property
-	#[zbus(property)]
+	#[zbus(property(emits_changed_signal = "false"))]
 	fn text(&self) -> zbus::Result<String>;
 }


### PR DESCRIPTION
Claire added the `Value::text` property last week after the PR to disable property caching on all properties was written. This PR now disables caching on `Value::text` too.