### PR TITLE
Add an example showing how to get the currently focused frame

### DIFF
--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -41,6 +41,10 @@ name    = "event_parsing_100k"
 path    = "./benches/event_parsing_100k.rs"
 
 [[example]]
+name = "currently-focused-frame"
+path = "./examples/currently-focused-frame.rs"
+
+[[example]]
 name = "accessible-counts"
 path = "./examples/accessible-counts.rs"
 

--- a/atspi/examples/currently-focused-frame.rs
+++ b/atspi/examples/currently-focused-frame.rs
@@ -1,0 +1,46 @@
+//! This example prints out the currently focused frame. A
+//! frame is generally semantically equivalent to an application
+//! window.
+//!
+//! ```sh
+//! cargo run --example currently-focused-frame
+//! ```
+//! Authors:
+//!    Colton Loftus
+
+use std::error::Error;
+
+use atspi::{MouseEvents, State};
+use atspi_connection::set_session_accessibility;
+use atspi_proxies::accessible::ObjectRefExt;
+
+#[async_std::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+	let atspi = atspi::AccessibilityConnection::new().await?;
+	let conn = atspi.connection();
+	set_session_accessibility(true).await?;
+	atspi.register_event::<MouseEvents>().await?;
+
+	let apps = atspi.root_accessible_on_registry().await?.get_children().await?;
+
+	let mut found_active_frame: bool = false;
+
+	for app in apps.iter() {
+		let proxy = app.clone().into_accessible_proxy(conn).await?;
+		let state = proxy.get_state().await?;
+		assert!(!state.contains(State::Active), "The top level application should never have active state; only its associated frames should have this state");
+
+		for frame in proxy.get_children().await? {
+			let frame = frame.clone().into_accessible_proxy(conn).await?;
+			let state = frame.get_state().await?;
+			if state.contains(State::Active) {
+				print!("Found active frame with title: '{}'", frame.name().await?);
+				found_active_frame = true;
+			}
+		}
+	}
+
+	assert!(found_active_frame, "There must be one active frame at any given time");
+
+	Ok(())
+}


### PR DESCRIPTION
The currently focused frame is useful for doing many types of traversals. For instance, if a user wants to find an accessible at a given coordinate, they would need to use the currently focused frame. The top level accessible from the registry that represents the app does not output this info. Rather, you need to get it from the child frames. I presume this is the case for many other types of visual / user-facing info so it seems like calling out how to get the frames would be useful.

I was using this to try and implement #285 but even though I am still stuck on that, it seems useful to add this example for posterity.

In this example I put a few assertions that help new users understand the properties of the example.