### PR TITLE
`GetNlinks/selection` -> `GetNLinks/Selection`

### DIFF
--- a/atspi-proxies/src/action.rs
+++ b/atspi-proxies/src/action.rs
@@ -12,7 +12,7 @@
 //! Components which are not "passive" providers of UI information should
 //! implement this interface, unless there is a more specialized interface for
 //! interaction like [`org.a11y.atspi.Text`][TextProxy] or [`org.a11y.atspi.Value`][ValueProxy].
-//!  
+//!
 //! [ActionProxy]: crate::action::ActionProxy
 //! [TextProxy]: crate::text::TextProxy
 //! [ValueProxy]: crate::value::ValueProxy
@@ -31,7 +31,7 @@ use atspi_common::Action;
 /// Components which are not "passive" providers of UI information should
 /// implement this interface, unless there is a more specialized interface for
 /// interaction like [`org.a11y.atspi.Text`][TextProxy] or [`org.a11y.atspi.Value`][ValueProxy].
-///  
+///
 /// [TextProxy]: crate::text::TextProxy
 /// [ValueProxy]: crate::value::ValueProxy
 #[zbus::proxy(interface = "org.a11y.atspi.Action", assume_defaults = true)]
@@ -66,7 +66,7 @@ pub trait Action {
 
 	/// Returns the localized description for the action at the specified
 	/// index, starting at zero.
-	///   
+	///
 	/// For	example, a screen reader will read out this description when
 	/// the user asks for extra detail on an action.
 	/// For example, "Clicks the button" for the "click" action of a button.
@@ -126,6 +126,6 @@ pub trait Action {
 	///
 	/// By convention, if there is more than one action available,
 	/// the first one is considered the "default" action of the object.
-	#[zbus(property)]
-	fn nactions(&self) -> zbus::Result<i32>;
+	#[zbus(property, name = "NActions")]
+	fn n_actions(&self) -> zbus::Result<i32>;
 }

--- a/atspi-proxies/src/hyperlink.rs
+++ b/atspi-proxies/src/hyperlink.rs
@@ -29,7 +29,7 @@ pub trait Hyperlink {
 	fn end_index(&self) -> zbus::Result<i32>;
 
 	/// `NAnchors` property
-	#[zbus(property)]
+	#[zbus(property, name = "NAnchors")]
 	fn n_anchors(&self) -> zbus::Result<i16>;
 
 	/// `StartIndex` property

--- a/atspi-proxies/src/hypertext.rs
+++ b/atspi-proxies/src/hypertext.rs
@@ -21,5 +21,6 @@ pub trait Hypertext {
 	fn get_link_index(&self, character_index: i32) -> zbus::Result<i32>;
 
 	/// `GetNLinks` method
+	#[zbus(name = "GetNLinks")]
 	fn get_n_links(&self) -> zbus::Result<i32>;
 }

--- a/atspi-proxies/src/hypertext.rs
+++ b/atspi-proxies/src/hypertext.rs
@@ -21,5 +21,5 @@ pub trait Hypertext {
 	fn get_link_index(&self, character_index: i32) -> zbus::Result<i32>;
 
 	/// `GetNLinks` method
-	fn get_nlinks(&self) -> zbus::Result<i32>;
+	fn get_n_links(&self) -> zbus::Result<i32>;
 }

--- a/atspi-proxies/src/selection.rs
+++ b/atspi-proxies/src/selection.rs
@@ -35,6 +35,6 @@ pub trait Selection {
 	fn select_child(&self, child_index: i32) -> zbus::Result<bool>;
 
 	/// `NSelectedChildren` property
-	#[zbus(property)]
-	fn nselected_children(&self) -> zbus::Result<i32>;
+	#[zbus(property, name = "NSelectedChildren")]
+	fn n_selected_children(&self) -> zbus::Result<i32>;
 }

--- a/atspi-proxies/src/table.rs
+++ b/atspi-proxies/src/table.rs
@@ -82,20 +82,20 @@ pub trait Table {
 	fn caption(&self) -> zbus::Result<ObjectRefOwned>;
 
 	/// `NColumns` property
-	#[zbus(property)]
-	fn ncolumns(&self) -> zbus::Result<i32>;
+	#[zbus(property, name = "NColumns")]
+	fn n_columns(&self) -> zbus::Result<i32>;
 
 	/// `NRows` property
-	#[zbus(property)]
-	fn nrows(&self) -> zbus::Result<i32>;
+	#[zbus(property, name = "NRows")]
+	fn n_rows(&self) -> zbus::Result<i32>;
 
 	/// `NSelectedColumns` property
-	#[zbus(property)]
-	fn nselected_columns(&self) -> zbus::Result<i32>;
+	#[zbus(property, name = "NSelectedColumns")]
+	fn n_selected_columns(&self) -> zbus::Result<i32>;
 
 	/// `NSelectedRows` property
-	#[zbus(property)]
-	fn nselected_rows(&self) -> zbus::Result<i32>;
+	#[zbus(property, name = "NSelectedRows")]
+	fn n_selected_rows(&self) -> zbus::Result<i32>;
 
 	/// `Summary` property
 	#[zbus(property)]

--- a/atspi-proxies/src/text.rs
+++ b/atspi-proxies/src/text.rs
@@ -64,6 +64,7 @@ pub trait Text {
 	fn get_default_attributes(&self) -> zbus::Result<std::collections::HashMap<String, String>>;
 
 	/// `GetNSelections` method
+	#[zbus(name = "GetNSelections")]
 	fn get_n_selections(&self) -> zbus::Result<i32>;
 
 	/// `GetOffsetAtPoint` method

--- a/atspi-proxies/src/text.rs
+++ b/atspi-proxies/src/text.rs
@@ -64,7 +64,7 @@ pub trait Text {
 	fn get_default_attributes(&self) -> zbus::Result<std::collections::HashMap<String, String>>;
 
 	/// `GetNSelections` method
-	fn get_nselections(&self) -> zbus::Result<i32>;
+	fn get_n_selections(&self) -> zbus::Result<i32>;
 
 	/// `GetOffsetAtPoint` method
 	fn get_offset_at_point(&self, x: i32, y: i32, coord_type: CoordType) -> zbus::Result<i32>;


### PR DESCRIPTION
- Searched through XML docs using the following: `rg 'method name="[A-Za-z]+"' atspi-common/xml/ -o | rg '[A-Z]{2,}'`
- Found exactly four matches:
    - `name="GetMDIZOrder"`
    - `name="GetNSelections"`
    - `name="GetNLinks"`
    - `name="GetURI"`
- All now use their correct name via either `_` separation or `#[zbus(name = )]`
