### PR TITLE
Do not assume default feature for common.

### DIFF
--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -23,7 +23,7 @@ tokio     = ["zbus/tokio"]
 tracing              = ["atspi-connection/tracing"]
 
 [dependencies]
-atspi-common     = { path = "../atspi-common", version = "0.11.0" }
+atspi-common     = { path = "../atspi-common", version = "0.11.0", default-features = false }
 atspi-connection = { path = "../atspi-connection", version = "0.11.0", optional = true }
 atspi-proxies    = { path = "../atspi-proxies", version = "0.11.0", optional = true }
 zbus             = { workspace = true, optional = true }


### PR DESCRIPTION
This allows other programs to depend on `atspi` directly, and without
enabling default features, gives a lean `atspi-common` (without `zbus`
support).
