### PR TITLE
Add codecov gates to stop minor PRs from tripping

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,11 +2,11 @@ coverage:
   status:
     project:
       default:
-		# auto will use main unless it's a branch of a branch
+        # auto will use main unless it's a branch of a branch
         target: auto
-		# fail only above 1% decrease
+        # fail only above 1% decrease
         threshold: 1%
-		# don't worry if there isn't a comparable report
+        # don't worry if there isn't a comparable report
         if_not_found: success
-		# show new code line differential on PR, don't fail
+        # show new code line differential on PR, don't fail
         informational: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+		# auto will use main unless it's a branch of a branch
+        target: auto
+		# fail only above 1% decrease
+        threshold: 1%
+		# don't worry if there isn't a comparable report
+        if_not_found: success
+		# show new code line differential on PR, don't fail
+        informational: true


### PR DESCRIPTION
- Stops new line coverage diffs from failing the job.
- Sets basic floor for failure: a decrease of >1%

Luuk mentioned that this has beccome an annoyance, and so we more or less ignore it now.
This should at least keep the liitle/minor changes from tripping the job constantly, and focus on the big stuff.
