### PR TITLE
Use workspace semver check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,12 +219,11 @@ jobs:
         with:
           toolchain: stable
       - name: Install Semver Checks
-        # no default features so that it uses native Rust TLS instead of trying to link with system TLS.
         uses: taiki-e/install-action@main
         with:
           tool: cargo-semver-checks
       - name: Check Semver Compliance
-        run: cargo semver-checks check-release -p atspi --default-features
+        run: cargo semver-checks check-release --workspace --all-features
   msrv-compliance:
     runs-on: ubuntu-latest
     needs: [clippy, no-unused-dependencies, find-msrv]


### PR DESCRIPTION
Previously, we were only testing the `atspi` crate itself for its public API.
Since much of the code lives in subcrates, recent bump requirements were completely missed—see #363, #356—and would continue to.

This instead checks semver for all crates in the workspace via the `--workspace` flag, and removes the comment about system TLS because it only used to be an option, but is no longer.

NOTE: I am expecting this to fail the semver check, as the already-merged PRs break `atspi-common`'s contract on crates.io.