### PR TITLE
Add another tree example

### DIFF
--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -43,6 +43,10 @@ name              = "tree"
 path              = "./examples/bus-tree.rs"
 
 [[example]]
+name              = "doc-info-tree"
+path              = "./examples/doc-info-tree.rs"
+
+[[example]]
 name              = "focused-tokio"
 path              = "./examples/focused-tokio.rs"
 

--- a/atspi/examples/doc-info-tree.rs
+++ b/atspi/examples/doc-info-tree.rs
@@ -1,0 +1,82 @@
+//! This example watches for document load events and prints a tree of accessible objects
+//! descending from the document root. It displays some generally useful info like
+//! the name, role, and coordinates of each accessible object.
+//!
+//! ```sh
+//! cargo run --example doc-info-tree
+//! ```
+//! Authors:
+//!    Colton Loftus,
+//!    Luuk van der Duim,
+//!    Tait Hoyem
+
+use atspi::connection::set_session_accessibility;
+use atspi::proxy::accessible::{AccessibleProxy, ObjectRefExt};
+use atspi::proxy::proxy_ext::ProxyExt;
+use atspi::{DocumentEvents, Event, State};
+use std::error::Error;
+use tokio_stream::StreamExt;
+use zbus::Connection;
+
+/// recursively print the children of an accessible object
+/// along with some useful information like their name and
+/// coordinates
+fn recursive_print_children<'a>(
+	proxy: &'a AccessibleProxy<'a>,
+	conn: &'a Connection,
+	indent: usize,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), Box<dyn Error>>> + Send + 'a>> {
+	Box::pin(async move {
+		for child in proxy.get_children().await?.iter() {
+			let child_proxy = child.as_accessible_proxy(conn).await?;
+			let component = child_proxy.proxies().await?.component().await?;
+			let extents = component.get_extents(atspi::CoordType::Screen).await?;
+			let name = child_proxy.name().await?;
+			let role = child_proxy.get_role_name().await?;
+			if child_proxy.get_state().await?.contains(State::Focusable) {
+				println!(
+					"{}child, role:{}, name:{}, extents:{:?}",
+					" ".repeat(indent),
+					role,
+					name,
+					extents
+				);
+			}
+			recursive_print_children(&child_proxy, conn, indent + 2).await?;
+		}
+		Ok(())
+	})
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+	let atspi = atspi::AccessibilityConnection::new().await?;
+	let conn = atspi.connection();
+	set_session_accessibility(true).await?;
+	atspi.register_event::<DocumentEvents>().await?;
+
+	let mut events = atspi.event_stream();
+
+	while let Some(event) = events.next().await {
+		match event {
+			Ok(Event::Document(DocumentEvents::LoadComplete(ev))) => {
+				let conn_clone = conn.clone();
+				tokio::spawn(async move {
+					let a11y_proxy = ev.item.into_accessible_proxy(&conn_clone).await;
+					match a11y_proxy {
+						Ok(proxy) => {
+							if let Err(err) = recursive_print_children(&proxy, &conn_clone, 0).await
+							{
+								eprintln!("Error: {}", err);
+							}
+						}
+						Err(err) => eprintln!("Error creating proxy: {}", err),
+					}
+				});
+			}
+			Ok(_) => {}
+			Err(err) => println!("Error: {}", err),
+		}
+	}
+	Ok(())
+}


### PR DESCRIPTION
I found the other atspi example code very useful and as such I wanted to contribute another example that is still relatively simple but helps to show how to:

- turn an `ObjectRef` into an `AccessibleProxy` and retrieve the natural language name
- get the coordinates by retrieving the associated `component` 
- checking the `StateSet` of the accessible

Some of this logic is shown in the existing tree example or Luuk's [a11y-app](https://github.com/luukvanderduim/a11y-app) but I tried to make it a bit less code / show off some other functionality,

## Example
```
host@computer ~/g/cAtspi (main)> cargo run --example doc-info-tree
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/examples/doc-info-tree`
  child, role:link, name:Skip to content, extents:(66, 116, 1, 1)
            child, role:push button, name:Open global navigation menu, extents:(85, 135, 38, 38)
      child, role:link, name:Homepage, extents:(138, 135, 38, 38)
                child, role:link, name:C-Loftus, extents:(186, 138, 79, 33)
                child, role:link, name:atspi, extents:(285, 138, 56, 33)
          child, role:push button, name:Type / to search, extents:(1578, 135, 312, 38)
      child, role:link, name:Chat with Copilot, extents:(1899, 135, 38, 38)
      child, role:push button, name:Open Copilot…, extents:(1938, 135, 28, 38)
      child, role:push button, name:Create something new, extents:(1996, 135, 69, 38)
    child, role:link, name:Your issues, extents:(2075, 135, 38, 38)
    child, role:link, name:Your pull requests, extents:(2123, 135, 38, 38)
      child, role:link, name:You have no unread notifications, extents:(2171, 135, 38, 38)
            child, role:push button, name:Open user navigation menu, extents:(2219, 135, 40, 38)
          child, role:link, name:Code, extents:(85, 194, 90, 36)
          child, role:link, name:Pull requests, extents:(184, 194, 157, 36)
          child, role:link, name:Actions, extents:(351, 194, 110, 36)
          child, role:link, name:Projects, extents:(471, 194, 115, 36)
          child, role:link, name:Wiki, extents:(596, 194, 85, 36)
          child, role:link, name:Security, extents:(690, 194, 116, 36)
          child, role:link, name:Insights, extents:(816, 194, 116, 36)
          child, role:link, name:Settings, extents:(942, 194, 117, 36)
        child, role:link, name:atspi, extents:(481, 260, 59, 36)
      child, role:link, name:odilia-app/atspi, extents:(527, 300, 105, 20)
            child, role:push button, name:Pin, extents:(1384, 260, 81, 33)
          child, role:link, name:Fork 0, extents:(1572, 260, 119, 33)
            child, role:push button, name:See your forks of this repository, extents:(1691, 260, 40, 33)
```