### PR TITLE
0.26.2 release

### DIFF
--- a/atspi-connection/Cargo.toml
+++ b/atspi-connection/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "atspi-connection"
 readme                 = "README.md"
 repository             = "https://github.com/odilia-app/atspi/"
 rust-version.workspace = true
-version                = "0.10.0"
+version                = "0.10.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -22,7 +22,7 @@ wrappers  = ["atspi-common/wrappers"]
 
 [dependencies]
 atspi-common   = { path = "../atspi-common/", version = "0.10.1", default-features = false, features = ["wrappers"] }
-atspi-proxies  = { path = "../atspi-proxies/", version = "0.10.0", default-features = false }
+atspi-proxies  = { path = "../atspi-proxies/", version = "0.10.1", default-features = false }
 futures-lite   = { version = "2", default-features = false }
 tracing        = { optional = true, workspace = true }
 zbus.workspace = true

--- a/atspi-proxies/Cargo.toml
+++ b/atspi-proxies/Cargo.toml
@@ -10,7 +10,7 @@ name                   = "atspi-proxies"
 readme                 = "README.md"
 repository             = "https://github.com/odilia-app/atspi"
 rust-version.workspace = true
-version                = "0.10.0"
+version                = "0.10.1"
 
   [package.metadata.release]
   publish = true

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -11,7 +11,7 @@ name                   = "atspi"
 readme                 = "../README.md"
 repository             = "https://github.com/odilia-app/atspi"
 rust-version.workspace = true
-version                = "0.26.1"
+version                = "0.26.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -30,8 +30,8 @@ tracing              = ["atspi-connection/tracing"]
 
 [dependencies]
 atspi-common     = { path = "../atspi-common", version = "0.10.1", default-features = false }
-atspi-connection = { path = "../atspi-connection", version = "0.10.0", default-features = false, optional = true }
-atspi-proxies    = { path = "../atspi-proxies", version = "0.10.0", default-features = false, optional = true }
+atspi-connection = { path = "../atspi-connection", version = "0.10.1", default-features = false, optional = true }
+atspi-proxies    = { path = "../atspi-proxies", version = "0.10.1", default-features = false, optional = true }
 zbus             = { workspace = true, default-features = false, optional = true }
 
 [[bench]]


### PR DESCRIPTION
Bump version to get `Value` property and permenant non-caching of DBus properties out.
