### PR TITLE
Make zbus-lockstep a dev dependency

### DIFF
--- a/atspi-common/Cargo.toml
+++ b/atspi-common/Cargo.toml
@@ -23,8 +23,6 @@ enumflags2           = "0.7.9"
 serde                = "1.0.200"
 static_assertions    = "1.1.0"
 zbus                 = { workspace = true, optional = true }
-zbus-lockstep        = { version = "0.5.2" }
-zbus-lockstep-macros = { version = "0.5.2" }
 zbus_names           = "4.1.1"
 zvariant             = { version = "5.2", default-features = false }
 
@@ -42,3 +40,5 @@ tokio-stream   = { version = "0.1.1", default-features = false, features = ["tim
 tokio-test        = "0.4.2"
 zbus_xml          = "5.0.2"
 zbus              = { workspace = true }
+zbus-lockstep        = "0.5.2"
+zbus-lockstep-macros = "0.5.2"

--- a/atspi-common/src/cache.rs
+++ b/atspi-common/src/cache.rs
@@ -3,13 +3,12 @@
 
 use crate::{object_ref::ObjectRefOwned, InterfaceSet, ObjectRef, Role, StateSet};
 use serde::{Deserialize, Serialize};
-use zbus_lockstep_macros::validate;
 use zvariant::Type;
 
 /// The item type provided by `Cache:Add` signals
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Debug, Serialize, Deserialize, Type, PartialEq, Eq, Hash)]
-#[validate(signal: "AddAccessible")]
+#[cfg_attr(test, zbus_lockstep_macros::validate(signal: "AddAccessible"))]
 pub struct CacheItem {
 	/// The accessible object (within the application)   (so)
 	pub object: ObjectRefOwned,

--- a/atspi-common/src/events/event_body.rs
+++ b/atspi-common/src/events/event_body.rs
@@ -3,7 +3,6 @@ use serde::{
 	ser::{SerializeMap, SerializeTuple},
 	Deserialize, Serialize,
 };
-use zbus_lockstep_macros::validate;
 use zvariant::{ObjectPath, OwnedValue, Type, Value};
 
 /// Event body as used exclusively by 'Qt' toolkit.
@@ -119,7 +118,7 @@ impl Serialize for Properties {
 /// own type: [`EventBodyQtOwned`].
 ///
 /// Signature `(siiva{sv})`,
-#[validate(signal: "PropertyChange")]
+#[cfg_attr(test, zbus_lockstep_macros::validate(signal: "PropertyChange"))]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Type)]
 pub struct EventBodyOwned {
 	/// kind variant, used for specifying an event triple "object:state-changed:focused",

--- a/atspi-common/src/events/registry.rs
+++ b/atspi-common/src/events/registry.rs
@@ -8,7 +8,6 @@ use crate::{error::AtspiError, events::MessageConversion, EventProperties};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "zbus")]
 use zbus::message::{Body as DbusBody, Header};
-use zbus_lockstep_macros::validate;
 use zbus_names::{OwnedUniqueName, UniqueName};
 use zvariant::Type;
 
@@ -120,7 +119,7 @@ impl_member_interface_registry_string_and_match_rule_for_event!(
 
 /// Signal type emitted by `EventListenerRegistered` and `EventListenerDeregistered` signals,
 /// which belong to the `Registry` interface, implemented by the registry-daemon.
-#[validate(signal: "EventListenerRegistered")]
+#[cfg_attr(test, zbus_lockstep_macros::validate(signal: "EventListenerRegistered"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq, Hash)]
 pub struct EventListeners {
 	pub bus_name: OwnedUniqueName,

--- a/atspi-common/src/object_ref.rs
+++ b/atspi-common/src/object_ref.rs
@@ -1,7 +1,6 @@
 use crate::AtspiError;
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
-use zbus_lockstep_macros::validate;
 use zbus_names::{BusName, UniqueName};
 use zvariant::{ObjectPath, Structure, Type};
 
@@ -25,7 +24,7 @@ pub(crate) const TEST_DEFAULT_OBJECT_REF: ObjectRef<'static> =
 /// using an application's bus name and object path. "(so)"
 ///
 /// Emitted by `RemoveAccessible` and `Available`
-#[validate(signal: "Available")]
+#[cfg_attr(test, zbus_lockstep_macros::validate(signal: "Available"))]
 #[derive(Clone, Debug, Eq, Type)]
 #[zvariant(signature = "(so)")]
 pub enum ObjectRef<'o> {
@@ -263,7 +262,7 @@ impl Default for ObjectRef<'_> {
 
 /// A wrapper around the static variant of `ObjectRef`.
 /// This is guaranteed to have a `'static` lifetime.
-#[validate(signal: "Available")]
+#[cfg_attr(test, zbus_lockstep_macros::validate(signal: "Available"))]
 #[derive(Clone, Debug, Default, Eq, Type)]
 pub struct ObjectRefOwned(pub(crate) ObjectRef<'static>);
 


### PR DESCRIPTION
I try to be mindful of the number of dependencies and the time it take to compile accesskit_unix. zbus-lockstep is two crates, one procedural macro. That procedural macro even reaches for external files which can be considered an abuse of procedural macros.

This pull request allows downstream users such as AccessKit to disable this dependency, while keeping it enabled by default.