### PR TITLE
Add example to watch and print selected text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           toolchain: nightly
       - uses: taiki-e/install-action@cargo-hack
       - name: Clippy hack
-        run: cargo hack --feature-powerset --workspace clippy --examples --tests --no-deps -- -D warnings
+        run: cargo hack --feature-powerset --workspace clippy --benches --examples --tests --no-deps -- -D warnings
   tests:
     runs-on: ubuntu-latest
     needs: [clippy, no-unused-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.77.2"
 [workspace.dependencies]
 enumflags2 = "0.7.7"
 tracing = "0.1.37"
+# we don't want the default features, because this will generate the blocking proxiesc which doubles compile time for both `zbus` and `atspi-proxies`.
 zbus = { version = "5.5", default-features = false, features = ["async-io"] }
 
 [profile.bench]

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -51,6 +51,10 @@ path              = "./examples/focused-tokio.rs"
 name              = "focused-async-std"
 path              = "./examples/focused-async-std.rs"
 
+[[example]]
+name              = "selected-text"
+path              = "./examples/selected-text.rs"
+
 [dev-dependencies]
 async-std      = { version = "1.12", features = ["attributes"] }
 atspi          = { path = "." }

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -16,14 +16,15 @@ version                = "0.27.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["proxies", "connection"]
+default = ["proxies", "connection", "wrappers"]
+wrappers = ["atspi-common/wrappers"]
 proxies = ["dep:atspi-proxies"]
 connection = ["dep:atspi-connection"]
 tokio     = ["zbus/tokio"]
 tracing              = ["atspi-connection/tracing"]
 
 [dependencies]
-atspi-common     = { path = "../atspi-common", version = "0.11.0" }
+atspi-common     = { path = "../atspi-common", version = "0.11.0", default-features = false }
 atspi-connection = { path = "../atspi-connection", version = "0.11.0", optional = true }
 atspi-proxies    = { path = "../atspi-proxies", version = "0.11.0", optional = true }
 zbus             = { workspace = true, optional = true }

--- a/atspi/examples/selected-text.rs
+++ b/atspi/examples/selected-text.rs
@@ -1,0 +1,36 @@
+//! This example demonstrates how to get the currently selected text.
+//!
+//! ```sh
+//! cargo run --example selected-text
+//! ```
+//! Authors:
+//!    Colton Loftus
+
+use atspi::{events::object::{TextSelectionChangedEvent}, ObjectEvents};
+use atspi_proxies::{accessible::ObjectRefExt, proxy_ext::ProxyExt};
+use futures_lite::stream::StreamExt;
+use std::{error::Error};
+
+#[async_std::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+	let atspi = atspi::AccessibilityConnection::new().await?;
+    let conn = atspi.connection();
+	atspi.register_event::<ObjectEvents>().await?;
+
+	let mut events = atspi.event_stream();
+
+	while let Some(ev) = events.next().await {
+        match ev {
+            Ok(ev) => {
+                if let Ok(ev) = <TextSelectionChangedEvent>::try_from(ev) {
+                    let text_proxy = ev.item.into_accessible_proxy(conn).await?.proxies().await?.text().await?;
+                    const ASSUME_ONLY_ONE_SELECTED_RANGE: i32 = 0;
+                    let (start, end) = text_proxy.get_selection(ASSUME_ONLY_ONE_SELECTED_RANGE).await?;
+                    println!("{}", text_proxy.get_text(start, end).await?);
+                }
+            }
+            Err(err) => eprintln!("Error: {err}"),
+        }
+	}
+	Ok(())
+}

--- a/atspi/examples/selected-text.rs
+++ b/atspi/examples/selected-text.rs
@@ -6,31 +6,44 @@
 //! Authors:
 //!    Colton Loftus
 
-use atspi::{events::object::{TextSelectionChangedEvent}, ObjectEvents};
+use atspi::{events::object::TextSelectionChangedEvent, ObjectEvents};
 use atspi_proxies::{accessible::ObjectRefExt, proxy_ext::ProxyExt};
 use futures_lite::stream::StreamExt;
-use std::{error::Error};
+use std::error::Error;
+
+// When using the text proxy, it is possible to
+// get the selected text from multiple different
+// ranges independent of each other. In this example
+// for the sake of simplicity, we only get the first
+const ASSUME_ONLY_ONE_SELECTED_RANGE: i32 = 0;
 
 #[async_std::main]
 async fn main() -> Result<(), Box<dyn Error>> {
 	let atspi = atspi::AccessibilityConnection::new().await?;
-    let conn = atspi.connection();
+	let conn = atspi.connection();
 	atspi.register_event::<ObjectEvents>().await?;
 
 	let mut events = atspi.event_stream();
 
 	while let Some(ev) = events.next().await {
-        match ev {
-            Ok(ev) => {
-                if let Ok(ev) = <TextSelectionChangedEvent>::try_from(ev) {
-                    let text_proxy = ev.item.into_accessible_proxy(conn).await?.proxies().await?.text().await?;
-                    const ASSUME_ONLY_ONE_SELECTED_RANGE: i32 = 0;
-                    let (start, end) = text_proxy.get_selection(ASSUME_ONLY_ONE_SELECTED_RANGE).await?;
-                    println!("{}", text_proxy.get_text(start, end).await?);
-                }
-            }
-            Err(err) => eprintln!("Error: {err}"),
-        }
+		match ev {
+			Ok(ev) => {
+				if let Ok(ev) = <TextSelectionChangedEvent>::try_from(ev) {
+					let text_proxy = ev
+						.item
+						.into_accessible_proxy(conn)
+						.await?
+						.proxies()
+						.await?
+						.text()
+						.await?;
+					let (start, end) =
+						text_proxy.get_selection(ASSUME_ONLY_ONE_SELECTED_RANGE).await?;
+					println!("{}", text_proxy.get_text(start, end).await?);
+				}
+			}
+			Err(err) => eprintln!("Error: {err}"),
+		}
 	}
 	Ok(())
 }


### PR DESCRIPTION
I think it would be useful to have an example to show how to use the text proxy and how to monitor the currently selected text.

## Potential issues I found while developing  

### Nautilus path issue

I did run into one issue with the example, namely in Nautilus if I try to select the text for a file path, it sometimes gives this error. 

```
Error: MethodError(OwnedErrorName("org.freedesktop.DBus.Error.InvalidArgs"), Some("Not a valid selection: 0"), Msg { type: Error, serial: 116, sender: UniqueName(":1.87"), reply-serial: 304, body: Str, fds: [] })
```

Otherwise I have tested this and it works well in Firefox.

### More than one selection support

If I try to support more than 1 range it seems like there is a dbus issue
```rs
                    let ranges = text_proxy.get_nselections().await?;
                    for i in 0..ranges {
                        let (start, end) = text_proxy.get_selection(i).await?;
                        println!("{}", text_proxy.get_text(start, end).await?);
                    }
```

```
host@computer ~/g/cAtspi (watchTextSelectionChanges) [1]> cargo run --example selected-text
   Compiling atspi v0.27.0 (/home/host/github/cAtspi/atspi)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.90s
     Running `target/debug/examples/selected-text`
Error: MethodError(OwnedErrorName("org.freedesktop.DBus.Error.UnknownMethod"), Some("Method \"GetNselections\" with signature \"\" on interface \"org.a11y.atspi.Text\" doesn't exist\n"), Msg { type: Error, serial: 229106, sender: UniqueName(":1.14"), reply-serial: 7, body: Str, fds: [] })
```