### PR TITLE
fix(common/object-ref): Translate "/org/a11y/atspi/null" sentinel value (issue #271)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "zbus-lockstep"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22426b1bc2aca91de97772506f0655fa373448e6010d79d5d5880915c388409"
+checksum = "29e96e38ded30eeab90b6ba88cb888d70aef4e7489b6cd212c5e5b5ec38045b6"
 dependencies = [
  "zbus_xml",
  "zvariant",
@@ -1910,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "zbus-lockstep-macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100ffec29ed51859052f4563061abe35557acb56ba574510571f8398efc70a29"
+checksum = "dc6821851fa840b708b4cbbaf6241868cabc85a2dc22f426361b0292bfc0b836"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/atspi-common/Cargo.toml
+++ b/atspi-common/Cargo.toml
@@ -23,8 +23,8 @@ enumflags2           = "0.7.9"
 serde                = "1.0.200"
 static_assertions    = "1.1.0"
 zbus                 = { workspace = true, optional = true }
-zbus-lockstep        = { version = "0.5.0" }
-zbus-lockstep-macros = { version = "0.5.0" }
+zbus-lockstep        = { version = "0.5.1" }
+zbus-lockstep-macros = { version = "0.5.1" }
 zbus_names           = "4.1.1"
 zvariant             = { version = "5.2", default-features = false }
 

--- a/atspi-common/src/cache.rs
+++ b/atspi-common/src/cache.rs
@@ -1,7 +1,7 @@
 //! Common types for `org.a11y.atspi.Cache` events.
 //!
 
-use crate::{InterfaceSet, ObjectRef, Role, StateSet};
+use crate::{object_ref::ParentRef, InterfaceSet, ObjectRef, Role, StateSet};
 use serde::{Deserialize, Serialize};
 use zbus_lockstep_macros::validate;
 use zbus_names::UniqueName;
@@ -17,7 +17,7 @@ pub struct CacheItem {
 	/// The application (root object(?)    (so)
 	pub app: ObjectRef,
 	/// The parent object.  (so)
-	pub parent: ObjectRef,
+	pub parent: ParentRef,
 	/// The accessbile index in parent.  i
 	pub index: i32,
 	/// Child count of the accessible  i
@@ -49,12 +49,12 @@ impl Default for CacheItem {
 					.unwrap()
 					.into(),
 			},
-			parent: ObjectRef {
+			parent: ParentRef::Some(ObjectRef {
 				name: UniqueName::from_static_str(":0.0").unwrap().into(),
 				path: ObjectPath::from_static_str("/org/a11y/atspi/accessible/parent")
 					.unwrap()
 					.into(),
-			},
+			}),
 			index: 0,
 			children: 0,
 			ifaces: InterfaceSet::empty(),
@@ -121,11 +121,16 @@ impl Default for LegacyCacheItem {
 }
 
 #[cfg(test)]
-#[test]
-fn zvariant_type_signature_of_legacy_cache_item() {
+mod tests {
+	use super::*;
 	use std::str::FromStr;
-	assert_eq!(
-		*<LegacyCacheItem as Type>::SIGNATURE,
-		zbus::zvariant::Signature::from_str("((so)(so)(so)a(so)assusau)").unwrap()
-	);
+	use zbus::zvariant::Type;
+
+	#[test]
+	fn zvariant_type_signature_of_legacy_cache_item() {
+		assert_eq!(
+			*<LegacyCacheItem as Type>::SIGNATURE,
+			zbus::zvariant::Signature::from_str("((so)(so)(so)a(so)assusau)").unwrap()
+		);
+	}
 }

--- a/atspi-common/src/events/registry.rs
+++ b/atspi-common/src/events/registry.rs
@@ -132,7 +132,7 @@ impl Default for EventListeners {
 	fn default() -> Self {
 		Self {
 			bus_name: UniqueName::from_static_str_unchecked(":0.0").into(),
-			path: String::from("/org/a11y/atspi/accessible/null"),
+			path: String::from("/org/a11y/atspi/null"),
 		}
 	}
 }
@@ -145,7 +145,7 @@ mod event_listener_tests {
 	fn test_event_listener_default_no_panic() {
 		let el = EventListeners::default();
 		assert_eq!(el.bus_name.as_str(), ":0.0");
-		assert_eq!(el.path.as_str(), "/org/a11y/atspi/accessible/null");
+		assert_eq!(el.path.as_str(), "/org/a11y/atspi/null");
 	}
 }
 

--- a/atspi-common/src/lib.rs
+++ b/atspi-common/src/lib.rs
@@ -24,7 +24,7 @@ pub use action::Action;
 pub mod object_match;
 pub use object_match::{MatchType, ObjectMatchRule, SortOrder, TreeTraversalType};
 pub mod object_ref;
-pub use object_ref::ObjectRef;
+pub use object_ref::{ObjectRef, ParentRef};
 pub mod operation;
 pub use operation::Operation;
 pub mod interface;

--- a/atspi-common/src/macros.rs
+++ b/atspi-common/src/macros.rs
@@ -354,7 +354,7 @@ macro_rules! generic_event_test_case {
 		fn generic_event_uses() {
 			use crate::events::traits::MessageConversion;
 			let struct_event = <$type>::default();
-			assert_eq!(struct_event.path().as_str(), "/org/a11y/atspi/accessible/null");
+			assert_eq!(struct_event.path().as_str(), "/org/a11y/atspi/null");
 			assert_eq!(struct_event.sender().as_str(), ":0.0");
 			let body = struct_event.body();
 			let body2 = Message::method_call(

--- a/atspi-common/src/object_ref.rs
+++ b/atspi-common/src/object_ref.rs
@@ -9,8 +9,6 @@ use zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Type, Value};
 /// "Why not just use `None`?"
 ///
 /// `DBus` (which the AT-SPI2 protocol runs on) does not have optional types, so this path indicates the sentinal, `None` value.
-///
-/// Also see: [`IsNullExt`]
 pub const NULL_OBJECT_PATH: ObjectPath<'static> =
 	ObjectPath::from_static_str_unchecked("/org/a11y/atspi/null");
 

--- a/atspi-common/src/object_ref.rs
+++ b/atspi-common/src/object_ref.rs
@@ -12,7 +12,7 @@ use zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Type, Value};
 ///
 /// Also see: [`IsNullExt`]
 pub const NULL_OBJECT_PATH: ObjectPath<'static> =
-	ObjectPath::from_static_str_unchecked("/org/atspi/atspi/null");
+	ObjectPath::from_static_str_unchecked("/org/a11y/atspi/null");
 
 /// An [extention trait](http://xion.io/post/code/rust-extension-traits.html) which adds a method to check if an object path matches the
 /// [`NULL_OBJECT_PATH`].
@@ -280,6 +280,7 @@ impl From<OwnedValue> for ParentRef {
 
 #[cfg(test)]
 mod test {
+	use super::NULL_OBJECT_PATH;
 	use crate::{object_ref::ObjectRefBorrowed, ObjectRef, ParentRef};
 	use zbus_names::UniqueName;
 	use zvariant::{serialized::Context, to_bytes, ObjectPath, Value, LE};
@@ -297,7 +298,7 @@ mod test {
 		let accessible: ObjectRef = value.try_into().unwrap();
 
 		assert_eq!(accessible.name.as_str(), ":0.0");
-		assert_eq!(accessible.path.as_str(), NULL_OBJECT_PATH);
+		assert_eq!(accessible.path.as_str(), &*NULL_OBJECT_PATH);
 	}
 
 	#[test]
@@ -313,7 +314,7 @@ mod test {
 		let accessible: ObjectRef = value.try_into().unwrap();
 
 		assert_eq!(accessible.name.as_str(), ":0.0");
-		assert_eq!(accessible.path.as_str(), NULL_OBJECT_PATH);
+		assert_eq!(accessible.path.as_str(), &*NULL_OBJECT_PATH);
 	}
 
 	#[test]
@@ -325,7 +326,7 @@ mod test {
 		let obj: ObjectRef = value.try_into().unwrap();
 
 		assert_eq!(obj.name.as_str(), ":0.0");
-		assert_eq!(obj.path.as_str(), NULL_OBJECT_PATH);
+		assert_eq!(obj.path.as_str(), &*NULL_OBJECT_PATH);
 	}
 
 	#[test]
@@ -339,7 +340,7 @@ mod test {
 		let obj: ObjectRef = value.try_into().unwrap();
 
 		assert_eq!(obj.name.as_str(), ":0.0");
-		assert_eq!(obj.path.as_str(), NULL_OBJECT_PATH);
+		assert_eq!(obj.path.as_str(), &*NULL_OBJECT_PATH);
 	}
 
 	#[test]
@@ -358,7 +359,7 @@ mod test {
 		let obj_borrow: ObjectRefBorrowed = value.try_into().unwrap();
 
 		assert_eq!(obj_borrow.name.as_str(), ":0.0");
-		assert_eq!(obj_borrow.path.as_str(), NULL_OBJECT_PATH);
+		assert_eq!(obj_borrow.path.as_str(), &*NULL_OBJECT_PATH);
 	}
 
 	#[test]
@@ -372,7 +373,7 @@ mod test {
 	fn test_objectref_default_doesnt_panic() {
 		let objr = ObjectRef::default();
 		assert_eq!(objr.name.as_str(), ":0.0");
-		assert_eq!(objr.path.as_str(), NULL_OBJECT_PATH);
+		assert_eq!(objr.path.as_str(), &*NULL_OBJECT_PATH);
 	}
 
 	#[test]
@@ -391,7 +392,7 @@ mod test {
 		let Value::ObjectPath(path) = vals.last().unwrap() else {
 			panic!("Unable to destructure field value: {:?}", vals.get(1).unwrap());
 		};
-		assert_eq!(path.as_str(), NULL_OBJECT_PATH);
+		assert_eq!(path.as_str(), &*NULL_OBJECT_PATH);
 	}
 
 	#[test]
@@ -465,7 +466,7 @@ mod test {
 		let obj_ref: ObjectRef = test_parent_obj.into();
 
 		let name = UniqueName::from_static_str(":0.0").unwrap();
-		let path = ObjectPath::from_static_str(NULL_OBJECT_PATH).unwrap();
+		let path = NULL_OBJECT_PATH;
 		assert_eq!(obj_ref.name, name.to_owned());
 		assert_eq!(obj_ref.path, path.into());
 	}

--- a/atspi-common/tests/tests.rs
+++ b/atspi-common/tests/tests.rs
@@ -140,7 +140,7 @@ async fn test_recv_add_accessible_unmarshalled_body() {
 	tokio::pin!(events);
 
 	let msg: zbus::Message = {
-		let path = "/org/a11y/atspi/accessible/null";
+		let path = "/org/a11y/atspi/null";
 		let iface = "org.a11y.atspi.Cache";
 		let member = "AddAccessible";
 

--- a/atspi-common/tests/tests.rs
+++ b/atspi-common/tests/tests.rs
@@ -117,7 +117,9 @@ async fn test_recv_add_accessible() {
 			}
 			assert_eq!(node_added.object.path.as_str(), "/org/a11y/atspi/accessible/object");
 			assert_eq!(node_added.app.path.as_str(), "/org/a11y/atspi/accessible/application");
-			assert_eq!(node_added.parent.path.as_str(), "/org/a11y/atspi/accessible/parent");
+
+			let parent: ObjectRef = node_added.parent.into();
+			assert_eq!(parent.path.as_str(), "/org/a11y/atspi/accessible/parent");
 
 			// If we did, break the loop.
 			break;
@@ -178,7 +180,11 @@ async fn test_recv_add_accessible_unmarshalled_body() {
 
 			assert_eq!(node_added.object.path.as_str(), "/org/a11y/atspi/accessible/object");
 			assert_eq!(node_added.app.path.as_str(), "/org/a11y/atspi/accessible/application");
-			assert_eq!(node_added.parent.path.as_str(), "/org/a11y/atspi/accessible/parent");
+
+			let parent: ObjectRef = node_added.parent.into();
+			// Check that the parent is correctly converted from `ParentRef` to `ObjectRef
+
+			assert_eq!(parent.path.as_str(), "/org/a11y/atspi/accessible/parent");
 
 			// If we did, break the loop.
 			break;

--- a/atspi-connection/src/lib.rs
+++ b/atspi-connection/src/lib.rs
@@ -146,7 +146,7 @@ impl AccessibilityConnection {
 	/// #       .arg("--address")
 	/// #       .arg(addr_str)
 	/// #       .arg("emit")
-	/// #       .arg("/org/a11y/atspi/accessible/null")
+	/// #       .arg("/org/a11y/atspi/null")
 	/// #       .arg("org.a11y.atspi.Event.Object")
 	/// #       .arg("StateChanged")
 	/// #       .arg("siiva{sv}")

--- a/atspi-proxies/src/accessible.rs
+++ b/atspi-proxies/src/accessible.rs
@@ -6,7 +6,7 @@
 //! Accessible is the interface which is implemented by all accessible objects.
 //!
 
-use crate::common::{InterfaceSet, ObjectRef, RelationType, Role, StateSet};
+use crate::common::{InterfaceSet, ObjectRef, ParentRef, RelationType, Role, StateSet};
 use crate::AtspiError;
 
 /// # `AccessibleProxy`
@@ -226,7 +226,7 @@ pub trait Accessible {
 	/// An application must have a single root object, called "/org/a11y/atspi/accessible/root".
 	/// All other objects should have that one as their highest-level ancestor.
 	#[zbus(property)]
-	fn parent(&self) -> zbus::Result<ObjectRef>;
+	fn parent(&self) -> zbus::Result<ParentRef>;
 
 	/// Help text for the current object.
 	#[zbus(property)]


### PR DESCRIPTION
GTK4 may return empty strings as bus name, but `atspi` stores bus names more strictly typed.

In `atspi` the `ObjectRef`'s `Default` implementation is the null object.

This PR adjusts `ObjectRef`'s `Deserialize` implementation to return `ObjectRef::default()` if it encounters an `(so)` with an empty string and the null path.
