### PR TITLE
Bump the minimum supported Rust version to 1.87.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = [
   "Tait Hoyem <tait@tait.tech>",
 ]
 description = "AT-SPI2 protocol implementation in Rust"
-rust-version = "1.77.2"
+rust-version = "1.87.0"
 
 [workspace.dependencies]
 enumflags2 = "0.7.9"


### PR DESCRIPTION
This is needed to update zbus_xml. This apparently unblocks an update to criterion, which can come in a follow-up pull request.