### PR TITLE
feat(conn)!: discover P2P peers lazily

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "atspi-common",
  "atspi-proxies",
  "enumflags2",
+ "event-listener",
  "futures-lite",
  "tokio-test",
  "tracing",

--- a/atspi-connection/Cargo.toml
+++ b/atspi-connection/Cargo.toml
@@ -15,13 +15,14 @@ version                = "0.15.0"
 
 [features]
 default  = ["p2p", "wrappers"]
-p2p      = ["dep:futures-lite", "zbus/p2p"]
+p2p      = ["dep:event-listener", "dep:futures-lite", "zbus/p2p"]
 tracing  = ["dep:tracing"]
 wrappers = ["atspi-common/wrappers", "dep:futures-lite"]
 
 [dependencies]
 atspi-common   = { path = "../atspi-common/", version = "0.15.0", default-features = false, features = ["zbus"] }
 atspi-proxies  = { path = "../atspi-proxies/", version = "0.15.0" }
+event-listener = { version = "5.4.1", optional = true }
 futures-lite   = { version = "2.6.0", default-features = false, optional = true }
 tracing        = { optional = true, workspace = true }
 zbus.workspace = true

--- a/atspi-connection/README.md
+++ b/atspi-connection/README.md
@@ -11,7 +11,7 @@ See the examples folder and documentation on how to use this library.
 ## Feature Flags
 
 * `default`: `wrappers`, `p2p`
-* `p2p`: dependencies `async-executor" and enables`zbus/p2p`
+* `p2p`: enables lazy peer discovery and `zbus/p2p`
 * `tracing`: enable support for the `tracing` crate
 * `wrappers`: enable support for `atspi-common` wrapper types that categorize events by interface, as well as the all-encompassing `Event` enum that can store any event type.
   * This also enables the `event_stream` function that allows you to receive a stream of `Event`s instead of specific events.

--- a/atspi-connection/p2p.md
+++ b/atspi-connection/p2p.md
@@ -8,8 +8,7 @@ The `Application` interface offers `GetApplicationBusAddress` which returns a bu
 
 ## `AccessibilityConnection`
 
-To avoid querying each object whether their bus name supports P2P, `AccessibilityConnection` keeps a list of all accessible applications on the bus that support P2P and continuously updates it.
-`AccessibilityConnection` is always in scope when performing operations on the accessibility bus, therefore it is the perfect place to keep the list of peers.
+`AccessibilityConnection` discovers an application's direct address only when a P2P-aware lookup first targets that application. Ready connections are reused, concurrent lookups for the same unique owner share one attempt, and normal P2P unavailability transparently falls back to the connection's long-lived accessibility bus.
 
 In practice, if you want to perform a method call on an `ObjectRef`, just get the `AccessibleProxy` for that object with `object_as_accessible`:
 
@@ -22,14 +21,13 @@ let name = obj_ap.name().await?;
 
 For `atspi` users who do not perform method calls or query properties, P2P is gated behind the "p2p" feature. Those users will need to opt out of default features.
 
-The feature "p2p" is enabled by default and if enabled, the `AccessibilityConnection` gains a list of applications that support P2P communication on initialization.
-Initialization of an `AccessibilityConnection` will also spawn a task to continuously listen for new applications entering or leaving the bus. It does so by listening for the `NameOwnerChanged` event emitted by the D-Bus daemon.
+The feature "p2p" is enabled by default. Initialization does not enumerate applications, request direct addresses, or open direct connections. It only starts a `NameOwnerChanged` listener used to invalidate cached identities; ownership signals never trigger discovery themselves.
 
-If users opt out, no list of `Peer`s will be kept and atspi will not listen for updates.
+If users opt out, no peer discovery state is kept and atspi does not start this listener.
 
 ## traits `P2P` and `Peer`
 
-As stated before, a list of `Peer`s is kept by the `AccessibilityConnection`.
+Ready peers are kept privately by `AccessibilityConnection`.
 
 The `Peer` struct can be considered a handle to individual peers that do support P2P and allows:
 
@@ -39,9 +37,52 @@ The `Peer` struct can be considered a handle to individual peers that do support
 
 The P2P trait offers the higher level API and is implemented for `AccessibilityConnection` and allows:
 
-- getting a peer by bus name
+- asynchronously discovering or getting a peer by bus name
+- taking a detached, unique-name-sorted snapshot of currently ready peers
 - getting an `AccessibleProxy` for the root object by bus name - may or may not support P2P
 - getting an `AccessibleProxy` for any `ObjectRef` - may or may not support P2P
+
+`get_peer` returns `Ok(Some(peer))` when a direct connection is ready. `Ok(None)` means the application definitively does not support P2P, a capability probe or connection attempt failed transiently, a transient failure is still in backoff, or ownership changed during discovery. Name-resolution and other failures that prevent correct shared-bus routing remain errors. Errors returned by `GetApplicationBusAddress` itself are optional-P2P failures and do not prevent shared-bus fallback.
+
+Ready transport is canonical by unique owner and never stores a discovery-order alias. For compatibility, `Peer::well_known_name()` describes the current lookup: unique-name lookups and `peers()` snapshots return `None`, while a well-known lookup returns the alias requested by that call. Two aliases for one owner therefore share one connection while each lookup reports its own alias.
+
+Invalid addresses and direct connection failures use per-owner retry delays of 1, 2, 4, 8, and 16 seconds, then 30 seconds. Unsupported applications remain cached until their owner changes. Negative state is bounded, so eviction can cause a later lookup to retry but never changes fallback correctness.
+
+```rust,no_run
+use atspi_connection::{AccessibilityConnection, P2P};
+use zbus::names::BusName;
+
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+let connection = AccessibilityConnection::new().await?;
+let name = BusName::try_from(":1.42")?;
+
+if let Some(peer) = connection.get_peer(&name).await? {
+    println!("direct peer: {}", peer.unique_name());
+}
+
+// This is an owned snapshot. Iterating or retaining it never locks discovery.
+for peer in connection.peers() {
+    println!("ready peer: {}", peer.unique_name());
+}
+# Ok(())
+# }
+```
+
+## Migrating from eager peer storage
+
+`get_peer` changed from `Option<Peer>` to `AtspiResult<Option<Peer>>` and now performs discovery. Add `.await?` before handling the option:
+
+```text
+connection.get_peer(&name)          // old
+connection.get_peer(&name).await?   // new
+```
+
+`peers` changed from `Arc<Mutex<Vec<Peer>>>` to an owned `Vec<Peer>`. Remove locking and iterate the returned snapshot directly:
+
+```text
+connection.peers().lock().unwrap().iter() // old
+connection.peers().iter()                 // new
+```
 
 ## `p2p_tree` example
 

--- a/atspi-connection/src/lib.rs
+++ b/atspi-connection/src/lib.rs
@@ -78,14 +78,7 @@ impl AccessibilityConnection {
 		tracing::debug!(address = %a11y_bus_addr, "Got a11y bus address");
 		let addr: Address = a11y_bus_addr.parse()?;
 
-		let accessibility_conn = Self::from_address(addr).await?;
-
-		#[cfg(feature = "p2p")]
-		accessibility_conn
-			.peers
-			.spawn_peer_listener_task(accessibility_conn.connection());
-
-		Ok(accessibility_conn)
+		Self::from_address(addr).await
 	}
 
 	/// Returns an [`AccessibilityConnection`], a wrapper for the [`RegistryProxy`]; a handle for the registry provider
@@ -99,7 +92,8 @@ impl AccessibilityConnection {
 	///
 	/// # Errors
 	///
-	/// `RegistryProxy` is configured with invalid path, interface or destination
+	/// Returns an error if the bus connection, registry proxy, D-Bus proxy, or
+	/// P2P ownership-signal subscription cannot be established.
 	pub async fn from_address(bus_addr: Address) -> AtspiResult<Self> {
 		#[cfg(feature = "tracing")]
 		tracing::info!("Connecting to a11y bus");
@@ -116,9 +110,11 @@ impl AccessibilityConnection {
 		return Ok(Self { registry, dbus_proxy });
 
 		#[cfg(feature = "p2p")]
-		let peers = Peers::initialize_peers(&bus).await?;
-		#[cfg(feature = "p2p")]
-		return Ok(Self { registry, dbus_proxy, peers });
+		{
+			let connection = Self { registry, dbus_proxy, peers: Peers::default() };
+			connection.peers.spawn_listener(connection.connection()).await?;
+			Ok(connection)
+		}
 	}
 
 	/// Stream yielding all `Event` types.
@@ -408,6 +404,23 @@ impl Deref for AccessibilityConnection {
 
 	fn deref(&self) -> &Self::Target {
 		&self.registry
+	}
+}
+
+#[cfg(all(test, feature = "p2p"))]
+mod p2p_constructor_tests {
+	use super::*;
+
+	#[test]
+	fn from_address_waits_for_peer_listener_subscription() {
+		let address = std::env::var("DBUS_SESSION_BUS_ADDRESS")
+			.expect("tests require a session bus address")
+			.parse()
+			.expect("session bus address must be valid");
+		let connection =
+			futures_lite::future::block_on(AccessibilityConnection::from_address(address))
+				.expect("connection to test session bus must succeed");
+		assert!(connection.peers.listener_started());
 	}
 }
 

--- a/atspi-connection/src/p2p.rs
+++ b/atspi-connection/src/p2p.rs
@@ -1,44 +1,40 @@
-//! Extends the `AccessibilityConnection` with P2P capabilities.
-//!
-//! # Considerations on using executors and P2P
-//!
-//! Every connection has a zbus `Executor` instance, on which tasks can be launched. Internally, zbus uses this executor for all sorts of tasks: listening for D-Bus signals,
-//! keeping property caches up to date, handling timeout errors, etc.
-//!
-//! When zbus users use `tokio` (zbus feature "tokio" set), zbus will latch onto the tokio runtime.
-//! The `Executor` instance will be empty and all zbus tasks are run on the user's tokio runtime.
-//! However, when using any other executor (smol, glommio, etc.), each `Connection` will spin up a thread with an `async_executor::Executor`.
-//!
-//! Typically an application will have a single connection, but with P2P, your application will have a connection with each application that supports it.
-//! Consequently, on anything but tokio, applications will get an extra thread with an `async_executor` for each connection!
-//! (So picking smol won't necessarily make your application small in the context of P2P.)
+//! Lazy peer-to-peer discovery for [`crate::AccessibilityConnection`].
 
 use atspi_common::{object_ref::ObjectRefOwned, AtspiError, ACCESSIBLE_ROOT_PATH};
-use atspi_proxies::{
-	accessible::{AccessibleProxy, ObjectRefExt},
-	application::{self, ApplicationProxy},
-	proxy_ext::ProxyExt,
-	registry::RegistryProxy,
-};
+use atspi_proxies::{accessible::AccessibleProxy, application::ApplicationProxy};
+use event_listener::Event;
 use futures_lite::stream::StreamExt;
-use std::sync::{Arc, Mutex};
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+use std::{
+	collections::HashMap,
+	future::Future,
+	pin::Pin,
+	sync::{Arc, Mutex},
+	time::{Duration, Instant},
+};
 use zbus::{
 	conn::Builder,
 	fdo::DBusProxy,
-	names::{
-		BusName, OwnedBusName, OwnedUniqueName, OwnedWellKnownName, UniqueName, WellKnownName,
-	},
-	proxy::{CacheProperties, Defaults},
+	names::{BusName, OwnedUniqueName, OwnedWellKnownName, UniqueName, WellKnownName},
+	proxy::CacheProperties,
 	zvariant::ObjectPath,
 	Address,
 };
 
-#[cfg(feature = "tracing")]
-use tracing::{debug, info, warn};
-
 use crate::AtspiResult;
 
-/// Represents a peer with the name, path and connection for the P2P peer.
+const NEGATIVE_CAPACITY: usize = 1_024;
+
+type DiscoveryFuture = Pin<Box<dyn Future<Output = DiscoveryResult> + Send + 'static>>;
+type DiscoveryFn = dyn Fn(zbus::Connection, OwnedUniqueName) -> DiscoveryFuture + Send + Sync;
+type TaskFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+type SpawnFn = dyn Fn(&zbus::Connection, TaskFuture) + Send + Sync;
+type Clock = dyn Fn() -> Instant + Send + Sync;
+#[cfg(test)]
+type AfterPublishFn = dyn Fn(&Arc<Mutex<DiscoveryState>>, &OwnedUniqueName) + Send + Sync;
+
+/// A direct connection to one accessible application.
 #[derive(Clone, Debug)]
 pub struct Peer {
 	unique_name: OwnedUniqueName,
@@ -48,789 +44,1430 @@ pub struct Peer {
 }
 
 impl Peer {
-	/// Creates a new `Peer` with the given bus name and socket path.
-	///
-	/// # Note
-	/// This function is intended for use in building the initial list of peers.
-	///
-	/// If given a `UniqueName`, it will check if the peer also owns a well-known name.
-	/// If given a `WellKnownName`, it will query the D-Bus for the unique name of the peer.
-	///
-	/// # Errors
-	/// - `DBusProxy` cannot be created.
-	/// - The socket address cannot be parsed.
-	///
-	pub(crate) async fn try_new<B, S>(
-		bus_name: B,
-		socket: S,
-		conn: &zbus::Connection,
-	) -> Result<Self, AtspiError>
-	where
-		B: Into<OwnedBusName>,
-		S: TryInto<Address>,
-	{
-		let dbus_proxy = DBusProxy::new(conn).await?;
-		let owned_bus_name: OwnedBusName = bus_name.into();
-
-		let socket_address = socket
-			.try_into()
-			.map_err(|_| AtspiError::ParseError("Invalid address string"))?;
-
-		// Because D-Bus does not let us query whether a unique name is the owner of a well-known name,
-		// we need to query all well-known names and their owners, and then check if the unique name is one of them.
-
-		// Get all well-known names from D-Bus
-		let well_known_names: Vec<OwnedWellKnownName> = dbus_proxy
-			.list_names()
-			.await?
-			.into_iter()
-			.filter_map(|name| {
-				if let BusName::WellKnown(well_known_name) = name.clone().inner() {
-					Some(OwnedWellKnownName::from(well_known_name.clone()))
-				} else {
-					None
-				}
-			})
-			.collect();
-
-		// We are creating a mapping of unique names to well-known names.
-		let mut unique_to_well_known: Vec<(OwnedUniqueName, OwnedWellKnownName)> = Vec::new();
-
-		// For each well-known name, we get the unique name of the owner.
-		// Note: not all well-known names on the bus will have an accessible owner.
-		// For instance, the `org.freedesktop.DBus` well-known name does not have an accessible connection.
-		for well_known_name in &well_known_names {
-			let bus_name = BusName::from(well_known_name.clone());
-			if let Ok(unique_name) = dbus_proxy.get_name_owner(bus_name).await {
-				unique_to_well_known.push((unique_name, well_known_name.clone()));
-			}
-		}
-
-		// Now we have a mapping of unique names to well-known names.
-		//
-		// A `Peer` instance requires a unique name which may or may not have a well-known name.
-		// We can build a `Peer` instance from either a unique name or a well-known name.
-		// If the argument name is a unique name, we look up whether this peer also owns a well-known name in our mapping.
-		// If the argument name is a well-known name, we _must_ get its unique owner too to create a `Peer`.
-		let (unique_name, well_known_name) = match owned_bus_name.inner() {
-			BusName::Unique(name) => {
-				// The argument name is the mandatory `UniqueName`, we do want check whether this peer also owns a well-known name.
-				let owned_well_known_name = unique_to_well_known.iter().find_map(|(u, w)| {
-					if u == name {
-						Some(w.clone())
-					} else {
-						None
-					}
-				});
-				let owned_unique_name = OwnedUniqueName::from(name.clone());
-				(owned_unique_name, owned_well_known_name)
-			}
-			BusName::WellKnown(well_known_name) => {
-				let bus_name = BusName::from(well_known_name.clone());
-				let owned_unique_name = dbus_proxy.get_name_owner(bus_name).await?;
-				let owned_well_known_name = OwnedWellKnownName::from(well_known_name.clone());
-				(owned_unique_name, Some(owned_well_known_name))
-			}
-		};
-
-		let p2p_connection = Builder::address(socket_address.clone())?.p2p().build().await?;
-
-		Ok(Peer { unique_name, well_known_name, socket_address, p2p_connection })
+	fn for_alias(&self, alias: Option<OwnedWellKnownName>) -> Self {
+		let mut peer = self.clone();
+		peer.well_known_name = alias;
+		peer
 	}
 
-	/// Returns the bus name of the peer.
+	/// Returns the peer's canonical unique bus name.
 	#[must_use]
 	pub fn unique_name(&self) -> &OwnedUniqueName {
 		&self.unique_name
 	}
 
-	/// Returns the well-known bus name of the peer, if it has one.
+	/// Returns the well-known name requested by this lookup, if any.
+	///
+	/// Ready transport is stored canonically by unique owner. Consequently,
+	/// unique-name lookups and [`P2P::peers`] snapshots return `None`, while a
+	/// well-known lookup returns that lookup's requested alias.
 	#[must_use]
 	pub fn well_known_name(&self) -> Option<&OwnedWellKnownName> {
 		self.well_known_name.as_ref()
 	}
 
-	/// Returns the socket [`Address`] of the peer.
+	/// Returns the advertised peer address.
 	#[must_use]
 	pub fn socket_address(&self) -> &Address {
 		&self.socket_address
 	}
 
-	/// Returns the p2p [`Connection`][zbus::Connection] of the peer.
+	/// Returns the direct connection.
 	pub fn connection(&self) -> &zbus::Connection {
 		&self.p2p_connection
 	}
 
-	/// Try to create a new `Peer` from a bus name.
+	/// Creates a peer for `bus_name` immediately.
+	///
+	/// Prefer [`P2P::get_peer`], which coalesces concurrent attempts and caches
+	/// normal P2P unavailability.
 	///
 	/// # Errors
-	/// Returns an error if the application proxy cannot be created or if it does not support `get_application_bus_address`.\
-	/// A non-existent bus name will also return an error.
+	/// Returns an error if name resolution, address retrieval, address parsing,
+	/// or connection creation fails.
 	pub async fn try_from_bus_name(
 		bus_name: BusName<'_>,
 		conn: &zbus::Connection,
 	) -> AtspiResult<Self> {
-		// Get the application proxy for the bus name
-		// ApplicationProxy has a valid default path.
-		let application_proxy = ApplicationProxy::builder(conn)
-			.destination(&bus_name)?
-			.cache_properties(CacheProperties::No)
-			.build()
-			.await?;
-
-		let socket_path = application_proxy.get_application_bus_address().await?;
-		Self::try_new(bus_name, socket_path.as_str(), conn).await
+		let (owner, alias) = resolve_owner(conn, &bus_name).await?;
+		match discover(conn.clone(), owner).await {
+			DiscoveryResult::Ready(peer) => Ok(peer.for_alias(alias)),
+			DiscoveryResult::Unsupported => Err(AtspiError::Owned(
+				"application does not support peer-to-peer connections".into(),
+			)),
+			DiscoveryResult::Transient(message) => Err(AtspiError::Owned(message)),
+		}
 	}
 
-	/// Returns a [`Proxies`][atspi_proxies::proxy_ext::Proxies] object for the given object path.\
-	/// A `Proxies` object is used to obtain any of the proxies the object supports.
+	/// Returns proxy helpers for `path` over this peer connection.
 	///
 	/// # Errors
-	/// On invalid object path.
+	/// Returns an error if the accessible proxy cannot be built or queried.
 	pub async fn proxies(
 		&'_ self,
 		path: &ObjectPath<'_>,
 	) -> AtspiResult<atspi_proxies::proxy_ext::Proxies<'_>> {
-		let accessible_proxy = AccessibleProxy::builder(&self.p2p_connection)
+		use atspi_proxies::proxy_ext::ProxyExt;
+		let proxy = AccessibleProxy::builder(&self.p2p_connection)
 			.path(path.to_owned())?
 			.destination(&self.unique_name)?
 			.cache_properties(CacheProperties::No)
 			.build()
 			.await?;
-
-		accessible_proxy.proxies().await
+		proxy.proxies().await
 	}
 
-	/// Returns an `AccessibleProxy` for the root accessible object of the peer.
+	/// Returns the peer's root accessible proxy.
 	///
 	/// # Errors
-	/// In case of an invalid connection.
+	/// Returns an error if the proxy cannot be built.
 	pub async fn as_root_accessible_proxy(&self) -> AtspiResult<AccessibleProxy<'_>> {
-		let bus_name = self.unique_name.as_ref();
 		AccessibleProxy::builder(&self.p2p_connection)
 			.path(ACCESSIBLE_ROOT_PATH)?
-			.destination(bus_name)?
+			.destination(&self.unique_name)?
 			.cache_properties(CacheProperties::No)
 			.build()
 			.await
-			.map_err(AtspiError::from)
+			.map_err(Into::into)
 	}
 
-	/// Returns an [`AccessibleProxy`] for the accessible object of the peer.
+	/// Returns an accessible proxy for `obj` over this peer connection.
 	///
 	/// # Errors
-	/// In case of an invalid connection or object path.
+	/// Returns an error if the object has no path or the proxy cannot be built.
 	pub async fn as_accessible_proxy(
 		&self,
 		obj: &ObjectRefOwned,
 	) -> AtspiResult<AccessibleProxy<'_>> {
-		let path = obj.path();
-		let bus_name = self.unique_name.as_ref();
 		AccessibleProxy::builder(&self.p2p_connection)
-			.path(path)?
-			.destination(bus_name)?
+			.path(obj.path())?
+			.destination(&self.unique_name)?
 			.cache_properties(CacheProperties::No)
 			.build()
 			.await
-			.map_err(AtspiError::from)
-	}
-
-	fn matches_name(&self, name: &BusName) -> bool {
-		match name {
-			BusName::Unique(unique_name) => unique_name == self.unique_name(),
-			// one is an Option<OwnedT> the other is Borrowed
-			BusName::WellKnown(well_known_name) => {
-				self.well_known_name().is_some_and(|w| w == well_known_name)
-			}
-		}
-	}
-}
-
-// A trait is needed to extend functionality on `BusName` for P2P address lookup.
-pub(crate) trait BusNameExt {
-	/// Looks up a `BusName`'s P2P address, if available.
-	async fn get_p2p_address(&self, conn: &zbus::Connection) -> AtspiResult<Address>;
-}
-
-impl BusNameExt for BusName<'_> {
-	async fn get_p2p_address(&self, conn: &zbus::Connection) -> AtspiResult<Address> {
-		// This relies on the default path for `ApplicationProxy`.
-		let application_proxy = application::ApplicationProxy::builder(conn)
-			.destination(self)?
-			.cache_properties(CacheProperties::No)
-			.build()
-			.await?;
-
-		application_proxy
-			.get_application_bus_address()
-			.await
-			.map_err(|e| {
-				AtspiError::Owned(format!("Failed to get application bus address for {self}: {e}"))
-			})
-			.and_then(|address| {
-				Address::try_from(address.as_str())
-					.map_err(|_| AtspiError::ParseError("Invalid address string"))
-			})
+			.map_err(Into::into)
 	}
 }
 
 #[derive(Clone, Debug)]
+enum FlightOutcome {
+	Ready { generation: u64, peer: Peer },
+	Absent,
+}
+
+#[derive(Debug)]
+struct Flight {
+	outcome: Mutex<Option<FlightOutcome>>,
+	event: Event,
+}
+
+impl Flight {
+	fn new() -> Self {
+		Self { outcome: Mutex::new(None), event: Event::new() }
+	}
+
+	fn complete(&self, outcome: FlightOutcome) {
+		*self.outcome.lock().expect("peer flight lock poisoned") = Some(outcome);
+		self.event.notify(usize::MAX);
+	}
+
+	async fn wait(&self) -> FlightOutcome {
+		loop {
+			let listener = self.event.listen();
+			if let Some(outcome) = self.outcome.lock().expect("peer flight lock poisoned").clone() {
+				return outcome;
+			}
+			listener.await;
+		}
+	}
+}
+
+#[derive(Debug)]
+struct ListenerReady {
+	result: Mutex<Option<AtspiResult<()>>>,
+	event: Event,
+}
+
+impl ListenerReady {
+	fn new() -> Self {
+		Self { result: Mutex::new(None), event: Event::new() }
+	}
+
+	fn complete(&self, result: AtspiResult<()>) {
+		*self.result.lock().expect("listener readiness lock poisoned") = Some(result);
+		self.event.notify(usize::MAX);
+	}
+
+	async fn wait(&self) -> AtspiResult<()> {
+		loop {
+			let listener = self.event.listen();
+			if let Some(result) =
+				self.result.lock().expect("listener readiness lock poisoned").take()
+			{
+				return result;
+			}
+			listener.await;
+		}
+	}
+}
+
+#[derive(Debug)]
+enum OwnerState {
+	Discovering { generation: u64, flight: Arc<Flight> },
+	Ready { generation: u64, peer: Peer },
+	Unsupported { generation: u64, last_attempt: Instant },
+	Transient { generation: u64, failures: u32, retry_at: Instant, last_attempt: Instant },
+}
+
+impl OwnerState {
+	fn generation(&self) -> u64 {
+		match self {
+			Self::Discovering { generation, .. }
+			| Self::Ready { generation, .. }
+			| Self::Unsupported { generation, .. }
+			| Self::Transient { generation, .. } => *generation,
+		}
+	}
+
+	fn negative_last_attempt(&self) -> Option<Instant> {
+		match self {
+			Self::Unsupported { last_attempt, .. } | Self::Transient { last_attempt, .. } => {
+				Some(*last_attempt)
+			}
+			_ => None,
+		}
+	}
+}
+
+#[derive(Clone, Debug)]
+struct Alias {
+	owner: OwnedUniqueName,
+	generation: u64,
+}
+
+#[derive(Debug)]
+struct DiscoveryState {
+	owners: HashMap<OwnedUniqueName, OwnerState>,
+	aliases: HashMap<OwnedWellKnownName, Alias>,
+	next_generation: u64,
+}
+
+impl Default for DiscoveryState {
+	fn default() -> Self {
+		Self { owners: HashMap::new(), aliases: HashMap::new(), next_generation: 1 }
+	}
+}
+
+impl DiscoveryState {
+	fn allocate_generation(&mut self) -> Result<u64, Vec<Arc<Flight>>> {
+		let generation = self.next_generation;
+		if generation == 0 {
+			return Err(self.clear());
+		}
+		match generation.checked_add(1) {
+			Some(next) => self.next_generation = next,
+			None => self.next_generation = 0,
+		}
+		Ok(generation)
+	}
+
+	fn clear(&mut self) -> Vec<Arc<Flight>> {
+		let flights = self
+			.owners
+			.values()
+			.filter_map(|state| match state {
+				OwnerState::Discovering { flight, .. } => Some(Arc::clone(flight)),
+				_ => None,
+			})
+			.collect();
+		self.owners.clear();
+		self.aliases.clear();
+		flights
+	}
+
+	fn invalidate_owner(&mut self, owner: &UniqueName<'_>) -> Vec<Arc<Flight>> {
+		self.aliases.retain(|_, alias| alias.owner.as_str() != owner.as_str());
+		self.owners
+			.remove(owner.as_str())
+			.and_then(|state| match state {
+				OwnerState::Discovering { flight, .. } => Some(vec![flight]),
+				_ => None,
+			})
+			.unwrap_or_default()
+	}
+
+	fn update_alias(
+		&mut self,
+		name: &WellKnownName<'_>,
+		old_owner: Option<&UniqueName<'_>>,
+		new_owner: Option<&UniqueName<'_>>,
+	) -> Vec<Arc<Flight>> {
+		let mut flights = Vec::new();
+		let owned_name = OwnedWellKnownName::from(name.clone());
+		let current_owner = self.aliases.get(&owned_name).map(|alias| alias.owner.clone());
+		if let Some(old_owner) = old_owner {
+			if current_owner
+				.as_ref()
+				.is_some_and(|current| current.as_str() != old_owner.as_str())
+			{
+				// A duplicate transfer already applied, or an out-of-order stale signal.
+				return flights;
+			}
+			flights.extend(self.invalidate_owner(old_owner));
+		} else if let Some(current_owner) = current_owner {
+			if new_owner.is_some_and(|new_owner| current_owner.as_str() == new_owner.as_str()) {
+				return flights;
+			}
+			flights.extend(self.invalidate_owner(&current_owner.as_ref()));
+		}
+		self.aliases.remove(&owned_name);
+		if let Some(new_owner) = new_owner {
+			let generation = match self.allocate_generation() {
+				Ok(generation) => generation,
+				Err(cleared) => {
+					flights.extend(cleared);
+					return flights;
+				}
+			};
+			self.aliases.insert(
+				owned_name,
+				Alias { owner: OwnedUniqueName::from(new_owner.clone()), generation },
+			);
+		}
+		flights
+	}
+
+	fn enforce_negative_capacity(&mut self, now: Instant) {
+		self.owners.retain(
+			|_, state| !matches!(state, OwnerState::Transient { retry_at, .. } if *retry_at <= now),
+		);
+		while self
+			.owners
+			.values()
+			.filter(|state| state.negative_last_attempt().is_some())
+			.count() >= NEGATIVE_CAPACITY
+		{
+			let candidate = self
+				.owners
+				.iter()
+				.filter_map(|(owner, state)| {
+					state.negative_last_attempt().map(|attempt| (owner.clone(), attempt))
+				})
+				.min_by(|(left_owner, left_time), (right_owner, right_time)| {
+					left_time.cmp(right_time).then_with(|| left_owner.cmp(right_owner))
+				})
+				.map(|(owner, _)| owner);
+			let Some(candidate) = candidate else { break };
+			self.owners.remove(&candidate);
+		}
+	}
+}
+
+enum DiscoveryResult {
+	Ready(Peer),
+	Unsupported,
+	Transient(String),
+}
+
+enum LookupAction {
+	Ready(Peer),
+	Absent,
+	Wait(Arc<Flight>),
+	Spawn { generation: u64, flight: Arc<Flight>, previous_failures: u32 },
+}
+
+#[derive(Clone)]
 pub(crate) struct Peers {
-	peers: Arc<Mutex<Vec<Peer>>>,
+	state: Arc<Mutex<DiscoveryState>>,
+	clock: Arc<Clock>,
+	discover: Arc<DiscoveryFn>,
+	spawn: Arc<SpawnFn>,
+	#[cfg(test)]
+	listener_started: Arc<AtomicBool>,
+	#[cfg(test)]
+	after_publish: Arc<AfterPublishFn>,
+}
+
+impl std::fmt::Debug for Peers {
+	fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		formatter.debug_struct("Peers").finish_non_exhaustive()
+	}
+}
+
+impl Default for Peers {
+	fn default() -> Self {
+		Self {
+			state: Arc::new(Mutex::new(DiscoveryState::default())),
+			clock: Arc::new(Instant::now),
+			discover: Arc::new(|connection, owner| Box::pin(discover(connection, owner))),
+			spawn: Arc::new(|connection, task| {
+				connection.executor().spawn(task, "P2PDiscoveryTask").detach();
+			}),
+			#[cfg(test)]
+			listener_started: Arc::new(AtomicBool::new(false)),
+			#[cfg(test)]
+			after_publish: Arc::new(|_, _| {}),
+		}
+	}
+}
+
+struct DiscoveryCleanup {
+	state: Arc<Mutex<DiscoveryState>>,
+	owner: OwnedUniqueName,
+	generation: u64,
+	flight: Arc<Flight>,
+	armed: bool,
+}
+
+impl DiscoveryCleanup {
+	fn disarm(&mut self) {
+		self.armed = false;
+	}
+}
+
+impl Drop for DiscoveryCleanup {
+	fn drop(&mut self) {
+		if !self.armed {
+			return;
+		}
+		let removed = {
+			let mut state = self.state.lock().expect("peer state lock poisoned");
+			let matches = matches!(
+				state.owners.get(&self.owner),
+				Some(OwnerState::Discovering { generation, flight })
+					if *generation == self.generation && Arc::ptr_eq(flight, &self.flight)
+			);
+			if matches {
+				state.owners.remove(&self.owner);
+			}
+			matches
+		};
+		if removed {
+			self.flight.complete(FlightOutcome::Absent);
+		}
+	}
 }
 
 impl Peers {
-	/// Returns a `Peers` containing the initial peers that support P2P connections.
-	///
-	/// # Note
-	/// Intended for internal use with `AccessibilityConnection::new()`.
-	///
-	/// # Errors
-	/// This function can return an error in the following cases:
-	/// - the `AccessibleProxy` to the registry cannot be created.
-	/// - the registry returns an error when querying for children.
-	/// - for any child, the `AccessibleProxy` cannot be created or the `ApplicationProxy` cannot be created.
-	pub(crate) async fn initialize_peers(conn: &zbus::Connection) -> AtspiResult<Self> {
-		let registry_well_known_name = RegistryProxy::DESTINATION
-			.as_ref()
-			.expect("RegistryProxy `default_destination` is not set");
-		let reg_accessible = AccessibleProxy::builder(conn)
-			.path(ACCESSIBLE_ROOT_PATH)?
-			.destination(registry_well_known_name)?
-			.cache_properties(CacheProperties::No)
-			.build()
-			.await?;
+	fn snapshot(&self) -> Vec<Peer> {
+		let mut peers: Vec<_> = self
+			.state
+			.lock()
+			.expect("peer state lock poisoned")
+			.owners
+			.values()
+			.filter_map(|state| match state {
+				OwnerState::Ready { peer, .. } => Some(peer.clone()),
+				_ => None,
+			})
+			.collect();
+		peers.sort_by(|left, right| left.unique_name.cmp(&right.unique_name));
+		peers
+	}
 
-		let accessible_applications = reg_accessible.get_children().await?;
-		let mut peers = Vec::with_capacity(accessible_applications.len());
+	async fn resolve_owner(
+		&self,
+		connection: &zbus::Connection,
+		name: &BusName<'_>,
+	) -> AtspiResult<(OwnedUniqueName, Option<OwnedWellKnownName>)> {
+		match name {
+			BusName::Unique(owner) => Ok((OwnedUniqueName::from(owner.clone()), None)),
+			BusName::WellKnown(name) => {
+				let owned_name = OwnedWellKnownName::from(name.clone());
+				if let Some(alias) = self
+					.state
+					.lock()
+					.expect("peer state lock poisoned")
+					.aliases
+					.get(&owned_name)
+					.cloned()
+				{
+					debug_assert_ne!(alias.generation, 0);
+					return Ok((alias.owner, Some(owned_name)));
+				}
+				let proxy = DBusProxy::new(connection).await?;
+				let owner = proxy.get_name_owner(BusName::WellKnown(name.clone())).await?;
+				// Only NameOwnerChanged mutates aliases. Caching this method reply could
+				// overwrite a transfer signal processed while the call was in flight.
+				Ok(Self::resolved_alias(owned_name, owner))
+			}
+		}
+	}
 
-		for app in accessible_applications {
-			let accessible_proxy = app.as_accessible_proxy(conn).await?;
-			let proxies = accessible_proxy.proxies().await?;
-			let application_proxy = proxies.application().await?;
+	fn resolved_alias(
+		name: OwnedWellKnownName,
+		owner: OwnedUniqueName,
+	) -> (OwnedUniqueName, Option<OwnedWellKnownName>) {
+		// Method replies are lookup-local. Only NameOwnerChanged may mutate aliases.
+		(owner, Some(name))
+	}
 
-			// Get the application bus address
-			// aka: Does the application support P2P connections?
-			if let Ok(address) = application_proxy.get_application_bus_address().await {
-				let name = app.name().ok_or(AtspiError::MissingName)?;
-				let bus_name = BusName::from(name.clone());
-
-				match Peer::try_new(bus_name, address.as_str(), conn).await {
-					Ok(peer) => peers.push(peer),
-
-					#[cfg(feature = "tracing")]
-					Err(e) => {
-						tracing::warn!("Failed to create peer for {:?}: {}", app.name_as_str(), e);
-					}
-
-					#[cfg(all(debug_assertions, not(feature = "tracing")))]
-					Err(e) => {
-						eprintln!("Failed to create peer for {:?}: {}", app.name_as_str(), e);
-					}
-
-					#[cfg(not(any(feature = "tracing", debug_assertions)))]
-					Err(_) => {
-						// Ignore error creating peer
-					}
+	async fn get(
+		&self,
+		connection: &zbus::Connection,
+		name: &BusName<'_>,
+	) -> AtspiResult<(OwnedUniqueName, Option<Peer>)> {
+		let (owner, alias) = self.resolve_owner(connection, name).await?;
+		let now = (self.clock)();
+		let action = {
+			let mut state = self.state.lock().expect("peer state lock poisoned");
+			match state.owners.get(&owner) {
+				Some(OwnerState::Ready { peer, .. }) => {
+					LookupAction::Ready(peer.for_alias(alias.clone()))
+				}
+				Some(OwnerState::Unsupported { .. }) => LookupAction::Absent,
+				Some(OwnerState::Transient { retry_at, .. }) if *retry_at > now => {
+					LookupAction::Absent
+				}
+				Some(OwnerState::Discovering { flight, .. }) => {
+					LookupAction::Wait(Arc::clone(flight))
+				}
+				current => {
+					let previous_failures = match current {
+						Some(OwnerState::Transient { failures, .. }) => *failures,
+						_ => 0,
+					};
+					let generation = state.allocate_generation().map_err(|flights| {
+						complete_absent(flights);
+						AtspiError::Owned("peer generation token exhausted".into())
+					})?;
+					let flight = Arc::new(Flight::new());
+					state.owners.insert(
+						owner.clone(),
+						OwnerState::Discovering { generation, flight: Arc::clone(&flight) },
+					);
+					LookupAction::Spawn { generation, flight, previous_failures }
 				}
 			}
-		}
+		};
 
-		Ok(Peers { peers: Arc::new(Mutex::new(peers)) })
-	}
-
-	/// Returns a [`Peer`] by its bus name.
-	fn get_peer(&self, bus_name: &BusName<'_>) -> Option<Peer> {
-		let peers = self.peers.lock().expect("already locked by current thread");
-
-		let matched = match bus_name {
-			BusName::Unique(unique_name) => {
-				peers.iter().find(|peer| peer.unique_name() == unique_name)
-			}
-			BusName::WellKnown(well_known_name) => {
-				let owned_well_known_name = OwnedWellKnownName::from(well_known_name.clone());
-				peers
-					.iter()
-					.find(|peer| peer.well_known_name() == Some(&owned_well_known_name))
+		let flight = match action {
+			LookupAction::Ready(peer) => return Ok((owner, Some(peer))),
+			LookupAction::Absent => return Ok((owner, None)),
+			LookupAction::Wait(flight) => flight,
+			LookupAction::Spawn { generation, flight, previous_failures } => {
+				self.spawn_discovery(
+					connection,
+					owner.clone(),
+					generation,
+					previous_failures,
+					Arc::clone(&flight),
+				);
+				flight
 			}
 		};
-		matched.cloned()
-	}
 
-	/// Returns the inner `Arc<Mutex<Vec<Peer>>>`.
-	fn inner(&self) -> Arc<Mutex<Vec<Peer>>> {
-		Arc::clone(&self.peers)
-	}
-
-	/// Inserts a new `Peer` into the list of peers.
-	async fn insert_unique(
-		&self,
-		unique_name: &zbus::names::UniqueName<'_>,
-		conn: &zbus::Connection,
-	) -> AtspiResult<()> {
-		let bus_name = BusName::Unique(unique_name.as_ref());
-		let address = bus_name.get_p2p_address(conn).await?;
-		let p2p_connection = Builder::address(address.clone())?.p2p().build().await?;
-
-		let unique_name = OwnedUniqueName::from(unique_name.clone());
-
-		let peer =
-			Peer { unique_name, well_known_name: None, socket_address: address, p2p_connection };
-
-		let mut guard = self.peers.lock().expect("lock already held by current thread");
-		guard.push(peer);
-		Ok(())
-	}
-
-	/// Removes a `Peer` from the list of peers by its unique name.
-	fn remove_unique(&self, unique_name: &zbus::names::UniqueName<'_>) {
-		let mut peers = self.peers.lock().expect("lock already held by current thread");
-		peers.retain(|peer| peer.unique_name() != unique_name);
-	}
-
-	/// Inserts a new `Peer` with a well-known name into the list of peers.
-	async fn insert_well_known(
-		&self,
-		well_known_name: &WellKnownName<'_>,
-		name_owner: &UniqueName<'_>,
-		conn: &zbus::Connection,
-	) -> AtspiResult<()> {
-		let bus_name = BusName::WellKnown(well_known_name.clone());
-		let address = bus_name.get_p2p_address(conn).await?;
-		let p2p_connection = Builder::address(address.clone())?.p2p().build().await?;
-
-		let well_known_name = OwnedWellKnownName::from(well_known_name.clone());
-		let unique_name = OwnedUniqueName::from(name_owner.clone());
-
-		let peer = Peer {
-			unique_name,
-			well_known_name: Some(well_known_name),
-			socket_address: address,
-			p2p_connection,
-		};
-
-		let mut guard = self.peers.lock().expect("lock already held by current thread");
-		guard.push(peer);
-		Ok(())
-	}
-
-	/// Removes a `Peer` with a well-known name from the list of peers.
-	fn remove_well_known(&self, well_known_name: &WellKnownName<'_>, name_owner: &UniqueName<'_>) {
-		let mut peers = self.peers.lock().expect("lock already held by current thread");
-		let owned_well_known_name = OwnedWellKnownName::from(well_known_name.clone());
-		peers.retain(|peer| {
-			(peer.well_known_name() != Some(&owned_well_known_name))
-				&& peer.unique_name() == name_owner
-		});
-	}
-
-	/// Update a `Peer` with a new owner of it's well-known name in the list of peers.
-	async fn update_well_known_owner(
-		&self,
-		well_known_name: &WellKnownName<'_>,
-		old_name_owner: &UniqueName<'_>,
-		new_name_owner: &UniqueName<'_>,
-		conn: &zbus::Connection,
-	) -> AtspiResult<()> {
-		let socket_address = BusName::from(new_name_owner.clone()).get_p2p_address(conn).await?;
-		let p2p_connection = Builder::address(socket_address.clone())?.p2p().build().await?;
-
-		let well_known_name = Some(OwnedWellKnownName::from(well_known_name.clone()));
-		let old_name_owner = OwnedUniqueName::from(old_name_owner.clone());
-		let unique_name = OwnedUniqueName::from(new_name_owner.clone());
-
-		let peer = Peer {
-			unique_name,
-			well_known_name: well_known_name.clone(),
-			socket_address,
-			p2p_connection,
-		};
-
-		let mut peers = self.peers.lock().expect("lock already held by current thread");
-		if let Some(existing_peer) = peers.iter_mut().find(|p| {
-			p.well_known_name() == well_known_name.as_ref() && p.unique_name() == &old_name_owner
-		}) {
-			*existing_peer = peer;
-		} else {
-			return Err(AtspiError::Owned(format!(
-                "Owner swap failed: well-known name {well_known_name:?} with owner: {old_name_owner} not found"
-            )));
+		match flight.wait().await {
+			FlightOutcome::Ready { generation, peer } => {
+				let valid = matches!(
+					self.state.lock().expect("peer state lock poisoned").owners.get(&owner),
+					Some(OwnerState::Ready { generation: current, .. }) if *current == generation
+				);
+				Ok((owner, valid.then(|| peer.for_alias(alias))))
+			}
+			FlightOutcome::Absent => Ok((owner, None)),
 		}
-		Ok(())
 	}
 
-	/// Spawns a task which listens for peer mutations.
-	///
-	/// This task listens for `NameOwnerChanged` signals and updates the list of peers accordingly.
-	///
-	/// # executor
-	/// The task is spawned on the executor of the `zbus::Connection`.
-	///
-	/// # Note
-	/// This function is called internally by `AccessibilityConnection::new()`.
-	#[allow(clippy::too_many_lines)]
-	pub(crate) fn spawn_peer_listener_task(&self, conn: &zbus::Connection) {
-		// Clone the `Peers` and `Connection` to move them into the async task.
-		// This is necessary because the async task needs to own these values.
+	fn spawn_discovery(
+		&self,
+		connection: &zbus::Connection,
+		owner: OwnedUniqueName,
+		generation: u64,
+		previous_failures: u32,
+		flight: Arc<Flight>,
+	) {
+		let task_connection = connection.clone();
+		let state = Arc::clone(&self.state);
+		let clock = Arc::clone(&self.clock);
+		let discover = Arc::clone(&self.discover);
+		let spawn = Arc::clone(&self.spawn);
+		#[cfg(test)]
+		let after_publish = Arc::clone(&self.after_publish);
+		spawn(
+			connection,
+			Box::pin(async move {
+				let mut cleanup = DiscoveryCleanup {
+					state: Arc::clone(&state),
+					owner: owner.clone(),
+					generation,
+					flight: Arc::clone(&flight),
+					armed: true,
+				};
+				let result = discover(task_connection, owner.clone()).await;
+				let now = clock();
+				let outcome = {
+					let mut state = state.lock().expect("peer state lock poisoned");
+					let valid = state
+						.owners
+						.get(&owner)
+						.is_some_and(|entry| entry.generation() == generation);
+					if valid {
+						match result {
+							DiscoveryResult::Ready(peer) => {
+								state.owners.insert(
+									owner.clone(),
+									OwnerState::Ready { generation, peer: peer.clone() },
+								);
+								FlightOutcome::Ready { generation, peer }
+							}
+							DiscoveryResult::Unsupported => {
+								state.enforce_negative_capacity(now);
+								state.owners.insert(
+									owner.clone(),
+									OwnerState::Unsupported { generation, last_attempt: now },
+								);
+								FlightOutcome::Absent
+							}
+							DiscoveryResult::Transient(message) => {
+								#[cfg(feature = "tracing")]
+								tracing::debug!(%owner, %message, "P2P discovery temporarily unavailable");
+								#[cfg(not(feature = "tracing"))]
+								let _ = message;
+								let failures = previous_failures.saturating_add(1);
+								let retry_at = now + retry_delay(failures);
+								state.enforce_negative_capacity(now);
+								state.owners.insert(
+									owner.clone(),
+									OwnerState::Transient {
+										generation,
+										failures,
+										retry_at,
+										last_attempt: now,
+									},
+								);
+								FlightOutcome::Absent
+							}
+						}
+					} else {
+						FlightOutcome::Absent
+					}
+				};
+				#[cfg(test)]
+				after_publish(&state, &owner);
+				flight.complete(outcome);
+				cleanup.disarm();
+			}),
+		);
+	}
+
+	pub(crate) async fn spawn_listener(&self, connection: &zbus::Connection) -> AtspiResult<()> {
 		let peers = self.clone();
-		let conn = conn.clone();
-		let executor = conn.executor().clone();
-
-		executor.spawn(async move {
-    		let dbus_proxy = match DBusProxy::new(&conn).await {
-    			Ok(proxy) => proxy,
-    			#[allow(unused_variables)]
-    			Err(err) => { // `err` use depends on `tracing`, so allow(unused_variables)
-    				#[cfg(feature = "tracing")]
-    				tracing::error!("Failed to create DBusProxy for peer listener: {err}");
-    				return;
-    			}
-    		};
-
-			let Ok(mut name_owner_changed_stream) = dbus_proxy.receive_name_owner_changed().await.inspect_err(|#[allow(unused_variables)] err| {
-				#[cfg(feature = "tracing")]
-				debug!("Failed to receive `NameOwnerChanged` stream: {err}");
-			}) else {
-				return;
-			};
-
-			while let Some(name_owner_event) = name_owner_changed_stream.next().await {
-					let Ok(args) = name_owner_event.args() else {
-						#[cfg(feature = "tracing")]
-						tracing::debug!("Received name owner changed event without args, skipping.");
-						continue;
+		let connection = connection.clone();
+		let executor = connection.executor().clone();
+		let ready = Arc::new(ListenerReady::new());
+		let task_ready = Arc::clone(&ready);
+		executor
+			.spawn(
+				async move {
+					let proxy = match DBusProxy::new(&connection).await {
+						Ok(proxy) => proxy,
+						Err(error) => {
+							peers.clear();
+							task_ready.complete(Err(error.into()));
+							return;
+						}
 					};
-					let name = args.name().clone();
-					let new = args.new_owner().clone();
-					let old = args.old_owner().clone();
-
-					// `NameOwnerChanged` table (U = Unique, W = Well-Known):
-					// | Name | Old Owner | New Owner | Operation |
-					// |------|-----------|-----------|----------|
-					// |   U  |   None    |  Some(U)  |  Add     |
-					// |   U  |   Some(U) |    None   |  Remove  |
-					// |   W  |   None    |  Some(U)  |  Add     |
-					// |   W  |   Some(U) |    None   |  Remove  |
-					// |   W  |   Some(U) |  Some(U)  |  Replace |
-
-					match name {
-						BusName::Unique(unique_name) => {
-							// `zvariant:Optional` has deref target `Option`.
-							match (&*old, &*new) {
-								// Application appeared on the bus.
-								(None, Some(new_owner)) => {
-									debug_assert_eq!(new_owner, &unique_name, "When a name appears on the bus, the new owner must be the unique name itself.");
-
-									if let Ok(()) = peers.insert_unique(&unique_name, &conn).await.inspect_err(|#[allow(unused_variables)] err| {
-										#[cfg(feature = "tracing")]
-										warn!("Failed to insert unique name: {unique_name}: {err}");
-									}) {
-										#[cfg(feature = "tracing")]
-										info!("Inserted unique name: {unique_name} into the peer list.");
-									};
-
-								}
-								// Unique name left the bus.
-								(Some(old), None) => {
-									debug_assert!(old == &unique_name, "When a unique name is removed from the bus, the old owner must be the unique name itself.");
-									peers.remove_unique(&unique_name);
-
-									#[cfg(feature = "tracing")]
-									info!("Peer with unique name: {unique_name} left the bus - removed from peer list.");
-								}
-
-								// Unknown combination.
-								(_, _) => {
-									#[cfg(feature = "tracing")]
-									debug!("NameOwnerChanged` with unique name: {unique_name} has unknown argument combination ({old:?}, {new:?}).");
+					let mut stream = match proxy.receive_name_owner_changed().await {
+						Ok(stream) => stream,
+						Err(error) => {
+							peers.clear();
+							task_ready.complete(Err(error.into()));
+							return;
+						}
+					};
+					#[cfg(test)]
+					peers.listener_started.store(true, AtomicOrdering::SeqCst);
+					task_ready.complete(Ok(()));
+					while let Some(signal) = stream.next().await {
+						let Ok(args) = signal.args() else { continue };
+						match args.name() {
+							BusName::Unique(name) => {
+								if args.new_owner().is_none() {
+									peers.invalidate_owner(name);
 								}
 							}
+							BusName::WellKnown(name) => peers.update_alias(
+								name,
+								args.old_owner().as_ref(),
+								args.new_owner().as_ref(),
+							),
 						}
-						BusName::WellKnown(well_known_name) => {
-							match (&*old, &*new) {
-								// Unknown mutatuion. Well-known names should always have at least a new or old owner.
-								(None, None) => {
-									#[cfg(feature = "tracing")]
-									debug!("Received `NameOwnerChanged` event with no old or new owner for well-known name: {}", well_known_name);
-								}
-
-								// Well-known name appeared on the bus.
-								(None, Some(new_owner_unique_name)) => {
-									if let Ok(()) = peers.insert_well_known(
-										&well_known_name,
-										new_owner_unique_name,
-										&conn,
-									).await.inspect_err(|#[allow(unused_variables)] err| {
-										#[cfg(feature = "tracing")]
-										warn!("Failed to insert well-known name: {} with owner: {} - {}", &well_known_name, &new_owner_unique_name, err);
-									}) {
-										#[cfg(feature = "tracing")]
-										info!("Well-known name: {} with owner: {} inserted into the peer list.", &well_known_name, &new_owner_unique_name);
-									}
-								}
-
-								// Well-known name left the bus.
-								(Some(old_owner_unique_name), None) => {
-									peers.remove_well_known(
-										&well_known_name,
-										old_owner_unique_name,
-									);
-
-									#[cfg(feature = "tracing")]
-									info!(
-										"Well-known name: {} with owner: {} removed from the peer list.",
-										&well_known_name,
-										&old_owner_unique_name
-									);
-								},
-
-								// Well-known name received a new owner on the bus.
-								(Some(old_owner_unique_name), Some(new_owner_unique_name)) => {
-									if let Ok(()) = peers.update_well_known_owner(&well_known_name, old_owner_unique_name, new_owner_unique_name, &conn).await.inspect_err(|#[allow(unused_variables)] err| {
-										#[cfg(feature = "tracing")]
-										warn!("Failed to update well-known name: {} owner from: {} to: {} - {}", &well_known_name, &old_owner_unique_name, &new_owner_unique_name, err);
-									}) {
-										#[cfg(feature = "tracing")]
-										info!("Well-known name: {} updated owner from: {} to: {}", &well_known_name, &old_owner_unique_name, &new_owner_unique_name);
-									};
-								}
-							}
-						}
-					} // End of match on `name`
-				} // End of while loop
-
-				#[cfg(feature = "tracing")]
-				tracing::warn!("Peer listener task stopped, clearing peers list.");
-				peers.clear();
-			}, "PeerListenerTask")
+					}
+					peers.clear();
+				},
+				"P2PListenerTask",
+			)
 			.detach();
+		ready.wait().await
 	}
 
-	/// Clears the list of peers.
-	///
-	/// # Note
-	/// This is used to reset the list of peers when the D-Bus connection is lost.
+	#[cfg(test)]
+	pub(crate) fn listener_started(&self) -> bool {
+		self.listener_started.load(AtomicOrdering::SeqCst)
+	}
+
+	fn invalidate_owner(&self, owner: &UniqueName<'_>) {
+		let flights = self
+			.state
+			.lock()
+			.expect("peer state lock poisoned")
+			.invalidate_owner(owner);
+		complete_absent(flights);
+	}
+
+	fn update_alias(
+		&self,
+		name: &WellKnownName<'_>,
+		old_owner: Option<&UniqueName<'_>>,
+		new_owner: Option<&UniqueName<'_>>,
+	) {
+		let flights = self
+			.state
+			.lock()
+			.expect("peer state lock poisoned")
+			.update_alias(name, old_owner, new_owner);
+		complete_absent(flights);
+	}
+
 	fn clear(&self) {
-		let mut peers = self.peers.lock().expect("lock already held by current thread");
-		peers.clear();
+		let flights = self.state.lock().expect("peer state lock poisoned").clear();
+		complete_absent(flights);
 	}
 }
 
-/// Trait for P2P connection handling.
+fn complete_absent(flights: Vec<Arc<Flight>>) {
+	for flight in flights {
+		flight.complete(FlightOutcome::Absent);
+	}
+}
+
+fn retry_delay(failures: u32) -> Duration {
+	let seconds = match failures {
+		1..=5 => 1_u64 << (failures - 1),
+		_ => 30,
+	};
+	Duration::from_secs(seconds)
+}
+
+async fn resolve_owner(
+	connection: &zbus::Connection,
+	name: &BusName<'_>,
+) -> AtspiResult<(OwnedUniqueName, Option<OwnedWellKnownName>)> {
+	match name {
+		BusName::Unique(owner) => Ok((OwnedUniqueName::from(owner.clone()), None)),
+		BusName::WellKnown(name) => {
+			let owner = DBusProxy::new(connection)
+				.await?
+				.get_name_owner(BusName::WellKnown(name.clone()))
+				.await?;
+			Ok((owner, Some(OwnedWellKnownName::from(name.clone()))))
+		}
+	}
+}
+
+async fn discover(connection: zbus::Connection, owner: OwnedUniqueName) -> DiscoveryResult {
+	let builder = match ApplicationProxy::builder(&connection).destination(&owner) {
+		Ok(builder) => builder,
+		Err(error) => return DiscoveryResult::Transient(error.to_string()),
+	};
+	let proxy = match builder.cache_properties(CacheProperties::No).build().await {
+		Ok(proxy) => proxy,
+		Err(error) => return DiscoveryResult::Transient(error.to_string()),
+	};
+	let advertised = match proxy.get_application_bus_address().await {
+		Ok(address) if address.is_empty() => return DiscoveryResult::Unsupported,
+		Ok(address) => address,
+		Err(error) if is_unknown_method(&error) => return DiscoveryResult::Unsupported,
+		Err(error) => return DiscoveryResult::Transient(error.to_string()),
+	};
+	let address = match Address::try_from(advertised.as_str()) {
+		Ok(address) => address,
+		Err(error) => return DiscoveryResult::Transient(error.to_string()),
+	};
+	let p2p_connection = match Builder::address(address.clone()) {
+		Ok(builder) => match builder.p2p().build().await {
+			Ok(connection) => connection,
+			Err(error) => return DiscoveryResult::Transient(error.to_string()),
+		},
+		Err(error) => return DiscoveryResult::Transient(error.to_string()),
+	};
+	DiscoveryResult::Ready(Peer {
+		unique_name: owner,
+		well_known_name: None,
+		socket_address: address,
+		p2p_connection,
+	})
+}
+
+fn is_unknown_method(error: &zbus::Error) -> bool {
+	match error {
+		zbus::Error::MethodError(name, _, _) => {
+			name.as_str() == "org.freedesktop.DBus.Error.UnknownMethod"
+		}
+		zbus::Error::FDO(error) => matches!(error.as_ref(), zbus::fdo::Error::UnknownMethod(_)),
+		_ => false,
+	}
+}
+
+fn routing_connection<'a>(
+	shared: &'a zbus::Connection,
+	peer: Option<&'a Peer>,
+) -> &'a zbus::Connection {
+	peer.map_or(shared, Peer::connection)
+}
+
+/// P2P-aware proxy construction and lazy peer discovery.
 pub trait P2P {
-	/// Returns a P2P connected `AccessibleProxy`for object, _if available_.\
-	/// If the application does not support P2P, this returns an `AccessibleProxy` for the object with a bus connection.
+	/// Returns an accessible proxy over P2P when available, otherwise over the
+	/// connection's shared accessibility bus.
 	fn object_as_accessible(
 		&'_ self,
 		obj: &ObjectRefOwned,
-	) -> impl std::future::Future<Output = AtspiResult<AccessibleProxy<'_>>>;
+	) -> impl Future<Output = AtspiResult<AccessibleProxy<'_>>>;
 
-	/// Returns a P2P connected `AccessibleProxy` to the root  accessible object for the given bus name, _if available_.\
-	/// If the P2P connection is not available, it returns an `AccessibleProxy` with a bus connection.
+	/// Returns a root accessible proxy over P2P when available, otherwise over
+	/// the connection's shared accessibility bus.
 	fn bus_name_as_root_accessible(
 		&'_ self,
 		name: &BusName,
-	) -> impl std::future::Future<Output = AtspiResult<AccessibleProxy<'_>>>;
+	) -> impl Future<Output = AtspiResult<AccessibleProxy<'_>>>;
 
-	/// Return a list of peers that are currently connected.
-	fn peers(&self) -> Arc<Mutex<Vec<Peer>>>;
+	/// Returns a detached, unique-name-sorted snapshot of ready peers.
+	///
+	/// The returned vector can be retained or modified without locking or
+	/// changing discovery state.
+	///
+	/// ```no_run
+	/// # use atspi_connection::{AccessibilityConnection, P2P};
+	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+	/// let connection = AccessibilityConnection::new().await?;
+	/// for peer in connection.peers() {
+	///     println!("{}", peer.unique_name());
+	/// }
+	/// # Ok(())
+	/// # }
+	/// ```
+	fn peers(&self) -> Vec<Peer>;
 
-	/// Returns a [`Peer`] by its bus name.
-	fn get_peer(&self, bus_name: &BusName<'_>) -> Option<Peer>;
+	/// Finds or lazily discovers a peer.
+	///
+	/// `Ok(None)` means P2P is unsupported, temporarily unavailable, or the
+	/// owner changed during discovery. Identity and shared-routing failures are
+	/// returned as errors.
+	///
+	/// # Errors
+	/// Returns an error when the target's canonical owner cannot be resolved or
+	/// discovery fails in a way that prevents reliable routing.
+	///
+	/// ```no_run
+	/// # use atspi_connection::{AccessibilityConnection, P2P};
+	/// # use zbus::names::BusName;
+	/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+	/// let connection = AccessibilityConnection::new().await?;
+	/// let name = BusName::try_from(":1.42")?;
+	/// if let Some(peer) = connection.get_peer(&name).await? {
+	///     println!("direct connection to {}", peer.unique_name());
+	/// }
+	/// # Ok(())
+	/// # }
+	/// ```
+	fn get_peer(
+		&'_ self,
+		bus_name: &BusName<'_>,
+	) -> impl Future<Output = AtspiResult<Option<Peer>>>;
 }
 
 impl P2P for crate::AccessibilityConnection {
-	/// Returns a P2P connected `AccessibleProxy` for the object, _if available_.\
-	/// If the application does not support P2P, an `AccessibleProxy` with a bus connection is returned.
-	///
-	/// # Examples
-	/// ```rust
-	/// # use tokio_test::block_on;
-	/// use zbus::names::UniqueName;
-	/// use zbus::zvariant::ObjectPath;
-	/// use atspi_proxies::accessible::AccessibleProxy;
-	/// use atspi_common::ObjectRef;
-	/// use atspi_connection::{P2P, Peer};
-	/// use atspi_connection::AccessibilityConnection;
-	///
-	/// # block_on(async {
-	/// let conn = AccessibilityConnection::new().await.unwrap();
-	///
-	/// let name = UniqueName::from_static_str_unchecked(":1.1");
-	/// let path = ObjectPath::from_static_str_unchecked("/org/freedesktop/accessible/root");
-	///
-	/// let object_ref = ObjectRef::new_owned(name, path);
-	/// let accessible_proxy = conn.object_as_accessible(&object_ref).await;
-	/// assert!(
-	///    accessible_proxy.is_ok(),
-	///    "Failed to get accessible proxy: {:?}",
-	///    accessible_proxy.err()
-	/// );
-	/// # });
-	/// ```
-	///
-	/// Handling `ObjectRef::Null` case:
-	///
-	/// ```rust
-	/// # use tokio_test::block_on;
-	/// use atspi_proxies::accessible::AccessibleProxy;
-	/// use atspi_common::{AtspiError, ObjectRef, ObjectRefOwned};
-	/// use atspi_connection::P2P;
-	/// use atspi_connection::AccessibilityConnection;
-	///
-	/// # block_on(async {
-	/// let conn = AccessibilityConnection::new().await.unwrap();
-	/// let object_ref = ObjectRef::Null;
-	/// let object_ref = ObjectRefOwned::new(object_ref); // Assume we received this from `Accessible.Parent`
-	///
-	/// let res = conn.object_as_accessible(&object_ref).await;
-	/// match res {
-	///     Ok(proxy) => {
-	///         // Use the proxy
-	///         let _proxy: AccessibleProxy<'_> = proxy;
-	///     }
-	///     Err(AtspiError::NullRef(_msg)) => {
-	///         // Handle null-reference case
-	///     }
-	///     Err(_other) => {
-	///         // Handle other error types
-	///     }
-	/// }
-	/// # });
-	/// ```
-	///
-	/// # Errors
-	/// If the method is called with a null-reference `ObjectRef`, it will return an `AtspiError::NullRef`.
-	/// Users should ensure that the `ObjectRef` is non-null before calling this method or handle the result.
-	/// If the `AccessibleProxy` cannot be created, or if the object path is invalid.
-	///
-	/// # Note
-	/// This function will first try to find a [`Peer`] with a P2P connection
 	async fn object_as_accessible(&self, obj: &ObjectRefOwned) -> AtspiResult<AccessibleProxy<'_>> {
 		if obj.is_null() {
 			return Err(AtspiError::NullRef(
 				"`p2p::object_as_accessible` called with null-reference ObjectRef",
 			));
 		}
-
-		let name = obj.name().ok_or(AtspiError::MissingName)?.to_owned();
-		let name = OwnedUniqueName::from(name);
-		let path = obj.path();
-
-		let conn = self
+		let owner = OwnedUniqueName::from(obj.name().ok_or(AtspiError::MissingName)?.to_owned());
+		let (_, peer) = self
 			.peers
-			.peers
-			.lock()
-			.expect("lock already held by current thread")
-			.iter()
-			.find_map(
-				|peer| if &name == peer.unique_name() { Some(peer.connection()) } else { None },
-			)
-			.cloned(); // Connection has a cheap `Arc` clone.
-
-		// Use p2p-connection or fall-back bus connection.
-		let conn = conn.unwrap_or_else(|| self.connection().clone());
-
-		AccessibleProxy::builder(&conn)
-			.destination(name)?
-			.path(path)?
+			.get(self.connection(), &BusName::Unique(owner.as_ref()))
+			.await?;
+		let connection = routing_connection(self.connection(), peer.as_ref());
+		AccessibleProxy::builder(connection)
+			.destination(owner)?
+			.path(obj.path())?
 			.cache_properties(CacheProperties::No)
 			.build()
 			.await
 			.map_err(Into::into)
 	}
 
-	/// Returns a P2P connected [`AccessibleProxy`] to the root accessible object for the given bus name _if available_.\
-	/// If the P2P connection is not available, it returns an `AccessibleProxy` with a bus connection.
-	///
-	/// # Examples
-	///
-	/// ```rust
-	/// # use tokio_test::block_on;
-	/// use zbus::names::BusName;
-	/// use atspi_proxies::accessible::AccessibleProxy;
-	/// use atspi_common::ObjectRef;
-	/// use atspi_connection::{AccessibilityConnection, P2P};
-	///
-	/// # block_on(async {
-	///   let conn = AccessibilityConnection::new().await.unwrap();
-	///   let bus_name = BusName::from_static_str("org.a11y.atspi.Registry").unwrap();
-	///   let _accessible_proxy = conn.bus_name_as_root_accessible(&bus_name).await.unwrap();
-	///   // Use the accessible proxy as needed
-	/// # });
-	/// ```
-	///
-	/// # Errors
-	/// In case of an invalid connection or object path.
 	async fn bus_name_as_root_accessible(
 		&'_ self,
 		name: &BusName<'_>,
 	) -> AtspiResult<AccessibleProxy<'_>> {
-		// Look up peer by bus name
-		let conn = self
-			.peers
-			.peers
-			.lock()
-			.expect("lock already held by current thread")
-			.iter()
-			.find_map(|peer| {
-				// If sought-after peer is found, only get the  `Connection`.
-				if peer.matches_name(name) {
-					Some(peer.connection())
-				} else {
-					None
-				}
-			})
-			.cloned();
-
-		// Use p2p-connection or fall-back bus connection.
-		let conn = conn.unwrap_or_else(|| self.connection().clone());
-
-		AccessibleProxy::builder(&conn)
+		let (owner, peer) = self.peers.get(self.connection(), name).await?;
+		let connection = routing_connection(self.connection(), peer.as_ref());
+		AccessibleProxy::builder(connection)
 			.path(ACCESSIBLE_ROOT_PATH)?
-			.destination(name.to_owned())?
+			.destination(owner)?
 			.cache_properties(CacheProperties::No)
 			.build()
 			.await
 			.map_err(Into::into)
 	}
 
-	/// Get the currently connected P2P capable peers.
-	///
-	/// # Examples
-	/// ```rust
-	/// # use tokio_test::block_on;
-	/// use atspi_connection::AccessibilityConnection;
-	/// use atspi_connection::{P2P, Peer};
-	///
-	/// # block_on(async {
-	///   let conn = AccessibilityConnection::new().await.unwrap();
-	///   let locked_peers = conn.peers();
-	///   let peers = locked_peers.lock().expect("lock already held by current thread");
-	///   for peer in &*peers {
-	///       println!("Peer: {} at {}", peer.unique_name(), peer.socket_address());
-	///   }
-	/// # });
-	/// ```
-	fn peers(&self) -> Arc<Mutex<Vec<Peer>>> {
-		self.peers.inner()
+	fn peers(&self) -> Vec<Peer> {
+		self.peers.snapshot()
 	}
 
-	/// Returns a [`Peer`] by its bus name.
-	///
-	/// # Examples
-	/// ```rust
-	/// # use tokio_test::block_on;
-	/// use atspi_connection::{AccessibilityConnection, P2P, Peer};
-	/// use zbus::names::BusName;
-	///
-	/// # block_on(async {
-	///   let a11y = AccessibilityConnection::new().await.unwrap();
-	///   let bus_name = BusName::from_static_str(":1.42").unwrap();
-	///   let peer: Option<Peer> = a11y.get_peer(&bus_name);
-	/// # });
-	/// ```
-	fn get_peer(&self, bus_name: &BusName<'_>) -> Option<Peer> {
-		self.peers.get_peer(bus_name)
+	async fn get_peer(&self, bus_name: &BusName<'_>) -> AtspiResult<Option<Peer>> {
+		self.peers
+			.get(self.connection(), bus_name)
+			.await
+			.map(|(_, peer)| peer)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::sync::atomic::{AtomicUsize, Ordering};
+
+	fn owner(name: &str) -> OwnedUniqueName {
+		OwnedUniqueName::try_from(name).unwrap()
+	}
+
+	async fn test_connections() -> (zbus::Connection, zbus::Connection) {
+		let server = zbus::Connection::session().await.unwrap();
+		let client = zbus::Connection::session().await.unwrap();
+		(server, client)
+	}
+
+	fn test_peers(discover: Arc<DiscoveryFn>) -> Peers {
+		Peers {
+			state: Arc::new(Mutex::new(DiscoveryState::default())),
+			clock: Arc::new(Instant::now),
+			discover,
+			spawn: Arc::new(|_, task| {
+				std::thread::spawn(move || futures_lite::future::block_on(task));
+			}),
+			listener_started: Arc::new(AtomicBool::new(false)),
+			after_publish: Arc::new(|_, _| {}),
+		}
+	}
+
+	fn ready_result(connection: zbus::Connection, owner: OwnedUniqueName) -> DiscoveryResult {
+		DiscoveryResult::Ready(Peer {
+			unique_name: owner,
+			well_known_name: None,
+			socket_address: Address::try_from("unix:path=/tmp/atspi-test-peer").unwrap(),
+			p2p_connection: connection,
+		})
+	}
+
+	#[test]
+	fn retry_policy_is_bounded_and_saturating() {
+		assert_eq!(retry_delay(1), Duration::from_secs(1));
+		assert_eq!(retry_delay(2), Duration::from_secs(2));
+		assert_eq!(retry_delay(3), Duration::from_secs(4));
+		assert_eq!(retry_delay(4), Duration::from_secs(8));
+		assert_eq!(retry_delay(5), Duration::from_secs(16));
+		assert_eq!(retry_delay(6), Duration::from_secs(30));
+		assert_eq!(retry_delay(u32::MAX), Duration::from_secs(30));
+		assert_eq!(u32::MAX.saturating_add(1), u32::MAX);
+	}
+
+	#[test]
+	fn listener_readiness_is_pending_until_subscription_reports_success() {
+		futures_lite::future::block_on(async {
+			let ready = Arc::new(ListenerReady::new());
+			let mut waiting = Box::pin(ready.wait());
+			assert!(futures_lite::future::poll_once(&mut waiting).await.is_none());
+			ready.complete(Ok(()));
+			waiting.await.unwrap();
+		});
+	}
+
+	#[test]
+	fn negative_capacity_prunes_expired_then_oldest_with_name_tie_break() {
+		let now = Instant::now();
+		let mut state = DiscoveryState::default();
+		state.owners.insert(
+			owner(":1.2"),
+			OwnerState::Transient { generation: 1, failures: 1, retry_at: now, last_attempt: now },
+		);
+		for index in 0..NEGATIVE_CAPACITY {
+			state.owners.insert(
+				owner(&format!(":2.{index}")),
+				OwnerState::Unsupported { generation: 2, last_attempt: now },
+			);
+		}
+		state.enforce_negative_capacity(now);
+		assert!(!state.owners.contains_key(&owner(":1.2")));
+		assert_eq!(
+			state
+				.owners
+				.values()
+				.filter(|entry| entry.negative_last_attempt().is_some())
+				.count(),
+			NEGATIVE_CAPACITY - 1
+		);
+	}
+
+	#[test]
+	fn invalidation_is_aba_safe_and_wakes_flight() {
+		let mut state = DiscoveryState::default();
+		let owner = owner(":1.7");
+		let first = state.allocate_generation().unwrap();
+		let flight = Arc::new(Flight::new());
+		state
+			.owners
+			.insert(owner.clone(), OwnerState::Discovering { generation: first, flight });
+		let flights = state.invalidate_owner(&owner.as_ref());
+		assert_eq!(flights.len(), 1);
+		let second = state.allocate_generation().unwrap();
+		assert_ne!(first, second);
+	}
+
+	#[test]
+	fn alias_transfer_invalidates_old_owner_without_discovery() {
+		let mut state = DiscoveryState::default();
+		let alias = WellKnownName::try_from("org.example.App").unwrap();
+		let old = owner(":1.1");
+		let new = owner(":1.2");
+		state.update_alias(&alias, None, Some(&old.as_ref()));
+		state.update_alias(&alias, Some(&old.as_ref()), Some(&new.as_ref()));
+		assert_eq!(state.aliases.get(&OwnedWellKnownName::from(alias)).unwrap().owner, new);
+	}
+
+	#[test]
+	fn unsupported_and_transient_states_obey_invalidation_and_retry_boundaries() {
+		let now = Instant::now();
+		let owner = owner(":1.9");
+		let mut state = DiscoveryState::default();
+		state
+			.owners
+			.insert(owner.clone(), OwnerState::Unsupported { generation: 1, last_attempt: now });
+		assert!(matches!(state.owners.get(&owner), Some(OwnerState::Unsupported { .. })));
+		state.invalidate_owner(&owner.as_ref());
+		assert!(!state.owners.contains_key(&owner));
+
+		state.owners.insert(
+			owner.clone(),
+			OwnerState::Transient {
+				generation: 2,
+				failures: 1,
+				retry_at: now + Duration::from_secs(1),
+				last_attempt: now,
+			},
+		);
+		assert!(matches!(
+			state.owners.get(&owner),
+			Some(OwnerState::Transient { retry_at, .. }) if *retry_at > now
+		));
+		state.enforce_negative_capacity(now + Duration::from_secs(1));
+		assert!(!state.owners.contains_key(&owner));
+	}
+
+	#[test]
+	fn duplicate_and_out_of_order_alias_signals_are_idempotent() {
+		let mut state = DiscoveryState::default();
+		let name = WellKnownName::try_from("org.example.App").unwrap();
+		let old = owner(":1.1");
+		let new = owner(":1.2");
+		state.update_alias(&name, None, Some(&old.as_ref()));
+		state.update_alias(&name, Some(&old.as_ref()), Some(&new.as_ref()));
+		let generation = state
+			.aliases
+			.get(&OwnedWellKnownName::from(name.clone()))
+			.unwrap()
+			.generation;
+
+		state.update_alias(&name, Some(&old.as_ref()), Some(&new.as_ref()));
+		state.update_alias(&name, Some(&old.as_ref()), None);
+		let alias = state.aliases.get(&OwnedWellKnownName::from(name)).unwrap();
+		assert_eq!(alias.owner, new);
+		assert_eq!(alias.generation, generation);
+	}
+
+	#[test]
+	fn clearing_state_releases_all_waiters_and_aliases() {
+		let mut state = DiscoveryState::default();
+		let first = Arc::new(Flight::new());
+		let second = Arc::new(Flight::new());
+		state.owners.insert(
+			owner(":1.1"),
+			OwnerState::Discovering { generation: 1, flight: Arc::clone(&first) },
+		);
+		state.owners.insert(
+			owner(":1.2"),
+			OwnerState::Discovering { generation: 2, flight: Arc::clone(&second) },
+		);
+		let alias = WellKnownName::try_from("org.example.App").unwrap();
+		state.update_alias(&alias, None, Some(&owner(":1.1").as_ref()));
+
+		let flights = state.clear();
+		assert_eq!(flights.len(), 2);
+		complete_absent(flights);
+		assert!(state.owners.is_empty());
+		assert!(state.aliases.is_empty());
+		assert!(matches!(futures_lite::future::block_on(first.wait()), FlightOutcome::Absent));
+		assert!(matches!(futures_lite::future::block_on(second.wait()), FlightOutcome::Absent));
+	}
+
+	#[test]
+	fn unique_then_alias_and_two_alias_orders_have_lookup_specific_metadata() {
+		futures_lite::future::block_on(async {
+			for aliases in [
+				["org.example.First", "org.example.Second"],
+				["org.example.Second", "org.example.First"],
+			] {
+				let (_server, client) = test_connections().await;
+				let attempts = Arc::new(AtomicUsize::new(0));
+				let discover: Arc<DiscoveryFn> = {
+					let attempts = Arc::clone(&attempts);
+					Arc::new(move |connection, owner| {
+						attempts.fetch_add(1, Ordering::SeqCst);
+						Box::pin(async move { ready_result(connection, owner) })
+					})
+				};
+				let peers = test_peers(discover);
+				let owner = owner(":1.42");
+				let unique = peers
+					.get(&client, &BusName::Unique(owner.as_ref()))
+					.await
+					.unwrap()
+					.1
+					.unwrap();
+				assert_eq!(unique.well_known_name(), None);
+
+				for alias_name in aliases {
+					let alias = WellKnownName::try_from(alias_name).unwrap();
+					peers.update_alias(&alias, None, Some(&owner.as_ref()));
+					let peer = peers
+						.get(&client, &BusName::WellKnown(alias.clone()))
+						.await
+						.unwrap()
+						.1
+						.unwrap();
+					assert_eq!(peer.well_known_name().map(|name| name.as_str()), Some(alias_name));
+				}
+				assert_eq!(attempts.load(Ordering::SeqCst), 1);
+				assert_eq!(peers.snapshot()[0].well_known_name(), None);
+			}
+		});
+	}
+
+	#[test]
+	fn initiating_caller_cancellation_keeps_one_shared_attempt() {
+		futures_lite::future::block_on(async {
+			let (_server, client) = test_connections().await;
+			let gate = Arc::new(Event::new());
+			let attempts = Arc::new(AtomicUsize::new(0));
+			let discover: Arc<DiscoveryFn> = {
+				let gate = Arc::clone(&gate);
+				let attempts = Arc::clone(&attempts);
+				Arc::new(move |_, _| {
+					let listener = gate.listen();
+					attempts.fetch_add(1, Ordering::SeqCst);
+					Box::pin(async move {
+						listener.await;
+						DiscoveryResult::Transient("expected test failure".into())
+					})
+				})
+			};
+			let peers = test_peers(discover);
+			let owner = owner(":1.44");
+			let name = BusName::Unique(owner.as_ref());
+			let mut initiating = Box::pin(peers.get(&client, &name));
+			assert!(futures_lite::future::poll_once(&mut initiating).await.is_none());
+			drop(initiating);
+			while attempts.load(Ordering::SeqCst) == 0 {
+				std::thread::yield_now();
+			}
+			gate.notify(usize::MAX);
+			let result = peers.get(&client, &BusName::Unique(owner.as_ref())).await.unwrap();
+			assert!(result.1.is_none());
+			assert_eq!(attempts.load(Ordering::SeqCst), 1);
+		});
+	}
+
+	#[test]
+	fn invalidation_wins_a_completion_race() {
+		futures_lite::future::block_on(async {
+			let (_server, client) = test_connections().await;
+			let gate = Arc::new(Event::new());
+			let discover: Arc<DiscoveryFn> = {
+				let gate = Arc::clone(&gate);
+				Arc::new(move |connection, owner| {
+					let listener = gate.listen();
+					Box::pin(async move {
+						listener.await;
+						ready_result(connection, owner)
+					})
+				})
+			};
+			let peers = test_peers(discover);
+			let owner = owner(":1.45");
+			let name = BusName::Unique(owner.as_ref());
+			let mut lookup = Box::pin(peers.get(&client, &name));
+			assert!(futures_lite::future::poll_once(&mut lookup).await.is_none());
+			peers.invalidate_owner(&owner.as_ref());
+			gate.notify(usize::MAX);
+			assert!(lookup.await.unwrap().1.is_none());
+			assert!(peers.snapshot().is_empty());
+		});
+	}
+
+	#[test]
+	fn completion_then_invalidation_removes_ready_transport() {
+		futures_lite::future::block_on(async {
+			let (_server, client) = test_connections().await;
+			let discover: Arc<DiscoveryFn> = Arc::new(move |connection, owner| {
+				Box::pin(async move { ready_result(connection, owner) })
+			});
+			let peers = test_peers(discover);
+			let owner = owner(":1.451");
+			assert!(peers
+				.get(&client, &BusName::Unique(owner.as_ref()))
+				.await
+				.unwrap()
+				.1
+				.is_some());
+			assert_eq!(peers.snapshot().len(), 1);
+			peers.invalidate_owner(&owner.as_ref());
+			assert!(peers.snapshot().is_empty());
+		});
+	}
+
+	#[test]
+	fn invalidation_between_ready_publication_and_notification_returns_absent() {
+		futures_lite::future::block_on(async {
+			let (_server, client) = test_connections().await;
+			let discover: Arc<DiscoveryFn> = Arc::new(move |connection, owner| {
+				Box::pin(async move { ready_result(connection, owner) })
+			});
+			let mut peers = test_peers(discover);
+			peers.after_publish = Arc::new(|state, owner| {
+				let flights = state
+					.lock()
+					.expect("peer state lock poisoned")
+					.invalidate_owner(&owner.as_ref());
+				assert!(flights.is_empty(), "ready state must already be published");
+			});
+			let owner = owner(":1.454");
+			let result = peers.get(&client, &BusName::Unique(owner.as_ref())).await.unwrap();
+			assert!(result.1.is_none());
+			assert!(peers.snapshot().is_empty());
+		});
+	}
+
+	#[test]
+	fn stale_alias_resolution_reply_cannot_overwrite_transfer_signal() {
+		let peers = Peers::default();
+		let alias = WellKnownName::try_from("org.example.Race").unwrap();
+		let old = owner(":1.10");
+		let new = owner(":1.11");
+		peers.update_alias(&alias, None, Some(&new.as_ref()));
+		let resolved = Peers::resolved_alias(OwnedWellKnownName::from(alias.clone()), old.clone());
+		assert_eq!(resolved.0, old);
+		assert_eq!(
+			peers
+				.state
+				.lock()
+				.expect("peer state lock poisoned")
+				.aliases
+				.get(&OwnedWellKnownName::from(alias))
+				.unwrap()
+				.owner,
+			new
+		);
+	}
+
+	#[test]
+	fn shared_bus_is_selected_when_discovery_returns_no_peer() {
+		futures_lite::future::block_on(async {
+			let (_server, client) = test_connections().await;
+			assert!(std::ptr::eq(routing_connection(&client, None), &client));
+			let DiscoveryResult::Ready(peer) = ready_result(client.clone(), owner(":1.452")) else {
+				unreachable!()
+			};
+			assert!(std::ptr::eq(routing_connection(&client, Some(&peer)), peer.connection()));
+		});
+	}
+
+	#[test]
+	fn cleanup_guard_does_not_remove_replacement_generation() {
+		let state = Arc::new(Mutex::new(DiscoveryState::default()));
+		let owner = owner(":1.453");
+		let old_flight = Arc::new(Flight::new());
+		let replacement = Arc::new(Flight::new());
+		state.lock().expect("peer state lock poisoned").owners.insert(
+			owner.clone(),
+			OwnerState::Discovering { generation: 2, flight: Arc::clone(&replacement) },
+		);
+		drop(DiscoveryCleanup {
+			state: Arc::clone(&state),
+			owner: owner.clone(),
+			generation: 1,
+			flight: old_flight,
+			armed: true,
+		});
+		assert!(matches!(
+			state.lock().expect("peer state lock poisoned").owners.get(&owner),
+			Some(OwnerState::Discovering { generation: 2, flight }) if Arc::ptr_eq(flight, &replacement)
+		));
+	}
+
+	#[test]
+	fn aborted_discovery_cleans_matching_generation_and_wakes_waiter() {
+		futures_lite::future::block_on(async {
+			let (_server, client) = test_connections().await;
+			let gate = Arc::new(Event::new());
+			let attempts = Arc::new(AtomicUsize::new(0));
+			let discover: Arc<DiscoveryFn> = {
+				let gate = Arc::clone(&gate);
+				let attempts = Arc::clone(&attempts);
+				Arc::new(move |_, _| {
+					let listener = gate.listen();
+					attempts.fetch_add(1, Ordering::SeqCst);
+					Box::pin(async move {
+						listener.await;
+						panic!("abort mocked discovery");
+					})
+				})
+			};
+			let peers = test_peers(discover);
+			let owner = owner(":1.46");
+			let name = BusName::Unique(owner.as_ref());
+			let mut first = Box::pin(peers.get(&client, &name));
+			assert!(futures_lite::future::poll_once(&mut first).await.is_none());
+			while attempts.load(Ordering::SeqCst) == 0 {
+				std::thread::yield_now();
+			}
+			let mut waiter = Box::pin(peers.get(&client, &name));
+			assert!(futures_lite::future::poll_once(&mut waiter).await.is_none());
+			gate.notify(usize::MAX);
+			assert!(waiter.await.unwrap().1.is_none());
+			assert!(!peers
+				.state
+				.lock()
+				.expect("peer state lock poisoned")
+				.owners
+				.contains_key(&owner));
+		});
+	}
+
+	#[test]
+	fn actual_get_applies_backoff_and_capacity_with_injected_time() {
+		futures_lite::future::block_on(async {
+			let (_server, client) = test_connections().await;
+			let now = Arc::new(Mutex::new(Instant::now()));
+			let attempts = Arc::new(AtomicUsize::new(0));
+			let discover: Arc<DiscoveryFn> = {
+				let attempts = Arc::clone(&attempts);
+				Arc::new(move |_, _| {
+					attempts.fetch_add(1, Ordering::SeqCst);
+					Box::pin(async { DiscoveryResult::Transient("temporary".into()) })
+				})
+			};
+			let mut peers = test_peers(discover);
+			peers.clock = {
+				let now = Arc::clone(&now);
+				Arc::new(move || *now.lock().expect("clock lock poisoned"))
+			};
+			let target = owner(":1.47");
+			assert!(peers
+				.get(&client, &BusName::Unique(target.as_ref()))
+				.await
+				.unwrap()
+				.1
+				.is_none());
+			assert!(peers
+				.get(&client, &BusName::Unique(target.as_ref()))
+				.await
+				.unwrap()
+				.1
+				.is_none());
+			assert_eq!(attempts.load(Ordering::SeqCst), 1);
+			*now.lock().expect("clock lock poisoned") += Duration::from_secs(1);
+			assert!(peers
+				.get(&client, &BusName::Unique(target.as_ref()))
+				.await
+				.unwrap()
+				.1
+				.is_none());
+			assert_eq!(attempts.load(Ordering::SeqCst), 2);
+
+			let current = *now.lock().expect("clock lock poisoned");
+			{
+				let mut state = peers.state.lock().expect("peer state lock poisoned");
+				state.owners.clear();
+				for index in 0..NEGATIVE_CAPACITY {
+					state.owners.insert(
+						owner(&format!(":2.{index}")),
+						OwnerState::Unsupported { generation: 1, last_attempt: current },
+					);
+				}
+			}
+			assert!(peers
+				.get(&client, &BusName::Unique(target.as_ref()))
+				.await
+				.unwrap()
+				.1
+				.is_none());
+			let state = peers.state.lock().expect("peer state lock poisoned");
+			assert_eq!(
+				state
+					.owners
+					.values()
+					.filter(|entry| entry.negative_last_attempt().is_some())
+					.count(),
+				NEGATIVE_CAPACITY
+			);
+			assert!(matches!(state.owners.get(&target), Some(OwnerState::Transient { .. })));
+		});
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn non_unknown_method_probe_error_is_transient() {
+		struct ErrorApplication {
+			fail: bool,
+		}
+
+		#[zbus::interface(name = "org.a11y.atspi.Application")]
+		impl ErrorApplication {
+			fn get_application_bus_address(&self) -> zbus::fdo::Result<String> {
+				if self.fail {
+					Err(zbus::fdo::Error::Failed("probe failed".into()))
+				} else {
+					Ok(String::new())
+				}
+			}
+		}
+
+		futures_lite::future::block_on(async {
+			let server = Builder::session()
+				.unwrap()
+				.serve_at(ACCESSIBLE_ROOT_PATH, ErrorApplication { fail: true })
+				.unwrap()
+				.build()
+				.await
+				.unwrap();
+			let client = zbus::Connection::session().await.unwrap();
+			let peers = Peers::default();
+			let owner = server.unique_name().unwrap().to_owned();
+			let result = peers.get(&client, &BusName::Unique(owner.as_ref())).await.unwrap();
+			assert!(result.1.is_none());
+			assert!(matches!(
+				peers
+					.state
+					.lock()
+					.expect("peer state lock poisoned")
+					.owners
+					.get(&owner),
+				Some(OwnerState::Transient { .. })
+			));
+		});
 	}
 }


### PR DESCRIPTION
`AccessibilityConnection::new()` can hang before returning because P2P initialization probes and connects to every accessible application sequentially. One unresponsive application can therefore block the entire connection, even though P2P is optional and the accessibility bus remains usable.

This PR avoids that failure mode by discovering a peer on its first P2P-aware lookup. Construction now only installs a `NameOwnerChanged` listener so cached identities and connections can be invalidated when ownership changes.

Discovery state is kept by unique bus owner. Concurrent lookups for the same owner share one attempt, and stale attempts cannot publish after an ownership change. Unsupported applications are cached until invalidation, while transient address and connection failures use bounded per-owner backoff.

When no direct connection is available, `object_as_accessible` and `bus_name_as_root_accessible` continue over the existing accessibility-bus connection. Failures that prevent resolving or routing the target remain errors.

This changes two public methods:

- `get_peer` becomes async and returns `AtspiResult<Option<Peer>>`;
- `peers` returns a detached `Vec<Peer>` instead of `Arc<Mutex<Vec<Peer>>>`.

The latter prevents callers from locking or mutating discovery state. These changes are semver-relevant; maintainer guidance on release handling is welcome.

Tested with:

```text
cargo test -p atspi-connection --all-features
```

All 20 unit tests and 10 doctests pass.

Development and test design were assisted by `GPT-5.6 Sol`.
