### PR TITLE
Make MatchType::Invalid default variant

### DIFF
--- a/atspi-common/src/object_match.rs
+++ b/atspi-common/src/object_match.rs
@@ -170,10 +170,10 @@ impl ObjectMatchRuleBuilder {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Type, Default)]
 #[repr(i32)]
 pub enum MatchType {
-	/// Invalidates match criterion.
+	#[default]
+	/// Invalidates match criterion. Meanting: the search of this property will not be performed.
 	Invalid,
 
-	#[default]
 	/// All of the criteria must be met.
 	All,
 


### PR DESCRIPTION
Previously, the default `MatchType` variant was `MatchType::All`.

However, this does not interact nicely with the `ObjectMatchRuleBuilder` since this means even on properties which are not specified, the specified match type would still be `MatchType::All`.

What this meant in Odilia is that it would perform an "All" match on every preperty (which can sometimes cause an await point) even when the set of things to check was empty.

This fixes that issue, since the unspecified properties now get set to `MatchType::Invalid` (i.e.: do not perform search of this property). This has been updated in the documentation as well.
