### PR TITLE
Update crates.io release to `v0.30`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atspi"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "atspi",
  "atspi-common",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "atspi-common"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "assert_matches",
  "atspi-connection",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "atspi-connection"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "atspi-common",
  "atspi-proxies",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "atspi-proxies"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "atspi-common",
  "byteorder",

--- a/atspi-common/Cargo.toml
+++ b/atspi-common/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "atspi-common"
 readme                 = "README.md"
 repository             = "https://github.com/odilia-app/atspi"
 rust-version.workspace = true
-version                = "0.13.0"
+version                = "0.14.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/atspi-common/src/events/event_wrappers.rs
+++ b/atspi-common/src/events/event_wrappers.rs
@@ -1302,7 +1302,7 @@ impl EventWrapperMessageConversion for CacheEvents {
 				} else {
 					Err(AtspiError::SignatureMatch(format!(
 						"No matching event for signature {} in interface {}",
-						&sig.to_string(),
+						sig.to_string(),
 						Self::DBUS_INTERFACE
 					)))
 				}

--- a/atspi-common/src/events/traits.rs
+++ b/atspi-common/src/events/traits.rs
@@ -177,7 +177,7 @@ where
 			return Err(AtspiError::SignatureMatch(format!(
 				"The message signature {} does not match the signal's body signature: {}",
 				body_signature,
-				&expected_signature.to_string(),
+				expected_signature.to_string(),
 			)));
 		}
 		Ok(())

--- a/atspi-common/src/interface.rs
+++ b/atspi-common/src/interface.rs
@@ -282,7 +282,7 @@ mod tests {
 			InterfaceSet::new(Interface::Accessible | Interface::Action | Interface::Component);
 		let encoded = to_bytes(ctxt, &object).unwrap();
 		let (decoded, _) = encoded.deserialize::<InterfaceSet>().unwrap();
-		assert!(object == decoded);
+		assert_eq!(object, decoded);
 	}
 
 	// The order of appearance of the interfaces is equal to the order in the enum.

--- a/atspi-connection/Cargo.toml
+++ b/atspi-connection/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "atspi-connection"
 readme                 = "README.md"
 repository             = "https://github.com/odilia-app/atspi/"
 rust-version.workspace = true
-version                = "0.13.0"
+version                = "0.14.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -20,8 +20,8 @@ tracing  = ["dep:tracing"]
 wrappers = ["atspi-common/wrappers", "dep:futures-lite"]
 
 [dependencies]
-atspi-common   = { path = "../atspi-common/", version = "0.13.0", default-features = false, features = ["zbus"] }
-atspi-proxies  = { path = "../atspi-proxies/", version = "0.13.0" }
+atspi-common   = { path = "../atspi-common/", version = "0.14.0", default-features = false, features = ["zbus"] }
+atspi-proxies  = { path = "../atspi-proxies/", version = "0.14.0" }
 futures-lite   = { version = "2.6.0", default-features = false, optional = true }
 tracing        = { optional = true, workspace = true }
 zbus.workspace = true

--- a/atspi-connection/src/p2p.rs
+++ b/atspi-connection/src/p2p.rs
@@ -248,10 +248,7 @@ impl BusNameExt for BusName<'_> {
 			.get_application_bus_address()
 			.await
 			.map_err(|e| {
-				AtspiError::Owned(format!(
-					"Failed to get application bus address for {}: {e}",
-					&self
-				))
+				AtspiError::Owned(format!("Failed to get application bus address for {self}: {e}"))
 			})
 			.and_then(|address| {
 				Address::try_from(address.as_str())

--- a/atspi-proxies/Cargo.toml
+++ b/atspi-proxies/Cargo.toml
@@ -10,7 +10,7 @@ name                   = "atspi-proxies"
 readme                 = "README.md"
 repository             = "https://github.com/odilia-app/atspi"
 rust-version.workspace = true
-version                = "0.13.0"
+version                = "0.14.0"
 
 [package.metadata.release]
 publish = true
@@ -21,12 +21,12 @@ default  = ["wrappers"]
 wrappers = []
 
 [dependencies]
-atspi-common = { path = "../atspi-common", version = "0.13.0" }
+atspi-common = { path = "../atspi-common", version = "0.14.0" }
 serde        = { version = "^1.0.200", default-features = false, features = ["derive"] }
 zbus         = { workspace = true }
 
 [dev-dependencies]
-atspi-common = { path = "../atspi-common", version = "0.13.0" }
+atspi-common = { path = "../atspi-common", version = "0.14.0" }
 byteorder    = "1.4"
 futures-lite = { version = "2.6.0", default-features = false }
 rename-item  = "0.1.0"

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -11,7 +11,7 @@ name                   = "atspi"
 readme                 = "../README.md"
 repository             = "https://github.com/odilia-app/atspi"
 rust-version.workspace = true
-version                = "0.29.0"
+version                = "0.30.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -25,9 +25,9 @@ tokio      = ["zbus/tokio"]
 tracing    = ["atspi-connection/tracing"]
 
 [dependencies]
-atspi-common     = { path = "../atspi-common", version = "0.13.0", default-features = false }
-atspi-connection = { path = "../atspi-connection", version = "0.13.0", optional = true }
-atspi-proxies    = { path = "../atspi-proxies", version = "0.13.0", optional = true }
+atspi-common     = { path = "../atspi-common", version = "0.14.0", default-features = false }
+atspi-connection = { path = "../atspi-connection", version = "0.14.0", optional = true }
+atspi-proxies    = { path = "../atspi-proxies", version = "0.14.0", optional = true }
 zbus             = { workspace = true, optional = true }
 
 [[bench]]


### PR DESCRIPTION
- Updates deps (mitigates some CVEs)
- Update event stream logic to remove method replies (which cause MissingInterface errors in the user-facing event stream).
