### PR TITLE
Remove Eq, PartialEq for AccessibleProxy; Fix #263

### DIFF
--- a/atspi-proxies/src/accessible.rs
+++ b/atspi-proxies/src/accessible.rs
@@ -305,13 +305,6 @@ impl ObjectRefExt for ObjectRef {
 	}
 }
 
-impl PartialEq for AccessibleProxy<'_> {
-	fn eq<'a>(&self, other: &Self) -> bool {
-		self.inner().path() == other.inner().path()
-	}
-}
-impl Eq for AccessibleProxy<'_> {}
-
 #[cfg(test)]
 mod tests {
 	use crate::accessible::Role;


### PR DESCRIPTION
This never should have been implemented in the first place. My bad.

I was much dumber in 2022.
