### PR TITLE
docs(proxies):  Local stowaway changes for main

### DIFF
--- a/atspi-proxies/src/socket.rs
+++ b/atspi-proxies/src/socket.rs
@@ -1,16 +1,14 @@
 //! # `SocketProxy`
 //!
-//! A handle for the object on the `Registry` service for the `org.a11y.atspi.Socket`
-//! interface.
+//! A handle for the object on the `Registry` service or on the 'plug' process implementing the
+//! `org.a11y.atspi.Socket` interface.
 //!
 //! The `Socket` D-Bus interface bundles two largely unrelated concerns:
 //!
 //!  - General application registration (`Embed`, which every server app calls on the registry).
 //!  - The cross-process stitching (`Embedded`).
 //!
-//! Only `Embedded` is part of the actual stitching.
-//!
-//! ## The Socket/Plug Stitching Mechanism
+//! Only the `Embedded` method call is part of the actual stitching.
 //!
 #![doc = include_str!("../doc/socket-plug.md")]
 //!

--- a/atspi-proxies/src/socket.rs
+++ b/atspi-proxies/src/socket.rs
@@ -12,18 +12,7 @@
 //!
 //! ## The Socket/Plug Stitching Mechanism
 //!
-//! The Socket/Plug mechanism bridges the accessibility trees of two independent,
-//! server-side processes — a **host (the socket)** and an **embedded app (the plug)** —
-//! so that an assistive technology sees a single, contiguous tree. This is purely a
-//! server-side orchestration; assistive technologies only consume the stitched result
-//! and do not take part in it.
-//!
-//! As far as we can tell from the reference implementation, the embedding itself happens
-//! directly between the host and the plug; the registry is only involved in the separate,
-//! general registration step. For a step-by-step walkthrough with a sequence diagram and
-//! source references, see the [Socket/Plug Stitching Mechanism] document.
-//!
-//! [Socket/Plug Stitching Mechanism]: https://github.com/odilia-app/atspi/blob/main/atspi-proxies/doc/socket-plug.md
+#![doc = include_str!("../doc/socket-plug.md")]
 //!
 //! ## D-Bus Addressing
 //!


### PR DESCRIPTION
Unsaved change escaped the push:

The actual ` #![doc = include_str!("../doc/socket-plug.md")]`

And additional minor refinements:

- Refines the first line to say that the handle is to an object on either the registry or on a 'plug' process. 
- Remove header that would otherwise appear twice due to inclusion of the doc.

