### PR TITLE
fix(conn): Only signal msgs require iface fields

### DIFF
--- a/atspi-connection/src/lib.rs
+++ b/atspi-connection/src/lib.rs
@@ -199,6 +199,13 @@ impl AccessibilityConnection {
 				Err(e) => return Some(Err(e.into())),
 			};
 
+			// Only signals are required to include an interface header field,
+			// we should first affirm this message is a signal. Otherwise not
+			// having an interface isn't an error at all.
+			if msg.message_type() != MessageType::Signal {
+				return None;
+			}
+
 			let msg_header = msg.header();
 			let Some(msg_interface) = msg_header.interface() else {
 				return Some(Err(AtspiError::MissingInterface));
@@ -207,9 +214,7 @@ impl AccessibilityConnection {
 			// Most events we encounter are sent on an "org.a11y.atspi.Event.*" interface,
 			// but there are exceptions like "org.a11y.atspi.Cache" or "org.a11y.atspi.Registry".
 			// So only signals with a suitable interface name will be parsed.
-			if msg_interface.starts_with("org.a11y.atspi")
-				&& msg.message_type() == MessageType::Signal
-			{
+			if msg_interface.starts_with("org.a11y.atspi") {
 				Some(Event::try_from(&msg))
 			} else {
 				None


### PR DESCRIPTION
In `connection::event_stream` we emit a `AtspiError::MissingInterface` if the message does not contain one.

[Only signals require an interface header field](https://dbus.freedesktop.org/doc/dbus-specification.html). See heading: 'Header Fields'.
So we should only return `MissingInterface` if the message is a signal. On non-signal messages we must return `None` - which is, not return an `Event`.