### PR TITLE
fix(common): correct `DBusMatchRule` for `EventListenerEvents`

### DIFF
--- a/atspi-common/src/events/event_wrappers.rs
+++ b/atspi-common/src/events/event_wrappers.rs
@@ -2113,8 +2113,7 @@ impl DBusInterface for EventListenerEvents {
 }
 
 impl DBusMatchRule for EventListenerEvents {
-	const MATCH_RULE_STRING: &'static str =
-		"type='signal',interface='org.a11y.atspi.Event.Registry'";
+	const MATCH_RULE_STRING: &'static str = "type='signal',interface='org.a11y.atspi.Registry'";
 }
 
 impl RegistryEventString for EventListenerEvents {


### PR DESCRIPTION
The event enum had a mistake in the `DBusMatchRule` impl.

Fixes: #306