### PR TITLE
ci: add commit template

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,49 @@
+# <type>(<scope>): <subject>                  -->|
+#                                            (50 chars)
+#
+# <body - explain what and why, not how>                            -->|
+#                                                                 (72 chars)
+#
+# <footer - breaking changes, issue references>
+#
+
+
+# Conventional commit message guide for atspi:
+
+# TYPES ───────────────────────────────────────────────────────────────────────
+# feat      ✨ New feature or enhancement
+# fix       🐛 Bug fix
+# docs      📚 Documentation changes
+# style     💎 Code style changes (formatting, semicolons, etc.)
+# refactor  ♻️  Code refactoring without functional changes
+# perf      ⚡ Performance improvements
+# test      🧪 Adding or updating tests
+# build     🏗️  Build system or dependency changes
+# ci        👷 CI/CD configuration changes
+# chore     🔧 Maintenance tasks, tooling changes
+# revert    ⏪ Reverting previous changes
+
+# SCOPES [optional] ---------──────────────────────────────────────────────────
+# atspi     📦 atspi crate
+# common    🔧 atspi-common
+# conn      🔗 atspi-connection
+# proxy     🔀 atspi-proxies
+# all       🌐 Workspace-wide changes
+
+# EXAMPLES ────────────────────────────────────────────────────────────────────
+# feat(atspi): add support for new accessibility events
+# fix(conn): handle connection timeout gracefully
+# docs(all): update README with installation instructions
+# refactor(proxy): simplify interface implementation
+# test(common): add unit tests for utility functions
+# perf(atspi)!: optimize event processing with breaking API changes
+
+# WRITING TIPS ────────────────────────────────────────────────────────────────
+# • Use imperative mood: "add" not "added" or "adds"
+# • Keep subject line under 50 characters
+# • Wrap body lines at 72 characters
+# • Separate subject from body with blank line
+# • Use body to explain WHAT and WHY, not HOW
+# • Reference issues: "Fixes #123", "Closes #456", "Resolves #789"
+# • Breaking changes: Add "!" after type/scope OR "BREAKING CHANGE:" footer
+# • Co-authors: "Co-authored-by: Name <email@example.com>"

--- a/README.md
+++ b/README.md
@@ -44,14 +44,26 @@ in the protocol descriptions, for example because they are deprecated (but still
 
 [A (partial) review of type validation may be found here](type_validation.md)
 
-## Contributors
+## Contributing
 
+This repository offers contributors hooks and a commit message template.
+We kindly request contributors to set both up locally.
+
+### git hooks
 This repository offers basic pre-commit and pre-push scripts in the `.githooks` directory.
-We recommend contributors to enable local git hooks.
 This command will configure git to use the hooks from the `.githooks` directory for this repository.
 
 ```sh
 git config core.hooksPath .githooks
+```
+### git commit message template
+
+The git commit message template helps contributors follow conventional commits for atspi.
+This command will configure git to use the commit message template from the `.gitmessage` file for
+this repository.
+
+```sh
+git config commit.template .gitmessage
 ```
 
 ## License


### PR DESCRIPTION
`atspi` currently lacks an up-to-date CHANGELOG.md` as is found in most crates.
Change logs are very useful to quickly get up to speed with the latest changes
of a crate.
Composing changes manually however is both arduous and unnecessary.

Following "conventional commits" unifies our messages and makes them
easier to parse. This will help us generate automated change logs in
the near future.

The commit message template helps us follow conventional commits in a way
tat is most relevant to `atspi`. 

The subject line is the most important for keeping our (future) CHANGELOG.md
up to date. If we manage to follow the rules, tools such as `git-cliff` will make 
updating the changelog light work - or maybe just CI pass even.

Addresses: #304