### PR TITLE
Release 0.31.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atspi"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "atspi",
  "atspi-common",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "atspi-common"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "assert_matches",
  "atspi-connection",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "atspi-connection"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "atspi-common",
  "atspi-proxies",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "atspi-proxies"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "atspi-common",
  "atspi-connection",

--- a/atspi-common/Cargo.toml
+++ b/atspi-common/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "atspi-common"
 readme                 = "README.md"
 repository             = "https://github.com/odilia-app/atspi"
 rust-version.workspace = true
-version                = "0.14.0"
+version                = "0.15.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/atspi-connection/Cargo.toml
+++ b/atspi-connection/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "atspi-connection"
 readme                 = "README.md"
 repository             = "https://github.com/odilia-app/atspi/"
 rust-version.workspace = true
-version                = "0.14.0"
+version                = "0.15.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -20,8 +20,8 @@ tracing  = ["dep:tracing"]
 wrappers = ["atspi-common/wrappers", "dep:futures-lite"]
 
 [dependencies]
-atspi-common   = { path = "../atspi-common/", version = "0.14.0", default-features = false, features = ["zbus"] }
-atspi-proxies  = { path = "../atspi-proxies/", version = "0.14.0" }
+atspi-common   = { path = "../atspi-common/", version = "0.15.0", default-features = false, features = ["zbus"] }
+atspi-proxies  = { path = "../atspi-proxies/", version = "0.15.0" }
 futures-lite   = { version = "2.6.0", default-features = false, optional = true }
 tracing        = { optional = true, workspace = true }
 zbus.workspace = true

--- a/atspi-proxies/Cargo.toml
+++ b/atspi-proxies/Cargo.toml
@@ -10,7 +10,7 @@ name                   = "atspi-proxies"
 readme                 = "README.md"
 repository             = "https://github.com/odilia-app/atspi"
 rust-version.workspace = true
-version                = "0.14.0"
+version                = "0.15.0"
 
 [package.metadata.release]
 publish = true
@@ -22,13 +22,13 @@ x11-legacy = []
 wrappers = []
 
 [dependencies]
-atspi-common = { path = "../atspi-common", version = "0.14.0" }
+atspi-common = { path = "../atspi-common", version = "0.15.0" }
 serde        = { version = "^1.0.200", default-features = false, features = ["derive"] }
 zbus         = { workspace = true }
 
 [dev-dependencies]
-atspi-common     = { path = "../atspi-common", version = "0.14.0" }
-atspi-connection = { path = "../atspi-connection", version = "0.14.0" }
+atspi-common     = { path = "../atspi-common", version = "0.15.0" }
+atspi-connection = { path = "../atspi-connection", version = "0.15.0" }
 byteorder        = "1.4"
 futures-lite     = { version = "2.6.0", default-features = false }
 rename-item      = "0.1.0"

--- a/atspi/Cargo.toml
+++ b/atspi/Cargo.toml
@@ -11,7 +11,7 @@ name                   = "atspi"
 readme                 = "../README.md"
 repository             = "https://github.com/odilia-app/atspi"
 rust-version.workspace = true
-version                = "0.30.0"
+version                = "0.31.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -26,9 +26,9 @@ tracing    = ["atspi-connection/tracing"]
 x11-legacy = ["atspi-proxies/x11-legacy"]
 
 [dependencies]
-atspi-common     = { path = "../atspi-common", version = "0.14.0", default-features = false }
-atspi-connection = { path = "../atspi-connection", version = "0.14.0", optional = true }
-atspi-proxies    = { path = "../atspi-proxies", version = "0.14.0", optional = true }
+atspi-common     = { path = "../atspi-common", version = "0.15.0", default-features = false }
+atspi-connection = { path = "../atspi-connection", version = "0.15.0", optional = true }
+atspi-proxies    = { path = "../atspi-proxies", version = "0.15.0", optional = true }
 zbus             = { workspace = true, optional = true }
 
 [[bench]]


### PR DESCRIPTION
Bump versions to match breaking changes.

- #365 found that `atpsi-common` had broken semver and needed a bump.
- This PR does the bump, including bumping subcrates to match atspi.
