### PR TITLE
fix(CI): Deny warnings when building docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,8 @@ jobs:
         with:
           toolchain: nightly
       - name: Generate Documentation
+        env:
+          RUSTDOCFLAGS: -D warnings
         run: cargo doc --workspace --no-deps --document-private-items
   cargo-deny:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We noticed broken inta-doc links slipped through CI unnoticed. This adds env variable that denies any warnings while building rustdocs.

Addresses issue #351
