### PR TITLE
ci: Integrate P2P test application

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,15 +266,18 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: main
+
       - name: Git checkout test project
         uses: actions/checkout@v6
         with:
           repository: luukvanderduim/test-atspi-p2p
           path: test-atspi-p2p
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
+
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
@@ -282,6 +285,7 @@ jobs:
           workspaces: |
             main
             test-atspi-p2p
+
       - name: Install System Dependencies
         run: |
           sudo apt-get -y update
@@ -292,13 +296,14 @@ jobs:
             gedit \
             metacity \
             caja
+
       - name: Setup virtual display and AT-SPI environment
         run: |
           # Start virtual display and wait until it's ready (max 10s)
-          Xvfb :99 -screen 0 1024x768x24 -nolisten tcp &
+          Xvfb :99 -screen 0 1024x768x24 &
           for i in $(seq 1 10); do
             xdpyinfo -display :99 >/dev/null 2>&1 && break
-            sleep 0.1
+            sleep 1
           done
           # Ensure Xvfb is truly stable for subsequent GUI apps
           sleep 0.5
@@ -325,23 +330,33 @@ jobs:
             fi
             sleep 0.1
           done
+          # Ensure AT-SPI bus is truly stable
+          sleep 0.1
+
+          # Explicitly enable accessibility
+          gsettings set org.gnome.desktop.interface toolkit-accessibility true
 
           # Export environment for subsequent steps
           echo "DISPLAY=:99" >> $GITHUB_ENV
           echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> $GITHUB_ENV
+          echo "GTK_MODULES=gail:atk-bridge" >> $GITHUB_ENV
+
       - name: Add local crates to P2P test project
         working-directory: ./test-atspi-p2p
         run: |
           cargo add --path ../main/atspi-connection
           cargo add --path ../main/atspi-common
           cargo add --path ../main/atspi-proxies
+
       - name: Build P2P test project
         working-directory: ./test-atspi-p2p
         run: cargo build
+
       - name: Run P2P test with GUI applications
         working-directory: ./test-atspi-p2p
         run: |
-          RUST_LOG=debug cargo run
+          # Run with either Gnome Calculator or Gedit, depending on which one works
+          GTK_MODULES=gail:atk-bridge RUST_LOG=debug cargo run -- gedit --sleep 1
         env:
           DISPLAY: ${{ env.DISPLAY }}
           DBUS_SESSION_BUS_ADDRESS: ${{ env.DBUS_SESSION_BUS_ADDRESS }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,7 +306,7 @@ jobs:
             sleep 1
           done
           # Ensure Xvfb is truly stable for subsequent GUI apps
-          sleep 0.5
+          sleep 1
 
           # Set the display for this step
           export DISPLAY=:99
@@ -316,11 +316,11 @@ jobs:
 
           # Start a minimal window manager
           metacity &
-          sleep 0.5
+          sleep 1
 
           # Start a desktop shell to provide the root desktop object
           caja &
-          sleep 0.5
+          sleep 1
 
           # Start AT-SPI bus and registry the standard way, then wait for it (max 15s)
           /usr/libexec/at-spi-bus-launcher --launch-immediately &
@@ -328,10 +328,10 @@ jobs:
             if dbus-send --session --dest=org.a11y.Bus --print-reply /org/a11y/bus org.a11y.Bus.GetAddress >/dev/null 2>&1; then
               break
             fi
-            sleep 0.1
+            sleep 1
           done
           # Ensure AT-SPI bus is truly stable
-          sleep 0.1
+          sleep 1
 
           # Explicitly enable accessibility
           gsettings set org.gnome.desktop.interface toolkit-accessibility true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,28 +264,14 @@ jobs:
     steps:
       - name: Git checkout main project
         uses: actions/checkout@v6
-        with:
-          path: main
-
-      - name: Git checkout test project
-        uses: actions/checkout@v6
-        with:
-          repository: luukvanderduim/test-atspi-p2p
-          path: test-atspi-p2p
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
           shared-key: "atspi-shared-cache"
-          workspaces: |
-            main
-            test-atspi-p2p
-
       - name: Install System Dependencies
         run: |
           sudo apt-get -y update
@@ -296,17 +282,14 @@ jobs:
             gedit \
             metacity \
             caja
-
       - name: Setup virtual display and AT-SPI environment
         run: |
           # Start virtual display and wait until it's ready (max 10s)
-          Xvfb :99 -screen 0 1024x768x24 &
+          Xvfb :99 -screen 0 1024x768x24 -nolisten tcp &
           for i in $(seq 1 10); do
             xdpyinfo -display :99 >/dev/null 2>&1 && break
-            sleep 1
+            sleep 0.1
           done
-          # Ensure Xvfb is truly stable for subsequent GUI apps
-          sleep 1
 
           # Set the display for this step
           export DISPLAY=:99
@@ -316,11 +299,11 @@ jobs:
 
           # Start a minimal window manager
           metacity &
-          sleep 1
+          sleep 0.5
 
           # Start a desktop shell to provide the root desktop object
           caja &
-          sleep 1
+          sleep 0.5
 
           # Start AT-SPI bus and registry the standard way, then wait for it (max 15s)
           /usr/libexec/at-spi-bus-launcher --launch-immediately &
@@ -328,35 +311,18 @@ jobs:
             if dbus-send --session --dest=org.a11y.Bus --print-reply /org/a11y/bus org.a11y.Bus.GetAddress >/dev/null 2>&1; then
               break
             fi
-            sleep 1
+            sleep 0.1
           done
-          # Ensure AT-SPI bus is truly stable
-          sleep 1
-
-          # Explicitly enable accessibility
-          gsettings set org.gnome.desktop.interface toolkit-accessibility true
 
           # Export environment for subsequent steps
           echo "DISPLAY=:99" >> $GITHUB_ENV
           echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> $GITHUB_ENV
-          echo "GTK_MODULES=gail:atk-bridge" >> $GITHUB_ENV
-
-      - name: Add local crates to P2P test project
-        working-directory: ./test-atspi-p2p
-        run: |
-          cargo add --path ../main/atspi-connection
-          cargo add --path ../main/atspi-common
-          cargo add --path ../main/atspi-proxies
-
       - name: Build P2P test project
-        working-directory: ./test-atspi-p2p
-        run: cargo build
-
+        run: cargo build -p atspi-test-p2p
       - name: Run P2P test with GUI applications
-        working-directory: ./test-atspi-p2p
         run: |
           # Run with either Gnome Calculator or Gedit, depending on which one works
-          GTK_MODULES=gail:atk-bridge RUST_LOG=debug cargo run -- gedit --sleep 1
+          RUST_LOG=debug cargo run -p atspi-test-p2p
         env:
           DISPLAY: ${{ env.DISPLAY }}
           DBUS_SESSION_BUS_ADDRESS: ${{ env.DBUS_SESSION_BUS_ADDRESS }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atspi-test-p2p"
+version = "0.2.0"
+dependencies = [
+ "atspi",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +797,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +866,15 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1210,6 +1235,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,6 +1257,12 @@ name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smol-macros"
@@ -1275,6 +1315,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1401,6 +1450,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1419,6 +1494,12 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members  = ["atspi", "atspi-common", "atspi-connection", "atspi-proxies"]
+members  = ["atspi", "atspi-common", "atspi-connection", "atspi-proxies",  "e2e/atspi-test-p2p"]
 resolver = "2"
 
 

--- a/e2e/atspi-test-p2p/Cargo.toml
+++ b/e2e/atspi-test-p2p/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "atspi-test-p2p"
+authors = ["Luuk van der Duim"]
+version = "0.2.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+atspi = { path = "../../atspi", features = ["tracing", "p2p", "tokio", "zbus"] }
+tokio = { version = "1.38.2", features = ["macros", "rt-multi-thread", "time"] }
+tracing = { workspace = true, features = ["std"] }
+tracing-subscriber = "0.3"

--- a/e2e/atspi-test-p2p/README.md
+++ b/e2e/atspi-test-p2p/README.md
@@ -1,0 +1,54 @@
+# test-atspi-p2p
+
+The P2P feature of [`atspi`](<http://github.com/odilia-app/atspi.git>) spawns a task that listens for [`NameOwnerChanged`](<https://dbus.freedesktop.org/doc/dbus-specification.html#bus-messages-name-owner-changed>) events.
+
+If feature 'p2p' is selected, this `DBus` signal is used to update the `Peers` list on the `AccessibilityConnection`.
+This list of available P2P-capable, accessible applications is kept to provide users a P2P connection / proxy of the  
+application when they need it.
+
+## What it does
+
+1. Subscribes to tracing messages
+2. Shows the applications in the `Peers` list
+3. Launches a P2P capable application and verifies its appearance in the `Peers` list,
+   indicating the `NamoOwnerChanged` signal was received and handled as intended.
+4. Terminates the application and verifies its removal from the `Peers` list,
+   indicating the `NamoOwnerChanged` signal was received and handled as intended.
+
+## Limitations
+
+Currently it does not verify the entry of a `WellKnownName` or the transfer of ownership of a `WellKnownName`.
+
+To verify this behavior, we need an example of such an application.
+Suggestions are welcome.
+
+## Example output
+
+```shell
+/test-atspi-p2p (main)> cargo run
+    Finished `dev` profile [unoptimized] target(s) in 0.03s
+     Running `target/debug/test-atspi-p2p`
+2025-07-18T15:10:45.534154Z  INFO main ThreadId(01) CI(p2p): Set session accessibility to true
+2025-07-18T15:10:45.538490Z  INFO main ThreadId(01) CI(p2p): Create accessibility connection
+2025-07-18T15:10:45.540512Z  INFO main ThreadId(01) new: Connecting to a11y bus
+2025-07-18T15:10:45.541409Z  INFO main ThreadId(01) new: Connected to a11y bus name=":1.39"
+2025-07-18T15:10:45.568757Z  INFO main ThreadId(01) CI(p2p): Launching child process "mate-calc"
+2025-07-18T15:10:45.688332Z  INFO tokio-runtime-worker ThreadId(19) Inserted unique name: :1.40 into the peer list.
+2025-07-18T15:10:46.606777Z  INFO                 main ThreadId(01) CI(p2p): Printing peers...
+Peer: ... (total: 24)
+Peer: ":1.29", human readable name: "code-insiders"
+Peer: ":1.32", human readable name: "element-desktop"
+Peer: ":1.40", human readable name: "mate-calc"
+
+2025-07-18T15:10:46.606816Z  INFO                 main ThreadId(01) CI(p2p): ✅ Peer insertion assertion passed
+2025-07-18T15:10:47.608781Z  INFO                 main ThreadId(01) CI(p2p): Terminating "mate-calc"
+2025-07-18T15:10:47.613761Z  INFO tokio-runtime-worker ThreadId(19) Peer with unique name: :1.40 left the bus - removed from peer list.
+2025-07-18T15:10:48.627097Z  INFO                 main ThreadId(01) CI(p2p): Printing peers...
+Peer: ... (total: 23)
+Peer: ":1.28", human readable name: "Firefox"
+Peer: ":1.29", human readable name: "code-insiders"
+Peer: ":1.32", human readable name: "element-desktop"
+
+2025-07-18T15:10:48.627137Z  INFO                 main ThreadId(01) CI(p2p): ✅ Peer removal assertion passed
+2025-07-18T15:10:48.627141Z  INFO                 main ThreadId(01) CI(p2p): ✅ All assertions passed, exiting
+```

--- a/e2e/atspi-test-p2p/src/main.rs
+++ b/e2e/atspi-test-p2p/src/main.rs
@@ -1,0 +1,208 @@
+use atspi::{
+	connection::{AccessibilityConnection, Peer, P2P},
+	proxy::accessible::ObjectRefExt,
+	zbus::names::OwnedBusName,
+};
+use std::{
+	sync::{Arc, Mutex},
+	time::Duration,
+};
+use tracing::{info, warn};
+use tracing_subscriber::fmt;
+
+const CHILD_NAME: &str = "gedit";
+const VERBOSITY: bool = false;
+const SLEEP_DURATION: Duration = Duration::from_millis(250); // 0.25s
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+	// Configure a custom tracing event formatter
+	let format = fmt::format()
+		.with_level(true) // level: severity level (error, warn, info)
+		.with_target(false) // target: originating process::path
+		.with_thread_ids(true)
+		.with_thread_names(true)
+		.compact();
+
+	// Create a `fmt` subscriber that uses our custom event format, and set it as the default.
+	tracing_subscriber::fmt().event_format(format).init();
+
+	info!("CI(p2p): Set session accessibility to true");
+	atspi::connection::set_session_accessibility(true)
+		.await
+		.expect("Failed to set session accessibility");
+
+	info!("CI(p2p): Create accessibility connection");
+	let a11y = AccessibilityConnection::new()
+		.await
+		.expect("Failed to create accessibility connection");
+
+	let peers = a11y.peers();
+
+	info!("CI(p2p): Launching child process \"{CHILD_NAME}\"");
+	let mut child_process = launch_child(CHILD_NAME, None, VERBOSITY);
+
+	// Poll the registry repeatedly to give the app ample time to register (up to 10 seconds)
+	info!("CI(p2p): Waiting for \"{CHILD_NAME}\" to register...");
+	let mut mapping = Vec::new();
+	for _ in 0..40 {
+		tokio::time::sleep(SLEEP_DURATION).await;
+		mapping = bus_names_to_human_readable(&a11y).await;
+		if mapping.iter().any(|(_bus_name, human_readable_name)| {
+			human_readable_name.to_lowercase().contains(CHILD_NAME)
+		}) {
+			break;
+		}
+	}
+
+	print_peers(peers.clone(), &mapping).await;
+
+	// Assert that the second app is part of the mapping
+	assert!(
+		mapping
+			.iter()
+			.any(|(_bus_name, human_readable_name)| human_readable_name
+				.to_lowercase()
+				.contains(CHILD_NAME)),
+		"App \"{CHILD_NAME}\" not registered as P2P application in Peers list."
+	);
+
+	info!("CI(p2p): ✅ Peer insertion assertion passed");
+	tokio::time::sleep(SLEEP_DURATION).await;
+	info!("CI(p2p): Terminating \"{CHILD_NAME}\"");
+
+	// Termination and removal of child
+	child_process.kill().expect("Failed to kill child process");
+	child_process.wait().expect("Failed to wait on process");
+
+	// Poll the registry repeatedly to give the app time to be removed (up to 10 seconds)
+	info!("CI(p2p): Waiting for \"{CHILD_NAME}\" to de-register...");
+	for _ in 0..40 {
+		tokio::time::sleep(SLEEP_DURATION).await;
+		mapping = bus_names_to_human_readable(&a11y).await;
+		if !mapping.iter().any(|(_bus_name, human_readable_name)| {
+			human_readable_name.to_lowercase().contains(CHILD_NAME)
+		}) {
+			break;
+		}
+	}
+
+	print_peers(peers, &mapping).await;
+
+	// Assert that the app is no longer part of the mapping
+	assert!(
+		mapping
+			.iter()
+			.find(|(_bus_name, human_readable_name)| human_readable_name
+				.to_lowercase()
+				.contains(CHILD_NAME))
+			.is_none(),
+		"App \"{CHILD_NAME}\" not removed as P2P application from Peers list."
+	);
+
+	info!("CI(p2p): ✅ Peer removal assertion passed");
+	info!("CI(p2p): ✅ All assertions passed, exiting");
+	Ok(())
+}
+
+async fn print_peers(peers: Arc<Mutex<Vec<Peer>>>, mapping: &[(OwnedBusName, String)]) {
+	info!("CI(p2p): Printing peers...");
+
+	let peers_locked = match peers.lock() {
+		Ok(peers_locked) => peers_locked,
+		Err(e) => {
+			warn!("Failed to lock peers: {}", e);
+			return;
+		}
+	};
+	let total_peers = peers_locked.len();
+
+	// The take iterator adaptor will take max. N elements from left to right, so we reverse the iterator first
+	let last_peers: Vec<&Peer> = peers_locked.iter().rev().take(3).collect();
+
+	// If there are more than 3 peers, indicate there are more
+	if total_peers > 3 {
+		println!("Peer: ... (total: {total_peers})");
+	}
+
+	// Print in reverse to restore chronological order
+	for peer in last_peers.iter().rev() {
+		let unique_name = peer.unique_name();
+
+		// Look up the human-readable name from the mapping
+		// Mapping may be longer than `last_peers`
+		let human_readable = mapping
+			.iter()
+			.find_map(|(bus_name, name)| {
+				if bus_name.as_str() == unique_name.as_str() {
+					Some(name.clone())
+				} else {
+					None
+				}
+			})
+			.unwrap_or_else(|| "not found".to_string());
+
+		println!("Peer: \"{unique_name}\", human readable name: \"{human_readable}\"");
+	}
+
+	if total_peers == 0 {
+		info!("CI(p2p): No peers found");
+	} else {
+		println!();
+	}
+}
+
+// Gets the accessible apps in registry, returns a mapping of bus names to human readable names
+async fn bus_names_to_human_readable(
+	a11y: &AccessibilityConnection,
+) -> Vec<(OwnedBusName, String)> {
+	let conn = a11y.connection();
+
+	let registry_accessible = a11y
+		.root_accessible_on_registry()
+		.await
+		.expect("Failed to get root accessible on registry");
+
+	let children = registry_accessible
+		.get_children()
+		.await
+		.expect("Failed to get children of root accessible");
+
+	// Create a mapping of bus_names to human readable names
+	let mut bus_name_to_human_readable: Vec<(OwnedBusName, String)> =
+		Vec::with_capacity(children.len());
+
+	for child in children {
+		let ap = child
+			.as_accessible_proxy(conn)
+			.await
+			.expect("Failed to get accessible proxy");
+
+		let natural_name = ap.name().await.expect("Failed to get name");
+		let bus_name: OwnedBusName = ap.inner().destination().to_owned().into();
+		bus_name_to_human_readable.push((bus_name, natural_name));
+	}
+
+	bus_name_to_human_readable
+}
+
+fn launch_child(child_name: &str, child_arg: Option<&str>, verbose: bool) -> std::process::Child {
+	let mut command = std::process::Command::new(child_name);
+	if let Some(arg) = child_arg {
+		command.arg(arg);
+	}
+
+	// With inherit() - child output mixes with parent output
+	// With null() - only parent output appears, child is silenced.
+	if verbose {
+		command
+			.stdout(std::process::Stdio::inherit())
+			.stderr(std::process::Stdio::inherit());
+	} else {
+		command
+			.stdout(std::process::Stdio::null())
+			.stderr(std::process::Stdio::null());
+	}
+
+	command.spawn().expect("Failed to launch child process")
+}


### PR DESCRIPTION
Move `atspi-test-p2p` from Luuk's GitHub to the atspi workspace for maintainability.
Storing the test-application out of tree kept it out of maintenance.

- Modify the test application to depend on the local `atspi` tree.
- Adjust the test application to sleep less.
- No longer accept command line arguments and drop `argh` dependency.
- Rewrite the `README.md`
- Add the crate to the `atspi` workspace in a new `e2e` folder for end-to-end tests.

Adjust `ci.yml` accordingly.

Tested locally with 'act' local ci runner.
Reduced run-time of `test-atspi-p2p` to 35-39 seconds.