### PR TITLE
fix(common): Introduce `RoleSet`

### DIFF
--- a/atspi-common/src/lib.rs
+++ b/atspi-common/src/lib.rs
@@ -40,7 +40,7 @@ pub use error::AtspiError;
 pub mod events;
 pub use events::{EventProperties, EventTypeProperties};
 mod role;
-pub use role::Role;
+pub use role::{Role, RoleSet};
 mod relation_type;
 pub use relation_type::RelationType;
 

--- a/atspi-common/src/object_match.rs
+++ b/atspi-common/src/object_match.rs
@@ -3,7 +3,7 @@ use std::{borrow::Borrow, collections::HashMap, marker::PhantomData};
 use serde::{Deserialize, Serialize};
 use zvariant::{Signature, Type};
 
-use crate::{Interface, InterfaceSet, Role, State, StateSet};
+use crate::{Interface, InterfaceSet, Role, RoleSet, State, StateSet};
 
 /// Defines how an object-tree is to be traversed.
 /// Used in `CollectionProxy`.
@@ -30,13 +30,18 @@ pub enum TreeTraversalType {
 /// let builder = MatchRule::builder();
 /// ```
 ///
+/// # Note on Naming
+/// This struct is named `ObjectMatchRule` instead of `MatchRule` to avoid
+/// naming conflicts and confusion with [`zbus::MatchRule`], which is used for
+/// lower-level D-Bus message filtering.
+///
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ObjectMatchRule {
 	pub states: StateSet,
 	pub states_mt: MatchType,
 	pub attr: HashMap<String, String>,
 	pub attr_mt: MatchType,
-	pub roles: Vec<Role>,
+	pub roles: RoleSet,
 	pub roles_mt: MatchType,
 	pub ifaces: InterfaceSet,
 	pub ifaces_mt: MatchType,
@@ -65,7 +70,7 @@ impl Type for ObjectMatchRule {
 		&Signature::I32,
 		<HashMap<&str, &str>>::SIGNATURE,
 		&Signature::I32,
-		<Vec<i32>>::SIGNATURE,
+		<RoleSet as Type>::SIGNATURE,
 		&Signature::I32,
 		<Vec<&str>>::SIGNATURE,
 		&Signature::I32,
@@ -83,17 +88,33 @@ impl ObjectMatchRule {
 
 /// The 'builder' type for `MatchRule`.
 /// Use its methods to set match criteria.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ObjectMatchRuleBuilder {
 	states: StateSet,
 	states_mt: MatchType,
 	attr: HashMap<String, String>,
 	attr_mt: MatchType,
-	roles: Vec<Role>,
+	roles: RoleSet,
 	roles_mt: MatchType,
 	ifaces: InterfaceSet,
 	ifaces_mt: MatchType,
 	invert: bool,
+}
+
+impl Default for ObjectMatchRuleBuilder {
+	fn default() -> Self {
+		Self {
+			states: StateSet::default(),
+			states_mt: MatchType::All,
+			attr: HashMap::default(),
+			attr_mt: MatchType::All,
+			roles: RoleSet::default(),
+			roles_mt: MatchType::All,
+			ifaces: InterfaceSet::default(),
+			ifaces_mt: MatchType::All,
+			invert: false,
+		}
+	}
 }
 
 impl ObjectMatchRuleBuilder {
@@ -101,10 +122,9 @@ impl ObjectMatchRuleBuilder {
 	#[must_use]
 	pub fn states<I>(mut self, states: I, mt: MatchType) -> Self
 	where
-		I: IntoIterator,
-		I::Item: Borrow<State>,
+		I: IntoIterator<Item = State>,
 	{
-		self.states = states.into_iter().map(|state| *state.borrow()).collect();
+		self.states = states.into_iter().collect();
 		self.states_mt = mt;
 		self
 	}
@@ -120,7 +140,7 @@ impl ObjectMatchRuleBuilder {
 	/// Insert a slice of `Role`s
 	#[must_use]
 	pub fn roles(mut self, roles: &[Role], mt: MatchType) -> Self {
-		self.roles = roles.into();
+		self.roles = RoleSet::new(roles.iter().copied());
 		self.roles_mt = mt;
 		self
 	}
@@ -164,28 +184,44 @@ impl ObjectMatchRuleBuilder {
 	}
 }
 
-/// Enumeration used by [`ObjectMatchRule`] to specify how to interpret [`ObjectRef`] objects.
+// `Empty` or `Invalid`
+// https://github.com/GNOME/at-spi2-core/blob/main/atk-adaptor/adaptors/collection-adaptor.c#L190-L214
+
+/// Enumeration used by [`ObjectMatchRule`] to specify how to select for [`ObjectRef`] objects.
+///
+/// This specifies the matching criteria for properties such as states, roles, interfaces, and attributes.
 ///
 /// [`ObjectRef`]: crate::object_ref::ObjectRef
+///
+// <https://github.com/GNOME/at-spi2-core/blob/main/atspi/atspi-constants.h#L203-L228>
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Type, Default)]
 #[repr(i32)]
 pub enum MatchType {
+	/// No objects match under this criterion.
+	///
+	/// *Note:* This will invalidate the entire `ObjectMatchRule`.
+	///
+	/// This represents an invalid or uninitialized match criterion.
 	#[default]
-	/// Invalidates match criterion. Meanting: the search of this property will not be performed.
-	Invalid,
+	Invalid = 0,
 
-	/// All of the criteria must be met.
-	All,
+	/// All objects that meet all of the specified criteria match.
+	///
+	/// If the set is empty, all objects match.
+	All = 1,
 
-	/// Any of the criteria must criteria must be met.
-	Any,
+	/// All objects that meet at least one of the specified criteria match.
+	Any = 2,
 
-	/// None of the criteria must be met.
-	NA,
+	/// All objects that meet none of the specified criteria match.
+	None = 3,
 
-	/// Same as [`Self::All`] if the criterion item is non-empty - All of the criteria must be met.
-	/// For empty criteria this rule requires the returned value to also have empty set.
-	Empty,
+	/// All objects that meet all criteria match if the criteria set is non-empty;
+	/// for empty criteria, only objects that also have an empty set for this property match.
+	///
+	/// *Note:* This is currently unimplemented in the upstream server-side C library,
+	/// behaving identically to `Invalid`, matching no objects for the entire `ObjectMatchRule`.
+	Empty = 4,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Type)]
@@ -274,7 +310,7 @@ mod tests {
 
 		assert_eq!(rule.states, StateSet::default());
 		assert_eq!(rule.attr, HashMap::new());
-		assert_eq!(rule.roles, Vec::new());
+		assert_eq!(rule.roles, RoleSet::default());
 		assert_eq!(rule.ifaces, InterfaceSet::default());
 		assert!(!rule.invert);
 	}
@@ -297,7 +333,7 @@ mod tests {
 			rule.attr,
 			[("name".to_string(), "value".to_string())].iter().cloned().collect()
 		);
-		assert_eq!(rule.roles, vec![Role::Alert]);
+		assert_eq!(rule.roles, RoleSet::new([Role::Alert]));
 		assert_eq!(rule.ifaces, InterfaceSet::new(Interface::Action));
 		assert!(rule.invert);
 	}

--- a/atspi-common/src/object_match.rs
+++ b/atspi-common/src/object_match.rs
@@ -184,8 +184,8 @@ impl ObjectMatchRuleBuilder {
 	}
 }
 
-// `Empty` or `Invalid`
-// https://github.com/GNOME/at-spi2-core/blob/main/atk-adaptor/adaptors/collection-adaptor.c#L190-L214
+// `Empty` or `Invalid` have no filter functions implemented and are ignored, invalidating the match rule.
+// <https://github.com/GNOME/at-spi2-core/blob/main/atk-adaptor/adaptors/collection-adaptor.c#L190-L214>
 
 /// Enumeration used by [`ObjectMatchRule`] to specify how to select for [`ObjectRef`] objects.
 ///
@@ -199,28 +199,32 @@ impl ObjectMatchRuleBuilder {
 pub enum MatchType {
 	/// No objects match under this criterion.
 	///
-	/// *Note:* This will invalidate the entire `ObjectMatchRule`.
+	/// *Note:* This will invalidate the entire `ObjectMatchRule`.\
+	/// There is no filter function implemented in the reference
+	/// implementation [`atk-adaptor`](https://github.com/GNOME/at-spi2-core/blob/main/atk-adaptor/adaptors/collection-adaptor.c#L190-L214).
+	/// This variant is ignored.
 	///
 	/// This represents an invalid or uninitialized match criterion.
-	#[default]
 	Invalid = 0,
 
-	/// All objects that meet all of the specified criteria match.
+	/// Objects meeting all of the specified criteria match.
 	///
 	/// If the set is empty, all objects match.
+	#[default]
 	All = 1,
 
-	/// All objects that meet at least one of the specified criteria match.
+	/// Objects meeting at least one of the specified criteria match.
 	Any = 2,
 
-	/// All objects that meet none of the specified criteria match.
+	/// Objects meeting none of the specified criteria match.
 	None = 3,
 
-	/// All objects that meet all criteria match if the criteria set is non-empty;
-	/// for empty criteria, only objects that also have an empty set for this property match.
+	/// No objects match under this criterion.
 	///
-	/// *Note:* This is currently unimplemented in the upstream server-side C library,
-	/// behaving identically to `Invalid`, matching no objects for the entire `ObjectMatchRule`.
+	/// # Unimplemented
+	/// This is unimplemented in the upstream server-side C library,
+	/// Use of this variant is ignored, just as `Invalid`, using `Empty` as `MatchType` in
+	/// an [`ObjectMatchRule`] will invalidate the match rule.
 	Empty = 4,
 }
 

--- a/atspi-common/src/object_match.rs
+++ b/atspi-common/src/object_match.rs
@@ -173,8 +173,6 @@ impl ObjectMatchRuleBuilder {
 /// This specifies the matching criteria for properties such as states, roles, interfaces, and attributes.
 ///
 /// [`ObjectRef`]: crate::object_ref::ObjectRef
-///
-// <https://github.com/GNOME/at-spi2-core/blob/main/atspi/atspi-constants.h#L203-L228>
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Type, Default)]
 #[repr(i32)]
 pub enum MatchType {

--- a/atspi-common/src/object_match.rs
+++ b/atspi-common/src/object_match.rs
@@ -180,12 +180,8 @@ impl ObjectMatchRuleBuilder {
 pub enum MatchType {
 	/// No objects match under this criterion.
 	///
-	/// *Note:* This will invalidate the entire `ObjectMatchRule`.\
-	/// There is no filter function implemented in the reference
-	/// implementation [`atk-adaptor`](https://github.com/GNOME/at-spi2-core/blob/main/atk-adaptor/adaptors/collection-adaptor.c#L190-L214).
-	/// This variant is ignored.
-	///
-	/// This represents an invalid or uninitialized match criterion.
+	/// This represents an invalid or uninitialized match criterion with atleast some implementations.
+	/// This variant will invalidate the whole match-rule in some, if not most implementations.
 	Invalid = 0,
 
 	/// Objects meeting all of the specified criteria match.
@@ -202,10 +198,7 @@ pub enum MatchType {
 
 	/// No objects match under this criterion.
 	///
-	/// # Unimplemented
-	/// This is unimplemented in the upstream server-side C library,
-	/// Use of this variant is ignored, just as `Invalid`, using `Empty` as `MatchType` in
-	/// an [`ObjectMatchRule`] will invalidate the match rule.
+	/// This variant invalidates the whole match-rule in some, if not most implementations.
 	Empty = 4,
 }
 

--- a/atspi-common/src/object_match.rs
+++ b/atspi-common/src/object_match.rs
@@ -88,7 +88,7 @@ impl ObjectMatchRule {
 
 /// The 'builder' type for `MatchRule`.
 /// Use its methods to set match criteria.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ObjectMatchRuleBuilder {
 	states: StateSet,
 	states_mt: MatchType,
@@ -99,22 +99,6 @@ pub struct ObjectMatchRuleBuilder {
 	ifaces: InterfaceSet,
 	ifaces_mt: MatchType,
 	invert: bool,
-}
-
-impl Default for ObjectMatchRuleBuilder {
-	fn default() -> Self {
-		Self {
-			states: StateSet::default(),
-			states_mt: MatchType::All,
-			attr: HashMap::default(),
-			attr_mt: MatchType::All,
-			roles: RoleSet::default(),
-			roles_mt: MatchType::All,
-			ifaces: InterfaceSet::default(),
-			ifaces_mt: MatchType::All,
-			invert: false,
-		}
-	}
 }
 
 impl ObjectMatchRuleBuilder {

--- a/atspi-common/src/object_match.rs
+++ b/atspi-common/src/object_match.rs
@@ -140,7 +140,7 @@ impl ObjectMatchRuleBuilder {
 	/// Insert a slice of `Role`s
 	#[must_use]
 	pub fn roles(mut self, roles: &[Role], mt: MatchType) -> Self {
-		self.roles = RoleSet::new(roles.iter().copied());
+		self.roles = RoleSet::from_iter(roles);
 		self.roles_mt = mt;
 		self
 	}
@@ -183,9 +183,6 @@ impl ObjectMatchRuleBuilder {
 		}
 	}
 }
-
-// `Empty` or `Invalid` have no filter functions implemented and are ignored, invalidating the match rule.
-// <https://github.com/GNOME/at-spi2-core/blob/main/atk-adaptor/adaptors/collection-adaptor.c#L190-L214>
 
 /// Enumeration used by [`ObjectMatchRule`] to specify how to select for [`ObjectRef`] objects.
 ///

--- a/atspi-common/src/object_match.rs
+++ b/atspi-common/src/object_match.rs
@@ -108,7 +108,7 @@ impl ObjectMatchRuleBuilder {
 	where
 		I: IntoIterator<Item = State>,
 	{
-		self.states = states.into_iter().collect();
+		self.states = StateSet::from_iter(states);
 		self.states_mt = mt;
 		self
 	}

--- a/atspi-common/src/role.rs
+++ b/atspi-common/src/role.rs
@@ -657,10 +657,11 @@ impl RoleSet {
 	pub fn contains(&self, role: Role) -> bool {
 		let role_val = role as usize;
 		let index = role_val / 32; // index into the array
+		debug_assert!(index < self.0.len());
 		let bit = role_val % 32;
 		// residual: the bit position within the array element note that residual can never exceed 32
 		if let Some(&bits) = self.0.get(index) {
-			(bits & (1 << bit)) != 0
+			(bits >> bit) & 0b1 == 0b1
 		} else {
 			false
 		}
@@ -670,6 +671,7 @@ impl RoleSet {
 	pub fn insert(&mut self, role: Role) {
 		let role_val = role as usize;
 		let index = role_val / 32;
+		debug_assert!(index < self.0.len());
 		let bit = role_val % 32;
 		if let Some(bits) = self.0.get_mut(index) {
 			*bits |= 1 << bit;
@@ -680,6 +682,7 @@ impl RoleSet {
 	pub fn remove(&mut self, role: Role) {
 		let role_val = role as usize;
 		let index = role_val / 32;
+		debug_assert!(index < self.0.len());
 		let bit = role_val % 32;
 		if let Some(bits) = self.0.get_mut(index) {
 			*bits &= !(1 << bit);
@@ -690,6 +693,7 @@ impl RoleSet {
 	pub fn toggle(&mut self, role: Role) {
 		let role_val = role as usize;
 		let index = role_val / 32;
+		debug_assert!(index < self.0.len());
 		let bit = role_val % 32;
 		if let Some(bits) = self.0.get_mut(index) {
 			*bits ^= 1 << bit;
@@ -807,8 +811,10 @@ impl Iterator for RoleSetIter {
 	type Item = Role;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		while self.index < 160 {
+		let bitfield_length = std::mem::size_of_val(&self.set.0) * (u8::BITS as usize);
+		while self.index < bitfield_length {
 			let current = u32::try_from(self.index).ok()?;
+
 			self.index += 1;
 			if let Ok(role) = Role::try_from(current) {
 				if self.set.contains(role) {

--- a/atspi-common/src/role.rs
+++ b/atspi-common/src/role.rs
@@ -3,7 +3,7 @@ use serde::{
 	ser::{SerializeSeq, Serializer},
 	Deserialize, Serialize,
 };
-use std::fmt;
+use std::{fmt, iter::FusedIterator};
 use zvariant::Type;
 
 use crate::AtspiError;
@@ -698,13 +698,19 @@ impl RoleSet {
 
 	/// Returns an iterator yielding each set [`Role`].
 	#[must_use]
-	pub fn iter(&self) -> RoleSetIter {
-		RoleSetIter { set: *self, index: 0 }
+	pub fn iter(&self) -> RoleSetIterator {
+		RoleSetIterator { set: *self, index: 0, remaining: self.len() }
+	}
+
+	/// Returns the number of roles in this set.
+	#[must_use]
+	pub fn len(&self) -> u32 {
+		self.0.iter().map(|&bits| (bits).count_ones()).sum::<u32>()
 	}
 }
 
 impl IntoIterator for RoleSet {
-	type IntoIter = RoleSetIter;
+	type IntoIter = RoleSetIterator;
 	type Item = Role;
 
 	fn into_iter(self) -> Self::IntoIter {
@@ -713,7 +719,7 @@ impl IntoIterator for RoleSet {
 }
 
 impl IntoIterator for &RoleSet {
-	type IntoIter = RoleSetIter;
+	type IntoIter = RoleSetIterator;
 	type Item = Role;
 
 	fn into_iter(self) -> Self::IntoIter {
@@ -792,22 +798,39 @@ impl std::ops::BitAndAssign for RoleSet {
 }
 
 #[derive(Clone, Debug)]
-pub struct RoleSetIter {
+pub struct RoleSetIterator {
 	set: RoleSet,
 	index: u32,
+	remaining: u32,
 }
 
-impl Iterator for RoleSetIter {
+impl Iterator for RoleSetIterator {
 	type Item = Role;
 
 	fn next(&mut self) -> Option<Self::Item> {
+		if self.remaining == 0 {
+			return None;
+		}
 		while let Ok(role) = Role::try_from(self.index) {
 			self.index += 1;
 			if self.set.contains(role) {
+				self.remaining -= 1;
 				return Some(role);
 			}
 		}
 		None
+	}
+
+	fn size_hint(&self) -> (usize, Option<usize>) {
+		(self.remaining as usize, Some(self.remaining as usize))
+	}
+}
+
+impl FusedIterator for RoleSetIterator {}
+
+impl ExactSizeIterator for RoleSetIterator {
+	fn len(&self) -> usize {
+		self.remaining as usize
 	}
 }
 
@@ -1050,5 +1073,63 @@ pub mod tests {
 		assert_eq!(decoded, set);
 		assert!(decoded.contains(Role::Alert));
 		assert!(decoded.contains(Role::Button));
+	}
+
+	#[test]
+	fn test_role_set_len() {
+		let mut set = RoleSet::empty();
+		assert_eq!(set.len(), 0);
+
+		set.insert(Role::Alert);
+		assert_eq!(set.len(), 1);
+
+		// Duplicate insert must not change the length
+		set.insert(Role::Alert);
+		assert_eq!(set.len(), 1);
+
+		set.insert(Role::Button);
+		set.insert(Role::Window);
+		assert_eq!(set.len(), 3);
+
+		set.remove(Role::Button);
+		assert_eq!(set.len(), 2);
+	}
+
+	#[test]
+	fn test_role_set_iterator_exact_size() {
+		let set = RoleSet::new([Role::Alert, Role::Button, Role::Window]);
+		let mut iter = set.iter();
+
+		assert_eq!(iter.len(), 3);
+		assert_eq!(iter.size_hint(), (3, Some(3)));
+
+		assert_eq!(iter.next(), Some(Role::Alert));
+		assert_eq!(iter.len(), 2);
+		assert_eq!(iter.size_hint(), (2, Some(2)));
+
+		assert_eq!(iter.next(), Some(Role::Button));
+		assert_eq!(iter.len(), 1);
+		assert_eq!(iter.size_hint(), (1, Some(1)));
+
+		assert_eq!(iter.next(), Some(Role::Window));
+		assert_eq!(iter.len(), 0);
+		assert_eq!(iter.size_hint(), (0, Some(0)));
+
+		assert_eq!(iter.next(), None);
+		assert_eq!(iter.len(), 0);
+		assert_eq!(iter.size_hint(), (0, Some(0)));
+	}
+
+	#[test]
+	fn test_role_set_iterator_fused() {
+		let set = RoleSet::new([Role::Alert]);
+		let mut iter = set.iter();
+
+		assert_eq!(iter.next(), Some(Role::Alert));
+
+		assert_eq!(iter.next(), None);
+
+		assert_eq!(iter.next(), None, "Fused, must return None");
+		assert_eq!(iter.next(), None, "Fused, must return None");
 	}
 }

--- a/atspi-common/src/role.rs
+++ b/atspi-common/src/role.rs
@@ -622,10 +622,17 @@ impl std::fmt::Display for Role {
 	}
 }
 
-//#[allow(clippy::module_name_repetitions)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
 /// The bitflag representation of all roles an object may have.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
 pub struct RoleSet([i32; 5]);
+
+fn element_idx_and_bit_for(role: Role) -> (usize, usize) {
+	let role_val = role as usize;
+	let index = role_val / 32;
+	debug_assert!(index < RoleSet::empty().0.len());
+	let bit = role_val % 32;
+	(index, bit)
+}
 
 impl RoleSet {
 	/// Create a new `RoleSet` from a collection of roles.
@@ -633,16 +640,12 @@ impl RoleSet {
 	where
 		I: IntoIterator<Item = Role>,
 	{
-		let mut set = Self::empty();
-		for role in roles {
-			set.insert(role);
-		}
-		set
+		Self::from_iter(roles)
 	}
 
 	/// Create an empty `RoleSet`.
 	#[must_use]
-	pub fn empty() -> Self {
+	pub const fn empty() -> Self {
 		Self([0; 5])
 	}
 
@@ -655,11 +658,7 @@ impl RoleSet {
 	/// Checks if a specific [`Role`] is in the set.
 	#[must_use]
 	pub fn contains(&self, role: Role) -> bool {
-		let role_val = role as usize;
-		let index = role_val / 32; // index into the array
-		debug_assert!(index < self.0.len());
-		let bit = role_val % 32;
-		// residual: the bit position within the array element note that residual can never exceed 32
+		let (index, bit) = element_idx_and_bit_for(role);
 		if let Some(&bits) = self.0.get(index) {
 			(bits >> bit) & 0b1 == 0b1
 		} else {
@@ -669,10 +668,7 @@ impl RoleSet {
 
 	/// Inserts a [`Role`] into the set.
 	pub fn insert(&mut self, role: Role) {
-		let role_val = role as usize;
-		let index = role_val / 32;
-		debug_assert!(index < self.0.len());
-		let bit = role_val % 32;
+		let (index, bit) = element_idx_and_bit_for(role);
 		if let Some(bits) = self.0.get_mut(index) {
 			*bits |= 1 << bit;
 		}
@@ -680,10 +676,7 @@ impl RoleSet {
 
 	/// Removes a [`Role`] from the set.
 	pub fn remove(&mut self, role: Role) {
-		let role_val = role as usize;
-		let index = role_val / 32;
-		debug_assert!(index < self.0.len());
-		let bit = role_val % 32;
+		let (index, bit) = element_idx_and_bit_for(role);
 		if let Some(bits) = self.0.get_mut(index) {
 			*bits &= !(1 << bit);
 		}
@@ -691,10 +684,7 @@ impl RoleSet {
 
 	/// Toggles a [`Role`] in the set.
 	pub fn toggle(&mut self, role: Role) {
-		let role_val = role as usize;
-		let index = role_val / 32;
-		debug_assert!(index < self.0.len());
-		let bit = role_val % 32;
+		let (index, bit) = element_idx_and_bit_for(role);
 		if let Some(bits) = self.0.get_mut(index) {
 			*bits ^= 1 << bit;
 		}
@@ -814,7 +804,6 @@ impl Iterator for RoleSetIter {
 		let bitfield_length = std::mem::size_of_val(&self.set.0) * (u8::BITS as usize);
 		while self.index < bitfield_length {
 			let current = u32::try_from(self.index).ok()?;
-
 			self.index += 1;
 			if let Ok(role) = Role::try_from(current) {
 				if self.set.contains(role) {
@@ -845,7 +834,8 @@ impl<'de> Deserialize<'de> for RoleSet {
 			where
 				D: Deserializer<'de>,
 			{
-				let arr = <[i32; 5] as Deserialize>::deserialize(deserializer)?;
+				let arr =
+					<[i32; RoleSet::empty().0.len()] as Deserialize>::deserialize(deserializer)?;
 				Ok(RoleSet(arr))
 			}
 		}
@@ -873,7 +863,7 @@ impl Type for RoleSet {
 
 #[cfg(test)]
 pub mod tests {
-	use super::Role;
+	use super::{Role, RoleSet};
 	use zvariant::serialized::Context;
 	use zvariant::{to_bytes, LE};
 
@@ -904,11 +894,35 @@ pub mod tests {
 	}
 
 	#[test]
-	fn test_role_set_operations() {
-		use super::RoleSet;
+	fn test_role_set_ops_empty() {
+		let set = RoleSet::empty();
+		assert!(set.is_empty());
+	}
 
+	#[test]
+	fn test_role_set_ops_remove() {
+		let mut set = RoleSet::new([Role::Arrow]);
+		assert!(!set.is_empty());
+		set.remove(Role::Arrow);
+		assert!(set.is_empty());
+	}
+
+	#[test]
+	fn test_role_set_ops_insert() {
+		let mut set = RoleSet::empty();
+
+		set.insert(Role::Alert);
+		set.insert(Role::Animation);
+		set.insert(Role::Header);
+		assert_eq!(set, RoleSet::new([Role::Alert, Role::Animation, Role::Header]));
+	}
+
+	#[test]
+	fn test_role_set_ops_contains() {
 		let mut set = RoleSet::empty();
 		assert!(set.is_empty());
+		assert!(!set.contains(Role::Alert));
+		assert!(!set.contains(Role::Button));
 
 		set.insert(Role::Alert);
 		assert!(!set.is_empty());
@@ -917,50 +931,97 @@ pub mod tests {
 
 		set.insert(Role::Button);
 		assert!(set.contains(Role::Button));
-
-		set.remove(Role::Alert);
-		assert!(!set.contains(Role::Alert));
-		assert!(set.contains(Role::Button));
-
-		let roles: Vec<Role> = set.iter().collect();
-		assert_eq!(roles, vec![Role::Button]);
 	}
 
 	#[test]
-	fn test_role_set_bitops() {
-		use super::RoleSet;
+	fn test_role_set_ops_toggle() {
+		let mut set = RoleSet::empty();
+		set.toggle(Role::Alert);
+		assert!(set.contains(Role::Alert));
+		set.toggle(Role::Alert);
+		assert!(!set.contains(Role::Alert));
+	}
 
+	#[test]
+	fn test_role_set_ops_bits() {
+		let mut set = RoleSet::new([Role::Alert, Role::Button]);
+		assert_eq!(set.bits(), [4, 2048, 0, 0, 0]);
+
+		set.insert(Role::Window);
+		assert_eq!(set.bits(), [4, 2048, 32, 0, 0]);
+	}
+
+	#[test]
+	fn test_role_set_ops_iter() {
+		let mut set = RoleSet::empty();
+		set.insert(Role::Alert);
+		set.insert(Role::Button);
+		assert_eq!(set.iter().collect::<Vec<_>>(), vec![Role::Alert, Role::Button]);
+	}
+
+	#[test]
+	fn test_role_set_bitops_xor() {
 		let set1 = RoleSet::new([Role::Alert, Role::Button]);
 		let set2 = RoleSet::new([Role::Button, Role::Window]);
 		let result = set1 ^ set2;
+
 		assert!(result.contains(Role::Alert));
 		assert!(result.contains(Role::Window));
 		assert!(!result.contains(Role::Button));
+	}
 
+	#[test]
+	fn test_role_set_bitops_and() {
+		let set1 = RoleSet::new([Role::Alert, Role::Button]);
+		let set2 = RoleSet::new([Role::Button, Role::Window]);
 		let result = set1 & set2;
+
 		assert!(!result.contains(Role::Alert));
 		assert!(!result.contains(Role::Window));
 		assert!(result.contains(Role::Button));
+	}
 
+	#[test]
+	fn test_role_set_bitops_or() {
+		let set1 = RoleSet::new([Role::Alert, Role::Button]);
+		let set2 = RoleSet::new([Role::Button, Role::Window]);
 		let result = set1 | set2;
 		assert!(result.contains(Role::Alert));
 		assert!(result.contains(Role::Window));
 		assert!(result.contains(Role::Button));
+	}
 
+	#[test]
+	fn test_role_set_bitops_xor_assign() {
+		let set1 = RoleSet::new([Role::Alert, Role::Button]);
+		let set2 = RoleSet::new([Role::Button, Role::Window]);
 		let mut set1_clone = set1;
 		set1_clone ^= set2;
+		assert_ne!(set1_clone, set1);
 		assert!(set1_clone.contains(Role::Alert));
 		assert!(set1_clone.contains(Role::Window));
 		assert!(!set1_clone.contains(Role::Button));
+	}
 
+	#[test]
+	fn test_role_set_bitops_and_assign() {
+		let set1 = RoleSet::new([Role::Alert, Role::Button]);
+		let set2 = RoleSet::new([Role::Button, Role::Window]);
 		let mut set1_clone = set1;
 		set1_clone &= set2;
+		assert_ne!(set1_clone, set1);
 		assert!(!set1_clone.contains(Role::Alert));
 		assert!(!set1_clone.contains(Role::Window));
 		assert!(set1_clone.contains(Role::Button));
+	}
 
+	#[test]
+	fn test_role_set_bitops_or_assign() {
+		let set1 = RoleSet::new([Role::Alert, Role::Button]);
+		let set2 = RoleSet::new([Role::Button, Role::Window]);
 		let mut set2_clone = set2;
 		set2_clone |= set1;
+		assert_ne!(set2_clone, set2);
 		assert!(set2_clone.contains(Role::Alert));
 		assert!(set2_clone.contains(Role::Window));
 		assert!(set2_clone.contains(Role::Button));

--- a/atspi-common/src/role.rs
+++ b/atspi-common/src/role.rs
@@ -704,8 +704,8 @@ impl RoleSet {
 
 	/// Returns the number of roles in this set.
 	#[must_use]
-	pub fn len(&self) -> u32 {
-		self.0.iter().map(|&bits| (bits).count_ones()).sum::<u32>()
+	pub fn len(&self) -> usize {
+		self.0.iter().map(|&bits| (bits).count_ones()).sum::<u32>() as usize
 	}
 }
 
@@ -801,7 +801,7 @@ impl std::ops::BitAndAssign for RoleSet {
 pub struct RoleSetIterator {
 	set: RoleSet,
 	index: u32,
-	remaining: u32,
+	remaining: usize,
 }
 
 impl Iterator for RoleSetIterator {
@@ -811,6 +811,7 @@ impl Iterator for RoleSetIterator {
 		if self.remaining == 0 {
 			return None;
 		}
+
 		while let Ok(role) = Role::try_from(self.index) {
 			self.index += 1;
 			if self.set.contains(role) {
@@ -822,7 +823,7 @@ impl Iterator for RoleSetIterator {
 	}
 
 	fn size_hint(&self) -> (usize, Option<usize>) {
-		(self.remaining as usize, Some(self.remaining as usize))
+		(self.remaining, Some(self.remaining))
 	}
 }
 
@@ -830,7 +831,7 @@ impl FusedIterator for RoleSetIterator {}
 
 impl ExactSizeIterator for RoleSetIterator {
 	fn len(&self) -> usize {
-		self.remaining as usize
+		self.remaining
 	}
 }
 

--- a/atspi-common/src/role.rs
+++ b/atspi-common/src/role.rs
@@ -1,4 +1,9 @@
-use serde::{Deserialize, Serialize};
+use serde::{
+	de::{Deserializer, Visitor},
+	ser::{SerializeSeq, Serializer},
+	Deserialize, Serialize,
+};
+use std::fmt;
 use zvariant::Type;
 
 use crate::AtspiError;
@@ -617,6 +622,249 @@ impl std::fmt::Display for Role {
 	}
 }
 
+//#[allow(clippy::module_name_repetitions)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
+/// The bitflag representation of all roles an object may have.
+pub struct RoleSet([i32; 5]);
+
+impl RoleSet {
+	/// Create a new `RoleSet` from a collection of roles.
+	pub fn new<I>(roles: I) -> Self
+	where
+		I: IntoIterator<Item = Role>,
+	{
+		let mut set = Self::empty();
+		for role in roles {
+			set.insert(role);
+		}
+		set
+	}
+
+	/// Create an empty `RoleSet`.
+	#[must_use]
+	pub fn empty() -> Self {
+		Self([0; 5])
+	}
+
+	/// Checks if all roles are unset.
+	#[must_use]
+	pub fn is_empty(&self) -> bool {
+		self.0.iter().all(|&bits| bits == 0)
+	}
+
+	/// Checks if a specific [`Role`] is in the set.
+	#[must_use]
+	pub fn contains(&self, role: Role) -> bool {
+		let role_val = role as usize;
+		let index = role_val / 32; // index into the array
+		let bit = role_val % 32;
+		// residual: the bit position within the array element note that residual can never exceed 32
+		if let Some(&bits) = self.0.get(index) {
+			(bits & (1 << bit)) != 0
+		} else {
+			false
+		}
+	}
+
+	/// Inserts a [`Role`] into the set.
+	pub fn insert(&mut self, role: Role) {
+		let role_val = role as usize;
+		let index = role_val / 32;
+		let bit = role_val % 32;
+		if let Some(bits) = self.0.get_mut(index) {
+			*bits |= 1 << bit;
+		}
+	}
+
+	/// Removes a [`Role`] from the set.
+	pub fn remove(&mut self, role: Role) {
+		let role_val = role as usize;
+		let index = role_val / 32;
+		let bit = role_val % 32;
+		if let Some(bits) = self.0.get_mut(index) {
+			*bits &= !(1 << bit);
+		}
+	}
+
+	/// Toggles a [`Role`] in the set.
+	pub fn toggle(&mut self, role: Role) {
+		let role_val = role as usize;
+		let index = role_val / 32;
+		let bit = role_val % 32;
+		if let Some(bits) = self.0.get_mut(index) {
+			*bits ^= 1 << bit;
+		}
+	}
+
+	/// Returns the raw bits representing the set.
+	#[must_use]
+	pub fn bits(&self) -> [i32; 5] {
+		self.0
+	}
+
+	/// Returns an iterator yielding each set [`Role`].
+	#[must_use]
+	pub fn iter(&self) -> RoleSetIter {
+		RoleSetIter { set: *self, index: 0 }
+	}
+}
+
+impl IntoIterator for RoleSet {
+	type IntoIter = RoleSetIter;
+	type Item = Role;
+
+	fn into_iter(self) -> Self::IntoIter {
+		self.iter()
+	}
+}
+
+impl IntoIterator for &RoleSet {
+	type IntoIter = RoleSetIter;
+	type Item = Role;
+
+	fn into_iter(self) -> Self::IntoIter {
+		self.iter()
+	}
+}
+
+impl FromIterator<Role> for RoleSet {
+	fn from_iter<I: IntoIterator<Item = Role>>(iter: I) -> Self {
+		let mut set = Self::empty();
+		for role in iter {
+			set.insert(role);
+		}
+		set
+	}
+}
+
+impl<'a> FromIterator<&'a Role> for RoleSet {
+	fn from_iter<I: IntoIterator<Item = &'a Role>>(iter: I) -> Self {
+		let mut set = Self::empty();
+		for &role in iter {
+			set.insert(role);
+		}
+		set
+	}
+}
+
+impl From<Role> for RoleSet {
+	fn from(value: Role) -> Self {
+		let mut set = Self::empty();
+		set.insert(value);
+		set
+	}
+}
+
+impl std::ops::BitXor for RoleSet {
+	type Output = RoleSet;
+
+	fn bitxor(self, other: Self) -> Self::Output {
+		RoleSet(std::array::from_fn(|i| self.0[i] ^ other.0[i]))
+	}
+}
+
+impl std::ops::BitXorAssign for RoleSet {
+	fn bitxor_assign(&mut self, other: Self) {
+		*self = *self ^ other;
+	}
+}
+
+impl std::ops::BitOr for RoleSet {
+	type Output = RoleSet;
+
+	fn bitor(self, other: Self) -> Self::Output {
+		RoleSet(std::array::from_fn(|i| self.0[i] | other.0[i]))
+	}
+}
+
+impl std::ops::BitOrAssign for RoleSet {
+	fn bitor_assign(&mut self, other: Self) {
+		*self = *self | other;
+	}
+}
+
+impl std::ops::BitAnd for RoleSet {
+	type Output = RoleSet;
+
+	fn bitand(self, other: Self) -> Self::Output {
+		RoleSet(std::array::from_fn(|i| self.0[i] & other.0[i]))
+	}
+}
+
+impl std::ops::BitAndAssign for RoleSet {
+	fn bitand_assign(&mut self, other: Self) {
+		*self = *self & other;
+	}
+}
+
+#[derive(Clone, Debug)]
+pub struct RoleSetIter {
+	set: RoleSet,
+	index: usize,
+}
+
+impl Iterator for RoleSetIter {
+	type Item = Role;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		while self.index < 160 {
+			let current = u32::try_from(self.index).ok()?;
+			self.index += 1;
+			if let Ok(role) = Role::try_from(current) {
+				if self.set.contains(role) {
+					return Some(role);
+				}
+			}
+		}
+		None
+	}
+}
+
+impl<'de> Deserialize<'de> for RoleSet {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		struct RoleSetVisitor;
+
+		impl<'de> Visitor<'de> for RoleSetVisitor {
+			type Value = RoleSet;
+
+			fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+				formatter
+					.write_str("a sequence comprised of five i32 that represents a valid RoleSet")
+			}
+
+			fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+			where
+				D: Deserializer<'de>,
+			{
+				let arr = <[i32; 5] as Deserialize>::deserialize(deserializer)?;
+				Ok(RoleSet(arr))
+			}
+		}
+
+		deserializer.deserialize_newtype_struct("RoleSet", RoleSetVisitor)
+	}
+}
+
+impl Serialize for RoleSet {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		let mut seq = serializer.serialize_seq(Some(5))?;
+		for &bits in &self.0 {
+			seq.serialize_element(&bits)?;
+		}
+		seq.end()
+	}
+}
+
+impl Type for RoleSet {
+	const SIGNATURE: &'static zvariant::Signature = <Vec<i32> as Type>::SIGNATURE;
+}
+
 #[cfg(test)]
 pub mod tests {
 	use super::Role;
@@ -647,5 +895,97 @@ pub mod tests {
 				from_role as u32
 			);
 		}
+	}
+
+	#[test]
+	fn test_role_set_operations() {
+		use super::RoleSet;
+
+		let mut set = RoleSet::empty();
+		assert!(set.is_empty());
+
+		set.insert(Role::Alert);
+		assert!(!set.is_empty());
+		assert!(set.contains(Role::Alert));
+		assert!(!set.contains(Role::Button));
+
+		set.insert(Role::Button);
+		assert!(set.contains(Role::Button));
+
+		set.remove(Role::Alert);
+		assert!(!set.contains(Role::Alert));
+		assert!(set.contains(Role::Button));
+
+		let roles: Vec<Role> = set.iter().collect();
+		assert_eq!(roles, vec![Role::Button]);
+	}
+
+	#[test]
+	fn test_role_set_bitops() {
+		use super::RoleSet;
+
+		let set1 = RoleSet::new([Role::Alert, Role::Button]);
+		let set2 = RoleSet::new([Role::Button, Role::Window]);
+		let result = set1 ^ set2;
+		assert!(result.contains(Role::Alert));
+		assert!(result.contains(Role::Window));
+		assert!(!result.contains(Role::Button));
+
+		let result = set1 & set2;
+		assert!(!result.contains(Role::Alert));
+		assert!(!result.contains(Role::Window));
+		assert!(result.contains(Role::Button));
+
+		let result = set1 | set2;
+		assert!(result.contains(Role::Alert));
+		assert!(result.contains(Role::Window));
+		assert!(result.contains(Role::Button));
+
+		let mut set1_clone = set1;
+		set1_clone ^= set2;
+		assert!(set1_clone.contains(Role::Alert));
+		assert!(set1_clone.contains(Role::Window));
+		assert!(!set1_clone.contains(Role::Button));
+
+		let mut set1_clone = set1;
+		set1_clone &= set2;
+		assert!(!set1_clone.contains(Role::Alert));
+		assert!(!set1_clone.contains(Role::Window));
+		assert!(set1_clone.contains(Role::Button));
+
+		let mut set2_clone = set2;
+		set2_clone |= set1;
+		assert!(set2_clone.contains(Role::Alert));
+		assert!(set2_clone.contains(Role::Window));
+		assert!(set2_clone.contains(Role::Button));
+	}
+
+	#[test]
+	fn test_role_set_serialization_deserialization() {
+		use super::RoleSet;
+		use zvariant::serialized::Data;
+
+		let mut set = RoleSet::empty();
+		set.insert(Role::Alert); // Role::Alert is index 2, bit 2 inside the first i32 element.
+		set.insert(Role::Button); // Role::Button is index 43, bit 11 inside the second i32 element (43 - 32 = 11).
+
+		let ctxt = Context::new_dbus(LE, 0);
+		let encoded = to_bytes(ctxt, &set).unwrap();
+
+		let expected_bytes = &[
+			20, 0, 0, 0, // D-Bus array length header = 20 bytes
+			4, 0, 0, 0, // Index 0: 1 << 2 = 4
+			0, 8, 0, 0, // Index 1: 1 << 11 = 2048 (0x0800 in Little-Endian)
+			0, 0, 0, 0, // Index 2: 0
+			0, 0, 0, 0, // Index 3: 0
+			0, 0, 0, 0, // Index 4: 0
+		];
+		assert_eq!(encoded.bytes(), expected_bytes);
+
+		let data = Data::new::<&[u8]>(expected_bytes, ctxt);
+		let (decoded, _) = data.deserialize::<RoleSet>().unwrap();
+		assert_eq!(decoded, set);
+		assert!(decoded.contains(Role::Alert));
+		assert!(decoded.contains(Role::Button));
 	}
 }

--- a/atspi-common/src/role.rs
+++ b/atspi-common/src/role.rs
@@ -794,21 +794,17 @@ impl std::ops::BitAndAssign for RoleSet {
 #[derive(Clone, Debug)]
 pub struct RoleSetIter {
 	set: RoleSet,
-	index: usize,
+	index: u32,
 }
 
 impl Iterator for RoleSetIter {
 	type Item = Role;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		let bitfield_length = std::mem::size_of_val(&self.set.0) * (u8::BITS as usize);
-		while self.index < bitfield_length {
-			let current = u32::try_from(self.index).ok()?;
+		while let Ok(role) = Role::try_from(self.index) {
 			self.index += 1;
-			if let Ok(role) = Role::try_from(current) {
-				if self.set.contains(role) {
-					return Some(role);
-				}
+			if self.set.contains(role) {
+				return Some(role);
 			}
 		}
 		None

--- a/atspi-common/src/state.rs
+++ b/atspi-common/src/state.rs
@@ -475,15 +475,10 @@ impl<'de> Deserialize<'de> for StateSet {
 			where
 				D: Deserializer<'de>,
 			{
-				match <Vec<u32> as Deserialize>::deserialize(deserializer) {
-					Ok(states) if states.len() == 2 => {
-						let mut bits = u64::from(states[0]);
-						bits |= (u64::from(states[1])) << 32;
-						StateSet::from_bits(bits).map_err(|_| de::Error::custom("invalid state"))
-					}
-					Ok(states) => Err(de::Error::invalid_length(states.len(), &"array of size 2")),
-					Err(e) => Err(e),
-				}
+				let arr = <[u32; 2] as Deserialize>::deserialize(deserializer)?;
+				let mut bits = u64::from(arr[0]);
+				bits |= (u64::from(arr[1])) << 32;
+				StateSet::from_bits(bits).map_err(|_| de::Error::custom("invalid state"))
 			}
 		}
 


### PR DESCRIPTION
Introduces `RoleSet` with all required mechanics.
It appears we cannot use `bitflags` on `RoleSet` because bitflags does not support an array as backing data.

`Serialize`, `Deserialize`, bitops, `IntoIterator`, `From<Role>` and tests.

Adjusted `ObjectMatchRule` and `MatchType` accordingly and/or to document the limitations found with `MatchType` in upstream atk-adaptor.


Addresses: issue #357