### PR TITLE
fix(proxies): Method `nactions` remove tab in the commnets

### DIFF
--- a/atspi-proxies/src/action.rs
+++ b/atspi-proxies/src/action.rs
@@ -124,7 +124,7 @@ pub trait Action {
 
 	/// Returns the number of available actions.
 	///
-	///	By convention, if there is more than one action available,
+	/// By convention, if there is more than one action available,
 	/// the first one is considered the "default" action of the object.
 	#[zbus(property)]
 	fn nactions(&self) -> zbus::Result<i32>;


### PR DESCRIPTION
The tab makes it appear we start a code block and suddenly code is expected where we don't have any.

Because the tab was perfectly aligned with the rest, this gets the 2025 Obscured Error Award. 