### PR TITLE
chore(proxies): Remove unused `return` module

### DIFF
--- a/atspi-proxies/src/result.rs
+++ b/atspi-proxies/src/result.rs
@@ -1,1 +1,0 @@
-pub type AtspiResult<T> = Result<T, crate::AtspiError>;


### PR DESCRIPTION
We have a module where we define an alias `AtspiResult<T>`, however we already have that in `atspi-common` which is a unconditional dependency of `atspi-proxies`.
